### PR TITLE
feat(core): RN 下 Markdown parser 走 native FFI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1518,6 +1518,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "supramark-markdown-native"
+version = "0.1.0"
+dependencies = [
+ "serde_json",
+ "supramark-markdown",
+]
+
+[[package]]
 name = "supramark-markdown-web"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ resolver = "2"
 members = [
     "crates/supramark-markdown",
     "crates/supramark-markdown/packages/web",
+    "crates/supramark-markdown/packages/native",
     "crates/dagre",
     "crates/graphviz-anywhere/packages/rust",
     "crates/graphviz-anywhere/examples/rust",

--- a/bun.lock
+++ b/bun.lock
@@ -114,6 +114,15 @@
         "@kookyleo/graphviz-anywhere-web",
       ],
     },
+    "crates/supramark-markdown/packages/react-native": {
+      "name": "@supramark/markdown-native-rn",
+      "version": "0.1.0",
+      "peerDependencies": {
+        "@supramark/core": "workspace:*",
+        "react": "*",
+        "react-native": "*",
+      },
+    },
     "crates/supramark-markdown/packages/web": {
       "name": "@supramark/markdown-web",
       "version": "0.1.0",
@@ -1385,6 +1394,8 @@
     "@supramark/feature-plantuml": ["@supramark/feature-plantuml@workspace:packages/features/diagrams/plantuml"],
 
     "@supramark/feature-weather": ["@supramark/feature-weather@workspace:packages/features/containers/weather"],
+
+    "@supramark/markdown-native-rn": ["@supramark/markdown-native-rn@workspace:crates/supramark-markdown/packages/react-native"],
 
     "@supramark/markdown-web": ["@supramark/markdown-web@workspace:crates/supramark-markdown/packages/web"],
 

--- a/crates/supramark-markdown/packages/native/Cargo.toml
+++ b/crates/supramark-markdown/packages/native/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "supramark-markdown-native"
+version = "0.1.0"
+edition = "2021"
+license = "Apache-2.0 AND MIT"
+authors = ["Supramark contributors"]
+description = "Native FFI wrapper around supramark-markdown for React Native / iOS / Android consumers"
+homepage = "https://github.com/kookyleo/supramark"
+repository = "https://github.com/kookyleo/supramark"
+publish = false
+
+[lib]
+# staticlib  → libsupramark_markdown_native.a   (iOS .xcframework, Android NDK static link)
+# cdylib     → libsupramark_markdown_native.so / .dylib / .dll (Android jniLibs, desktop hosts)
+# rlib       → keep so other in-workspace Rust crates can depend on this wrapper if useful.
+crate-type = ["staticlib", "cdylib", "rlib"]
+
+[dependencies]
+supramark-markdown = { path = "../.." }
+serde_json = "1"

--- a/crates/supramark-markdown/packages/native/include/supramark_markdown.h
+++ b/crates/supramark-markdown/packages/native/include/supramark_markdown.h
@@ -1,0 +1,78 @@
+/* SPDX-License-Identifier: Apache-2.0 AND MIT */
+/*
+ * supramark_markdown.h — C ABI for libsupramark_markdown_native.{a,so,dylib}
+ *
+ * This header is the canonical contract between the native build
+ * artefact and any C / Objective-C / Swift / Kotlin / JNI consumer.
+ * The Rust impl lives in src/lib.rs; keep this file in sync with the
+ * #[no_mangle] entry points and SUPRAMARK_MARKDOWN_* constants there.
+ */
+
+#ifndef SUPRAMARK_MARKDOWN_H
+#define SUPRAMARK_MARKDOWN_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* ---- Error codes (must match SUPRAMARK_MARKDOWN_* in src/lib.rs) ---- */
+
+/* Parse succeeded; *out_buf / *out_len populated, caller owns buffer. */
+#define SUPRAMARK_MARKDOWN_OK               0
+/* AST serialization to JSON failed. */
+#define SUPRAMARK_MARKDOWN_ERR_SERIALIZE    1
+/* A required pointer was NULL, or input was not valid UTF-8. */
+#define SUPRAMARK_MARKDOWN_ERR_NULL_INPUT   2
+
+/*
+ * Parse a Markdown source string into AST v2 JSON.
+ *
+ * input      : pointer to the Markdown source bytes. May be either a
+ *              NUL-terminated C string (pass input_len = 0) or an
+ *              explicit-length byte buffer (pass input_len > 0). The
+ *              explicit-length form is preferred for large inputs.
+ * input_len  : number of bytes at `input`, or 0 to use strlen-style.
+ * out_buf    : on success, *out_buf is set to a heap-allocated UTF-8
+ *              JSON byte buffer. NOT NUL-terminated. Caller MUST
+ *              release with supramark_markdown_free.
+ * out_len    : on success, *out_len is set to the byte length of the
+ *              buffer at *out_buf.
+ *
+ * The returned JSON matches the schema produced by the wasm-bindgen
+ * wrapper `@supramark/markdown-web`'s `parse_json`, so JS consumers
+ * can `JSON.parse` it identically across Web / Node / RN runtimes.
+ *
+ * Returns one of the SUPRAMARK_MARKDOWN_* status codes. On non-OK
+ * return the out-params are zero-initialised (NULL / 0).
+ */
+int32_t supramark_markdown_parse_json(
+    const char* input, size_t input_len,
+    char** out_buf, size_t* out_len
+);
+
+/*
+ * Release a buffer previously returned by supramark_markdown_parse_json.
+ *
+ * Passing (NULL, 0) is a no-op. Passing a buffer that did not come
+ * from supramark_markdown_parse_json, or a `len` that does not match
+ * the original allocation, is undefined behaviour: the buffer is freed
+ * through Rust's global allocator and may not match the C runtime's
+ * free(3).
+ */
+void supramark_markdown_free(char* buf, size_t len);
+
+/*
+ * Returns a static, NUL-terminated UTF-8 version string identifying
+ * this build of libsupramark_markdown_native. The returned pointer is
+ * valid for the lifetime of the loaded library; do NOT free it.
+ */
+const char* supramark_markdown_version(void);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
+#endif /* SUPRAMARK_MARKDOWN_H */

--- a/crates/supramark-markdown/packages/native/include/supramark_markdown.h
+++ b/crates/supramark-markdown/packages/native/include/supramark_markdown.h
@@ -28,13 +28,22 @@ extern "C" {
 #define SUPRAMARK_MARKDOWN_ERR_NULL_INPUT   2
 
 /*
+ * Sentinel input_len that opts into the NUL-terminated C-string path
+ * (length computed via strlen). Every other value — including 0 — is an
+ * explicit byte length, so input_len == 0 is a valid empty document.
+ */
+#define SUPRAMARK_MARKDOWN_LEN_CSTRING      ((size_t)-1)
+
+/*
  * Parse a Markdown source string into AST v2 JSON.
  *
- * input      : pointer to the Markdown source bytes. May be either a
- *              NUL-terminated C string (pass input_len = 0) or an
- *              explicit-length byte buffer (pass input_len > 0). The
- *              explicit-length form is preferred for large inputs.
- * input_len  : number of bytes at `input`, or 0 to use strlen-style.
+ * input      : pointer to the Markdown source bytes. Pass the exact byte
+ *              length in input_len (the buffer need NOT be
+ *              NUL-terminated). For an empty document pass input_len = 0;
+ *              `input` is then not dereferenced and may be NULL.
+ * input_len  : number of bytes at `input`. 0 means an empty document.
+ *              Pass SUPRAMARK_MARKDOWN_LEN_CSTRING to treat `input` as a
+ *              NUL-terminated C string (length via strlen).
  * out_buf    : on success, *out_buf is set to a heap-allocated UTF-8
  *              JSON byte buffer. NOT NUL-terminated. Caller MUST
  *              release with supramark_markdown_free.

--- a/crates/supramark-markdown/packages/native/src/lib.rs
+++ b/crates/supramark-markdown/packages/native/src/lib.rs
@@ -1,0 +1,276 @@
+//! Native FFI wrapper around `supramark-markdown`.
+//!
+//! Mirrors the wasm-bindgen surface in `crates/supramark-markdown/packages/web`
+//! but exposes a C ABI so React Native, iOS, Android, and other native
+//! hosts can link against `libsupramark_markdown_native.{a,so,dylib}` and
+//! call `supramark_markdown_parse_json(...)` to turn a Markdown source
+//! string into an AST v2 JSON byte buffer.
+//!
+//! Error handling
+//! --------------
+//! All entry points return `int32_t` status codes (see
+//! `SUPRAMARK_MARKDOWN_*` constants in `include/supramark_markdown.h`).
+//! Out-parameters are written only on success. On failure they are
+//! zero-initialised so callers that forget to check the return code at
+//! least see `NULL` / `0`.
+//!
+//! Memory ownership
+//! ----------------
+//! `supramark_markdown_parse_json` heap-allocates the JSON buffer via
+//! Rust's global allocator. Callers MUST release it through
+//! `supramark_markdown_free(buf, len)` to match the allocator that
+//! produced it; calling `free(3)` from C is undefined behaviour because
+//! the Rust allocator may be jemalloc/mimalloc in a host build.
+
+use std::ffi::{CStr, c_char};
+use std::os::raw::c_int;
+use std::ptr;
+use std::slice;
+
+// ---------------------------------------------------------------------------
+// Status codes — keep in sync with include/supramark_markdown.h
+// ---------------------------------------------------------------------------
+
+/// Parse succeeded; `*out_buf` / `*out_len` are populated.
+pub const SUPRAMARK_MARKDOWN_OK: c_int = 0;
+/// AST serialization to JSON failed. In practice this should never
+/// happen for a well-formed `SupramarkNode`, but we surface it as a
+/// distinct code so hosts can distinguish allocator/serializer faults
+/// from input issues.
+pub const SUPRAMARK_MARKDOWN_ERR_SERIALIZE: c_int = 1;
+/// `input` or one of the out-parameter pointers was NULL, or `input`
+/// was not valid UTF-8 / not NUL-terminated within `input_len` bytes.
+pub const SUPRAMARK_MARKDOWN_ERR_NULL_INPUT: c_int = 2;
+
+// ---------------------------------------------------------------------------
+// Public C ABI
+// ---------------------------------------------------------------------------
+
+/// Parse a Markdown source string into AST v2 JSON.
+///
+/// On success returns [`SUPRAMARK_MARKDOWN_OK`] and writes a
+/// heap-allocated, non-NUL-terminated UTF-8 JSON byte buffer to
+/// `*out_buf` together with its length (in bytes) in `*out_len`. The
+/// caller MUST release the buffer with [`supramark_markdown_free`].
+///
+/// `input` may be either a NUL-terminated C string (pass
+/// `input_len = 0`, in which case the wrapper computes the length with
+/// `strlen`) or an explicit-length byte buffer (pass `input_len > 0`,
+/// in which case the buffer does NOT need to be NUL-terminated). The
+/// latter is preferred because it avoids a redundant scan on large
+/// inputs.
+///
+/// The returned JSON matches the schema produced by
+/// `@supramark/markdown-web`'s `parse_json` (the wasm-bindgen wrapper),
+/// so JS consumers can `JSON.parse` it identically across Web / Node /
+/// RN runtimes.
+///
+/// # Safety
+///
+/// All pointer arguments are dereferenced. The caller must ensure:
+///   * `input` points to at least `input_len` readable bytes (or, when
+///     `input_len == 0`, to a NUL-terminated C string).
+///   * `out_buf` and `out_len` are valid, writable, non-aliasing.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn supramark_markdown_parse_json(
+    input: *const c_char,
+    input_len: usize,
+    out_buf: *mut *mut c_char,
+    out_len: *mut usize,
+) -> c_int {
+    if out_buf.is_null() || out_len.is_null() {
+        return SUPRAMARK_MARKDOWN_ERR_NULL_INPUT;
+    }
+    // SAFETY: out_buf / out_len null-checked just above; caller
+    // contracted them as writable, non-aliasing.
+    unsafe {
+        *out_buf = ptr::null_mut();
+        *out_len = 0;
+    }
+
+    if input.is_null() {
+        return SUPRAMARK_MARKDOWN_ERR_NULL_INPUT;
+    }
+
+    let input_bytes: &[u8] = if input_len == 0 {
+        // SAFETY: caller guaranteed NUL-terminated valid C string.
+        let cstr = unsafe { CStr::from_ptr(input) };
+        match cstr.to_bytes_with_nul().split_last() {
+            Some((_nul, body)) => body,
+            None => return SUPRAMARK_MARKDOWN_ERR_NULL_INPUT,
+        }
+    } else {
+        // SAFETY: caller guaranteed `input_len` readable bytes at `input`.
+        unsafe { slice::from_raw_parts(input as *const u8, input_len) }
+    };
+
+    let input_str = match std::str::from_utf8(input_bytes) {
+        Ok(s) => s,
+        Err(_) => return SUPRAMARK_MARKDOWN_ERR_NULL_INPUT,
+    };
+
+    // 主 crate 的 `parse` 不返回 Result：内部解析失败会以 diagnostics
+    // 字段的形式挂到 AST 上，不会抛错。所以这里只可能因 serde_json
+    // 序列化失败而报错（实际几乎不会发生）。
+    let node = supramark_markdown::parse(input_str);
+    let json_bytes = match serde_json::to_vec(&node) {
+        Ok(bytes) => bytes,
+        Err(_) => return SUPRAMARK_MARKDOWN_ERR_SERIALIZE,
+    };
+
+    let len = json_bytes.len();
+    let boxed: Box<[u8]> = json_bytes.into_boxed_slice();
+    let raw: *mut u8 = Box::into_raw(boxed) as *mut u8;
+    // SAFETY: out_buf / out_len null-checked at function entry.
+    unsafe {
+        *out_buf = raw as *mut c_char;
+        *out_len = len;
+    }
+    SUPRAMARK_MARKDOWN_OK
+}
+
+/// Release a buffer previously returned by
+/// [`supramark_markdown_parse_json`].
+///
+/// Passing `(NULL, 0)` is a no-op. Passing a buffer that did not come
+/// from `supramark_markdown_parse_json`, or a `len` that does not match
+/// the original allocation, is undefined behaviour.
+///
+/// # Safety
+///
+/// See module-level "Memory ownership" note. `buf` must have been
+/// produced by [`supramark_markdown_parse_json`] and not yet freed;
+/// `len` must equal the `out_len` value the parse call wrote.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn supramark_markdown_free(buf: *mut c_char, len: usize) {
+    if buf.is_null() || len == 0 {
+        return;
+    }
+    let slice_ptr = ptr::slice_from_raw_parts_mut(buf as *mut u8, len);
+    // SAFETY: caller contracts buf+len match a prior parse call.
+    unsafe { drop(Box::from_raw(slice_ptr)) };
+}
+
+/// Returns a static, NUL-terminated UTF-8 C string with this wrapper
+/// crate's version (matches the `supramark-markdown` crate version it
+/// wraps).
+///
+/// The returned pointer is valid for the lifetime of the loaded
+/// library; callers must NOT free it.
+#[unsafe(no_mangle)]
+pub extern "C" fn supramark_markdown_version() -> *const c_char {
+    static VERSION: &[u8] = concat!(env!("CARGO_PKG_VERSION"), "\0").as_bytes();
+    VERSION.as_ptr() as *const c_char
+}
+
+// ---------------------------------------------------------------------------
+// Tests — exercised via `cargo test -p supramark-markdown-native`.
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::ffi::CString;
+
+    /// 最小 Markdown 输入 → 期望返回合法 JSON。
+    #[test]
+    fn parse_roundtrip_simple() {
+        let src = CString::new("# Hello").unwrap();
+        let mut out_buf: *mut c_char = ptr::null_mut();
+        let mut out_len: usize = 0;
+
+        let rc = unsafe {
+            supramark_markdown_parse_json(
+                src.as_ptr(),
+                0,
+                &mut out_buf as *mut *mut c_char,
+                &mut out_len as *mut usize,
+            )
+        };
+        assert_eq!(rc, SUPRAMARK_MARKDOWN_OK, "parse returned {rc}");
+        assert!(!out_buf.is_null());
+        assert!(out_len > 0);
+
+        let json = unsafe { slice::from_raw_parts(out_buf as *const u8, out_len) };
+        let json_str = std::str::from_utf8(json).expect("JSON must be UTF-8");
+        // AST v2 root 节点带 type 字段
+        assert!(json_str.contains("\"type\""), "expected type field in JSON");
+
+        unsafe { supramark_markdown_free(out_buf, out_len) };
+    }
+
+    /// 显式长度路径（input 不需要 NUL 结尾）。
+    #[test]
+    fn parse_with_explicit_length() {
+        let src = b"# Hello";
+        let mut out_buf: *mut c_char = ptr::null_mut();
+        let mut out_len: usize = 0;
+        let rc = unsafe {
+            supramark_markdown_parse_json(
+                src.as_ptr() as *const c_char,
+                src.len(),
+                &mut out_buf,
+                &mut out_len,
+            )
+        };
+        assert_eq!(rc, SUPRAMARK_MARKDOWN_OK);
+        assert!(out_len > 0);
+        unsafe { supramark_markdown_free(out_buf, out_len) };
+    }
+
+    /// NULL input → ERR_NULL_INPUT，out-params 保持原状。
+    #[test]
+    fn parse_null_input() {
+        let mut out_buf: *mut c_char = ptr::null_mut();
+        let mut out_len: usize = 0;
+        let rc = unsafe {
+            supramark_markdown_parse_json(ptr::null(), 0, &mut out_buf, &mut out_len)
+        };
+        assert_eq!(rc, SUPRAMARK_MARKDOWN_ERR_NULL_INPUT);
+        assert!(out_buf.is_null());
+        assert_eq!(out_len, 0);
+    }
+
+    /// NULL out-params → ERR_NULL_INPUT（不崩溃）。
+    #[test]
+    fn parse_null_outparams() {
+        let src = CString::new("a").unwrap();
+        let rc = unsafe {
+            supramark_markdown_parse_json(src.as_ptr(), 0, ptr::null_mut(), ptr::null_mut())
+        };
+        assert_eq!(rc, SUPRAMARK_MARKDOWN_ERR_NULL_INPUT);
+    }
+
+    /// Free of (NULL, 0) 是 no-op（不能崩）。
+    #[test]
+    fn free_null_is_noop() {
+        unsafe { supramark_markdown_free(ptr::null_mut(), 0) };
+    }
+
+    /// Version 字符串非空，且与 crate 版本一致。
+    #[test]
+    fn version_string() {
+        let p = supramark_markdown_version();
+        assert!(!p.is_null());
+        let s = unsafe { CStr::from_ptr(p) }.to_str().unwrap();
+        assert_eq!(s, env!("CARGO_PKG_VERSION"));
+    }
+
+    /// 解析出的 JSON 能被 serde_json 还原成同样的结构（round-trip）。
+    #[test]
+    fn json_is_parseable() {
+        let src = CString::new("# Title\n\nparagraph **bold**").unwrap();
+        let mut out_buf: *mut c_char = ptr::null_mut();
+        let mut out_len: usize = 0;
+        let rc = unsafe {
+            supramark_markdown_parse_json(src.as_ptr(), 0, &mut out_buf, &mut out_len)
+        };
+        assert_eq!(rc, SUPRAMARK_MARKDOWN_OK);
+
+        let json = unsafe { slice::from_raw_parts(out_buf as *const u8, out_len) };
+        let value: serde_json::Value = serde_json::from_slice(json).expect("must be valid JSON");
+        assert_eq!(value["type"], "root");
+
+        unsafe { supramark_markdown_free(out_buf, out_len) };
+    }
+}

--- a/crates/supramark-markdown/packages/native/src/lib.rs
+++ b/crates/supramark-markdown/packages/native/src/lib.rs
@@ -22,7 +22,7 @@
 //! produced it; calling `free(3)` from C is undefined behaviour because
 //! the Rust allocator may be jemalloc/mimalloc in a host build.
 
-use std::ffi::{CStr, c_char};
+use std::ffi::{c_char, CStr};
 use std::os::raw::c_int;
 use std::ptr;
 use std::slice;
@@ -288,12 +288,34 @@ mod tests {
     fn parse_empty_input_null_ptr() {
         let mut out_buf: *mut c_char = ptr::null_mut();
         let mut out_len: usize = 0;
-        let rc = unsafe {
-            supramark_markdown_parse_json(ptr::null(), 0, &mut out_buf, &mut out_len)
-        };
+        let rc =
+            unsafe { supramark_markdown_parse_json(ptr::null(), 0, &mut out_buf, &mut out_len) };
         assert_eq!(rc, SUPRAMARK_MARKDOWN_OK);
         assert!(!out_buf.is_null());
         unsafe { supramark_markdown_free(out_buf, out_len) };
+    }
+
+    /// Invalid UTF-8 bytes (explicit length) -> ERR_NULL_INPUT, out-params
+    /// left untouched. Covers the `str::from_utf8` failure branch: a caller
+    /// passing a non-UTF-8 source (e.g. binary data mistaken for text) must
+    /// not crash and returns the documented error code.
+    #[test]
+    fn parse_invalid_utf8() {
+        // 0xFF / 0xFE are not valid UTF-8 lead bytes.
+        let src: [u8; 3] = [b'#', 0xFF, 0xFE];
+        let mut out_buf: *mut c_char = ptr::null_mut();
+        let mut out_len: usize = 0;
+        let rc = unsafe {
+            supramark_markdown_parse_json(
+                src.as_ptr() as *const c_char,
+                src.len(),
+                &mut out_buf,
+                &mut out_len,
+            )
+        };
+        assert_eq!(rc, SUPRAMARK_MARKDOWN_ERR_NULL_INPUT);
+        assert!(out_buf.is_null());
+        assert_eq!(out_len, 0);
     }
 
     /// NULL out-params → ERR_NULL_INPUT（不崩溃）。

--- a/crates/supramark-markdown/packages/native/src/lib.rs
+++ b/crates/supramark-markdown/packages/native/src/lib.rs
@@ -42,6 +42,13 @@ pub const SUPRAMARK_MARKDOWN_ERR_SERIALIZE: c_int = 1;
 /// was not valid UTF-8 / not NUL-terminated within `input_len` bytes.
 pub const SUPRAMARK_MARKDOWN_ERR_NULL_INPUT: c_int = 2;
 
+/// Sentinel `input_len` value that opts into the NUL-terminated
+/// C-string convenience: the wrapper computes the byte length itself
+/// via `strlen` (`CStr`). Every other `input_len` — including `0` — is
+/// an explicit byte length, so an empty document (`input_len == 0`)
+/// parses as an empty root instead of being misread as the strlen path.
+pub const SUPRAMARK_MARKDOWN_LEN_CSTRING: usize = usize::MAX;
+
 // ---------------------------------------------------------------------------
 // Public C ABI
 // ---------------------------------------------------------------------------
@@ -53,12 +60,12 @@ pub const SUPRAMARK_MARKDOWN_ERR_NULL_INPUT: c_int = 2;
 /// `*out_buf` together with its length (in bytes) in `*out_len`. The
 /// caller MUST release the buffer with [`supramark_markdown_free`].
 ///
-/// `input` may be either a NUL-terminated C string (pass
-/// `input_len = 0`, in which case the wrapper computes the length with
-/// `strlen`) or an explicit-length byte buffer (pass `input_len > 0`,
-/// in which case the buffer does NOT need to be NUL-terminated). The
-/// latter is preferred because it avoids a redundant scan on large
-/// inputs.
+/// `input` is interpreted by `input_len`: pass the exact byte length of
+/// the buffer (it does NOT need to be NUL-terminated). `input_len == 0`
+/// is a valid, empty document — `input` is never dereferenced in that
+/// case, so callers may pass `NULL` for an empty buffer. Pass the
+/// sentinel [`SUPRAMARK_MARKDOWN_LEN_CSTRING`] to opt into the
+/// NUL-terminated C-string convenience (length computed via `strlen`).
 ///
 /// The returned JSON matches the schema produced by
 /// `@supramark/markdown-web`'s `parse_json` (the wasm-bindgen wrapper),
@@ -67,9 +74,12 @@ pub const SUPRAMARK_MARKDOWN_ERR_NULL_INPUT: c_int = 2;
 ///
 /// # Safety
 ///
-/// All pointer arguments are dereferenced. The caller must ensure:
-///   * `input` points to at least `input_len` readable bytes (or, when
-///     `input_len == 0`, to a NUL-terminated C string).
+/// The out-parameters are always dereferenced. The caller must ensure:
+///   * `input` points to at least `input_len` readable bytes when
+///     `0 < input_len < SUPRAMARK_MARKDOWN_LEN_CSTRING`, or to a
+///     NUL-terminated C string when `input_len ==
+///     SUPRAMARK_MARKDOWN_LEN_CSTRING`. When `input_len == 0` `input`
+///     is not read and may be `NULL`.
 ///   * `out_buf` and `out_len` are valid, writable, non-aliasing.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn supramark_markdown_parse_json(
@@ -88,19 +98,28 @@ pub unsafe extern "C" fn supramark_markdown_parse_json(
         *out_len = 0;
     }
 
-    if input.is_null() {
-        return SUPRAMARK_MARKDOWN_ERR_NULL_INPUT;
-    }
-
+    // Resolve `input` to a byte slice.
+    //
+    // `input_len == 0` is an empty document: callers (iOS/Android
+    // bridges) hand us the real byte length, which is 0 for an empty
+    // string, and may pass a NULL/dangling pointer for it — so we must
+    // not dereference `input` here. `SUPRAMARK_MARKDOWN_LEN_CSTRING`
+    // opts into the strlen path; any other value is an explicit length.
     let input_bytes: &[u8] = if input_len == 0 {
-        // SAFETY: caller guaranteed NUL-terminated valid C string.
-        let cstr = unsafe { CStr::from_ptr(input) };
-        match cstr.to_bytes_with_nul().split_last() {
-            Some((_nul, body)) => body,
-            None => return SUPRAMARK_MARKDOWN_ERR_NULL_INPUT,
+        &[]
+    } else if input_len == SUPRAMARK_MARKDOWN_LEN_CSTRING {
+        if input.is_null() {
+            return SUPRAMARK_MARKDOWN_ERR_NULL_INPUT;
         }
+        // SAFETY: input null-checked above; caller guaranteed a
+        // NUL-terminated valid C string.
+        unsafe { CStr::from_ptr(input) }.to_bytes()
     } else {
-        // SAFETY: caller guaranteed `input_len` readable bytes at `input`.
+        if input.is_null() {
+            return SUPRAMARK_MARKDOWN_ERR_NULL_INPUT;
+        }
+        // SAFETY: input null-checked above; caller guaranteed
+        // `input_len` readable bytes at `input`.
         unsafe { slice::from_raw_parts(input as *const u8, input_len) }
     };
 
@@ -182,7 +201,7 @@ mod tests {
         let rc = unsafe {
             supramark_markdown_parse_json(
                 src.as_ptr(),
-                0,
+                SUPRAMARK_MARKDOWN_LEN_CSTRING,
                 &mut out_buf as *mut *mut c_char,
                 &mut out_len as *mut usize,
             )
@@ -218,17 +237,63 @@ mod tests {
         unsafe { supramark_markdown_free(out_buf, out_len) };
     }
 
-    /// NULL input → ERR_NULL_INPUT，out-params 保持原状。
+    /// NULL input（strlen 路径）→ ERR_NULL_INPUT，out-params 保持原状。
     #[test]
     fn parse_null_input() {
         let mut out_buf: *mut c_char = ptr::null_mut();
         let mut out_len: usize = 0;
         let rc = unsafe {
-            supramark_markdown_parse_json(ptr::null(), 0, &mut out_buf, &mut out_len)
+            supramark_markdown_parse_json(
+                ptr::null(),
+                SUPRAMARK_MARKDOWN_LEN_CSTRING,
+                &mut out_buf,
+                &mut out_len,
+            )
         };
         assert_eq!(rc, SUPRAMARK_MARKDOWN_ERR_NULL_INPUT);
         assert!(out_buf.is_null());
         assert_eq!(out_len, 0);
+    }
+
+    /// 空文档（显式长度 0）→ OK，返回合法 root JSON，且不解引用 input。
+    /// 这是 iOS / Android bridge 对空字符串源的真实调用形态
+    /// （`[sourceData length]` / `GetArrayLength` 都为 0）。
+    #[test]
+    fn parse_empty_input_explicit_len() {
+        let src = b"";
+        let mut out_buf: *mut c_char = ptr::null_mut();
+        let mut out_len: usize = 0;
+        let rc = unsafe {
+            supramark_markdown_parse_json(
+                src.as_ptr() as *const c_char,
+                0,
+                &mut out_buf,
+                &mut out_len,
+            )
+        };
+        assert_eq!(rc, SUPRAMARK_MARKDOWN_OK);
+        assert!(!out_buf.is_null());
+        assert!(out_len > 0);
+
+        let json = unsafe { slice::from_raw_parts(out_buf as *const u8, out_len) };
+        let value: serde_json::Value = serde_json::from_slice(json).expect("must be valid JSON");
+        assert_eq!(value["type"], "root");
+
+        unsafe { supramark_markdown_free(out_buf, out_len) };
+    }
+
+    /// 空文档 + NULL 指针（len 0）→ OK：len 0 时不解引用 input，
+    /// 覆盖 iOS `[emptyData bytes]` 可能返回 NULL 的情况。
+    #[test]
+    fn parse_empty_input_null_ptr() {
+        let mut out_buf: *mut c_char = ptr::null_mut();
+        let mut out_len: usize = 0;
+        let rc = unsafe {
+            supramark_markdown_parse_json(ptr::null(), 0, &mut out_buf, &mut out_len)
+        };
+        assert_eq!(rc, SUPRAMARK_MARKDOWN_OK);
+        assert!(!out_buf.is_null());
+        unsafe { supramark_markdown_free(out_buf, out_len) };
     }
 
     /// NULL out-params → ERR_NULL_INPUT（不崩溃）。
@@ -263,7 +328,12 @@ mod tests {
         let mut out_buf: *mut c_char = ptr::null_mut();
         let mut out_len: usize = 0;
         let rc = unsafe {
-            supramark_markdown_parse_json(src.as_ptr(), 0, &mut out_buf, &mut out_len)
+            supramark_markdown_parse_json(
+                src.as_ptr(),
+                SUPRAMARK_MARKDOWN_LEN_CSTRING,
+                &mut out_buf,
+                &mut out_len,
+            )
         };
         assert_eq!(rc, SUPRAMARK_MARKDOWN_OK);
 

--- a/crates/supramark-markdown/packages/react-native/.gitignore
+++ b/crates/supramark-markdown/packages/react-native/.gitignore
@@ -1,0 +1,15 @@
+# Staged native artefacts — produced by `node scripts/prepare-native.js`
+# from cargo-built target/. NEVER commit these binaries to git.
+ios/Frameworks/
+android/src/main/jniLibs/
+
+# react-native-builder-bob build output
+lib/
+
+# Node / build noise
+node_modules/
+*.log
+
+# Android CMake external native build state
+android/.cxx/
+android/build/

--- a/crates/supramark-markdown/packages/react-native/SupramarkMarkdownNative.podspec
+++ b/crates/supramark-markdown/packages/react-native/SupramarkMarkdownNative.podspec
@@ -1,0 +1,44 @@
+require "json"
+
+package = JSON.parse(File.read(File.join(__dir__, "package.json")))
+
+# Podspec is at the package root (not ios/) so Expo / RN autolinking discovers
+# it via `findPodspecFile(packageRoot)`. All path references inside point under
+# ios/ where the actual sources + vendored xcframework live.
+
+Pod::Spec.new do |s|
+  s.name         = "SupramarkMarkdownNative"
+  s.version      = package["version"]
+  s.summary      = package["description"]
+  s.homepage     = package["repository"]["url"]
+  s.license      = package["license"]
+  s.authors      = package["authors"]
+  s.source       = { :git => package["repository"]["url"], :tag => "v#{s.version}" }
+
+  # iOS 15.1 matches what scripts/build-ios.sh / Xcode crosscompile target
+  # the supramark-markdown-native staticlib for. Lowering this without a
+  # rebuild would cause an SDK/ABI mismatch at link time.
+  s.ios.deployment_target = "15.1"
+  s.osx.deployment_target = "11.0"
+
+  s.source_files = "ios/*.{h,m,mm}"
+  s.public_header_files = "ios/SupramarkMarkdownModule.h"
+
+  # The vendored xcframework is staged under ios/Frameworks/ by
+  # scripts/prepare-native.js (consuming target/ios-xcframeworks/ from
+  # the workspace root after cargo build + scripts/build-ios-xcframework.sh).
+  s.preserve_paths = "ios/Frameworks/**"
+  s.vendored_frameworks = "ios/Frameworks/SupramarkMarkdown.xcframework"
+  s.xcconfig = {
+    "HEADER_SEARCH_PATHS" =>
+      "\"$(PODS_TARGET_SRCROOT)/ios/Frameworks/SupramarkMarkdown.xcframework/ios-arm64/Headers\" " \
+      "\"$(PODS_TARGET_SRCROOT)/ios/Frameworks/SupramarkMarkdown.xcframework/ios-arm64_x86_64-simulator/Headers\"",
+    "OTHER_LDFLAGS" => "$(inherited)",
+  }
+
+  if respond_to?(:install_modules_dependencies, true)
+    install_modules_dependencies(s)
+  else
+    s.dependency "React-Core"
+  end
+end

--- a/crates/supramark-markdown/packages/react-native/__tests__/index.test.ts
+++ b/crates/supramark-markdown/packages/react-native/__tests__/index.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it, mock } from 'bun:test';
+import {
+  getNativeParserAdapter,
+  listNativeParserAdapters,
+} from '@supramark/core/rn';
+
+// 记录 mock native module 收到的调用，验证 wrapper 没有绕开 RN bridge。
+const nativeCalls: string[] = [];
+
+// 模拟 Old Architecture 下的 NativeModules.SupramarkMarkdownNative。
+const nativeMarkdownModule = {
+  parseJson: async (source: string) => {
+    nativeCalls.push(`parse:${source}`);
+    return JSON.stringify({ type: 'root', ast_version: 2, source });
+  },
+  getVersion: async () => {
+    nativeCalls.push('version');
+    return 'mock-markdown-native';
+  },
+};
+
+mock.module('react-native', () => ({
+  NativeModules: {
+    SupramarkMarkdownNative: nativeMarkdownModule,
+  },
+  Platform: {
+    select: (options: Record<string, string | undefined>) => options.default ?? '',
+  },
+  TurboModuleRegistry: {
+    getEnforcing: () => undefined,
+  },
+}));
+
+describe('@supramark/markdown-native-rn', () => {
+  it('导入包时注册 native parser adapter，并把调用转发给 RN native module', async () => {
+    expect(listNativeParserAdapters()).toEqual([]);
+
+    const markdownNative = await import('../src/index');
+    const adapter = getNativeParserAdapter();
+
+    expect(adapter).toBeDefined();
+    expect(listNativeParserAdapters()).toEqual([adapter]);
+    expect(await adapter?.parseJson('# title')).toBe(
+      JSON.stringify({ type: 'root', ast_version: 2, source: '# title' })
+    );
+    expect(await markdownNative.parseJsonNative('direct')).toBe(
+      JSON.stringify({ type: 'root', ast_version: 2, source: 'direct' })
+    );
+    expect(await markdownNative.getNativeVersion()).toBe('mock-markdown-native');
+    expect(nativeCalls).toEqual(['parse:# title', 'parse:direct', 'version']);
+  });
+});

--- a/crates/supramark-markdown/packages/react-native/__tests__/resolve-native.test.ts
+++ b/crates/supramark-markdown/packages/react-native/__tests__/resolve-native.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it, mock } from 'bun:test';
+
+// `resolveNative` is a pure selection function, so we can exercise all
+// three fallback branches (turbo / bridge / unlinked) with plain fakes —
+// no reliance on import-time module resolution, which the bun test runner
+// caches per-process and cannot re-evaluate per file.
+mock.module('react-native', () => ({
+  NativeModules: {},
+  Platform: {
+    select: (options: Record<string, string | undefined>) => options.default ?? '',
+  },
+  TurboModuleRegistry: {
+    getEnforcing: () => undefined,
+  },
+}));
+
+const { resolveNative } = await import('../src/index');
+
+const turbo = {
+  parseJson: async () => JSON.stringify({ via: 'turbo' }),
+  getVersion: async () => 'turbo',
+};
+const bridge = {
+  parseJson: async () => JSON.stringify({ via: 'bridge' }),
+  getVersion: async () => 'bridge',
+};
+
+describe('resolveNative — native module fallback order', () => {
+  it('prefers the TurboModule (new arch) over the legacy bridge', () => {
+    const resolved = resolveNative(turbo, bridge);
+    expect(resolved).toBe(turbo);
+  });
+
+  it('falls back to the NativeModules bridge when no TurboModule', () => {
+    expect(resolveNative(null, bridge)).toBe(bridge);
+    expect(resolveNative(undefined, bridge)).toBe(bridge);
+  });
+
+  it('returns a Proxy that throws an actionable linking error when unlinked', () => {
+    const resolved = resolveNative(null, null);
+    // Construction itself must not throw — the error is deferred to use.
+    expect(() => (resolved as { parseJson: unknown }).parseJson).toThrow(
+      /doesn't seem to be linked/
+    );
+    expect(() => (resolved as { getVersion: unknown }).getVersion).toThrow(/rebuilt the app/);
+  });
+});

--- a/crates/supramark-markdown/packages/react-native/android/build.gradle
+++ b/crates/supramark-markdown/packages/react-native/android/build.gradle
@@ -1,0 +1,85 @@
+// Android library wrapper for supramark-markdown-native.
+//
+// CMake builds a tiny JNI shim (supramark_markdown_jni.c) that statically
+// links the cargo-produced libsupramark_markdown_native.{so} (from
+// src/main/jniLibs/<abi>/, populated by scripts/prepare-native.js).
+//
+// Host integrators must include `libc++_shared.so` in their APK —
+// the supramark-markdown-native staticlib is built against the NDK with
+// ANDROID_STL=c++_shared. RN >= 0.71 bundles this automatically;
+// standalone Android apps may need to add `packagingOptions` to
+// include it. See README.
+
+buildscript {
+    def kotlinVersion = rootProject.ext.has("kotlinVersion")
+            ? rootProject.ext.get("kotlinVersion")
+            : "1.9.25"
+
+    repositories {
+        google()
+        mavenCentral()
+    }
+
+    dependencies {
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
+    }
+}
+
+def safeExtGet(prop, fallback) {
+    rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
+apply plugin: "com.android.library"
+apply plugin: "com.facebook.react"
+
+android {
+    namespace "com.supramark.markdownnative"
+    compileSdkVersion safeExtGet("compileSdkVersion", 35)
+
+    defaultConfig {
+        minSdkVersion safeExtGet("minSdkVersion", 24)
+        targetSdkVersion safeExtGet("targetSdkVersion", 35)
+
+        externalNativeBuild {
+            cmake {
+                cppFlags ""
+                arguments "-DANDROID_STL=c++_shared"
+            }
+        }
+
+        ndk {
+            abiFilters "arm64-v8a", "x86_64"
+        }
+    }
+
+    externalNativeBuild {
+        cmake {
+            path "src/main/CMakeLists.txt"
+            version "3.22.1"
+        }
+    }
+
+    // jniLibs/ is populated by scripts/prepare-native.js with the
+    // cargo-built libsupramark_markdown_native.so per ABI; CMake's
+    // IMPORTED target points at that location.
+    sourceSets {
+        main {
+            java.srcDirs = ["src/main/java"]
+            jniLibs.srcDirs = ["src/main/jniLibs"]
+        }
+    }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_11
+        targetCompatibility JavaVersion.VERSION_11
+    }
+}
+
+repositories {
+    google()
+    mavenCentral()
+}
+
+dependencies {
+    implementation "com.facebook.react:react-android:+"
+}

--- a/crates/supramark-markdown/packages/react-native/android/build.gradle
+++ b/crates/supramark-markdown/packages/react-native/android/build.gradle
@@ -47,8 +47,12 @@ android {
             }
         }
 
+        // Keep in sync with scripts/build-native.sh + prepare-native.js,
+        // which build and stage all four ABIs into jniLibs/. CMake
+        // FATAL_ERRORs if a filtered-in ABI has no staged .so, so this
+        // list must not exceed what was staged.
         ndk {
-            abiFilters "arm64-v8a", "x86_64"
+            abiFilters "arm64-v8a", "armeabi-v7a", "x86_64", "x86"
         }
     }
 

--- a/crates/supramark-markdown/packages/react-native/android/src/main/CMakeLists.txt
+++ b/crates/supramark-markdown/packages/react-native/android/src/main/CMakeLists.txt
@@ -1,0 +1,44 @@
+cmake_minimum_required(VERSION 3.22.1)
+project(supramark_markdown_jni)
+
+# Pre-built libsupramark_markdown_native.so for this ABI — staged by
+# scripts/prepare-native.js under jniLibs/<abi>/. We import it as a
+# SHARED library so the host's APK bundles a single .so per ABI.
+set(MARKDOWN_NATIVE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/jniLibs/${ANDROID_ABI}")
+set(MARKDOWN_NATIVE_LIB "${MARKDOWN_NATIVE_DIR}/libsupramark_markdown_native.so")
+
+if(NOT EXISTS "${MARKDOWN_NATIVE_LIB}")
+    message(FATAL_ERROR
+        "Missing prebuilt supramark-markdown-native library:\n"
+        "  ${MARKDOWN_NATIVE_LIB}\n"
+        "Run `cargo ndk -t arm64-v8a -t armeabi-v7a -t x86_64 -t x86 build "
+        "--release -p supramark-markdown-native` and then "
+        "`node scripts/prepare-native.js` in this package."
+    )
+endif()
+
+# Header path: prepare-native.js 把 C ABI header 拷贝到包内的
+# jni/include/，让包自包含（file: 协议安装后包被拷贝到消费者 node_modules，
+# 原先指向 monorepo 内 native crate 的相对路径会断裂）。
+set(SUPRAMARK_MARKDOWN_INCLUDE
+    "${CMAKE_CURRENT_SOURCE_DIR}/jni/include")
+
+add_library(supramark_markdown_native SHARED IMPORTED)
+set_target_properties(supramark_markdown_native PROPERTIES
+    IMPORTED_NO_SONAME TRUE
+    IMPORTED_LOCATION "${MARKDOWN_NATIVE_LIB}"
+)
+
+add_library(supramark_markdown_jni SHARED
+    jni/supramark_markdown_jni.c
+)
+
+target_include_directories(supramark_markdown_jni PRIVATE
+    "${SUPRAMARK_MARKDOWN_INCLUDE}"
+)
+
+find_library(log-lib log)
+target_link_libraries(supramark_markdown_jni
+    supramark_markdown_native
+    ${log-lib}
+)

--- a/crates/supramark-markdown/packages/react-native/android/src/main/java/com/supramark/markdownnative/SupramarkMarkdownModule.java
+++ b/crates/supramark-markdown/packages/react-native/android/src/main/java/com/supramark/markdownnative/SupramarkMarkdownModule.java
@@ -1,0 +1,99 @@
+/*
+ * SupramarkMarkdownModule.java — RN bridge module for supramark-markdown native FFI.
+ *
+ * Loads libsupramark_markdown_jni.so (the JNI shim, which in turn links
+ * libsupramark_markdown_native.so), dispatches parse calls off the JS
+ * thread, and resolves promises with the produced AST v2 JSON string.
+ */
+
+package com.supramark.markdownnative;
+
+import androidx.annotation.NonNull;
+
+import com.facebook.react.bridge.Promise;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.ReactContextBaseJavaModule;
+import com.facebook.react.bridge.ReactMethod;
+
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+public class SupramarkMarkdownModule extends ReactContextBaseJavaModule {
+
+    public static final String NAME = "SupramarkMarkdownNative";
+
+    private static final int OK             = 0;
+    private static final int ERR_SERIALIZE  = 1;
+    private static final int ERR_NULL_INPUT = 2;
+
+    static {
+        // Loading the JNI shim transitively pulls in libsupramark_markdown_native.so
+        // via its DT_NEEDED entry (set up by CMake's IMPORTED target).
+        System.loadLibrary("supramark_markdown_jni");
+    }
+
+    private final ExecutorService parseQueue =
+        Executors.newSingleThreadExecutor(r -> {
+            Thread t = new Thread(r, "supramark-markdown-native-parse");
+            t.setDaemon(true);
+            return t;
+        });
+
+    public SupramarkMarkdownModule(ReactApplicationContext reactContext) {
+        super(reactContext);
+    }
+
+    @Override
+    @NonNull
+    public String getName() {
+        return NAME;
+    }
+
+    // Pass UTF-8 bytes through JNI so Rust receives standard UTF-8, not JNI modified UTF-8.
+    private static native byte[] nativeParseJson(byte[] sourceUtf8, int[] statusOut);
+    private static native String nativeGetVersion();
+
+    @ReactMethod
+    public void parseJson(final String source, final Promise promise) {
+        if (source == null) {
+            promise.reject("NULL_INPUT", "parseJson: source is null");
+            return;
+        }
+        parseQueue.execute(() -> {
+            try {
+                int[] status = new int[]{ ERR_SERIALIZE };
+                byte[] jsonUtf8 = nativeParseJson(source.getBytes(StandardCharsets.UTF_8), status);
+                // Null bytes mean the native parser failed before producing JSON.
+                if (jsonUtf8 == null || status[0] != OK) {
+                    String code;
+                    switch (status[0]) {
+                        case ERR_SERIALIZE:  code = "SERIALIZE_ERROR"; break;
+                        case ERR_NULL_INPUT: code = "NULL_INPUT"; break;
+                        default:             code = "UNKNOWN"; break;
+                    }
+                    promise.reject(code, "supramark_markdown_parse_json returned " + status[0]);
+                    return;
+                }
+                String json = new String(jsonUtf8, StandardCharsets.UTF_8);
+                promise.resolve(json);
+            } catch (Throwable t) {
+                promise.reject("UNKNOWN", t.toString(), t);
+            }
+        });
+    }
+
+    @ReactMethod
+    public void getVersion(final Promise promise) {
+        try {
+            String v = nativeGetVersion();
+            if (v == null) {
+                promise.reject("UNKNOWN", "supramark_markdown_version returned NULL");
+            } else {
+                promise.resolve(v);
+            }
+        } catch (Throwable t) {
+            promise.reject("UNKNOWN", t.toString(), t);
+        }
+    }
+}

--- a/crates/supramark-markdown/packages/react-native/android/src/main/java/com/supramark/markdownnative/SupramarkMarkdownPackage.java
+++ b/crates/supramark-markdown/packages/react-native/android/src/main/java/com/supramark/markdownnative/SupramarkMarkdownPackage.java
@@ -1,0 +1,38 @@
+/*
+ * SupramarkMarkdownPackage.java — RN package registration entrypoint.
+ *
+ * Hosts add `new SupramarkMarkdownPackage()` to their list of packages in
+ * MainApplication.java (old arch). Under the new architecture this is
+ * picked up via codegen + autolinking and the manual registration is
+ * not needed.
+ */
+
+package com.supramark.markdownnative;
+
+import androidx.annotation.NonNull;
+
+import com.facebook.react.ReactPackage;
+import com.facebook.react.bridge.NativeModule;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.uimanager.ViewManager;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class SupramarkMarkdownPackage implements ReactPackage {
+
+    @Override
+    @NonNull
+    public List<NativeModule> createNativeModules(@NonNull ReactApplicationContext reactContext) {
+        List<NativeModule> modules = new ArrayList<>();
+        modules.add(new SupramarkMarkdownModule(reactContext));
+        return modules;
+    }
+
+    @Override
+    @NonNull
+    public List<ViewManager> createViewManagers(@NonNull ReactApplicationContext reactContext) {
+        return Collections.emptyList();
+    }
+}

--- a/crates/supramark-markdown/packages/react-native/android/src/main/jni/__tests__/SupramarkMarkdownModule.java
+++ b/crates/supramark-markdown/packages/react-native/android/src/main/jni/__tests__/SupramarkMarkdownModule.java
@@ -53,14 +53,16 @@ public final class SupramarkMarkdownModule {
         check(json.contains("\"type\"") && json.contains("root"), "simple: JSON has root node");
 
         // 2. Empty byte[] (length 0) is a valid empty document, not an error.
-        //    Scope note: this guards the bridge-level behaviour. It does not,
-        //    on this host JVM, reproduce the failure the input_len == 0 fix
-        //    targets: HotSpot's GetByteArrayElements over an empty array
-        //    happens to hand back a pointer that the pre-fix strlen path reads
-        //    as empty, so the test passes either way here. The fix matters on
-        //    real Android ART (non-NUL-terminated buffer); the NULL/empty FFI
-        //    contract itself is teeth-tested in the Rust suite
-        //    (parse_empty_input_null_ptr / parse_empty_input_explicit_len).
+        //    Scope note: this guards bridge-level behaviour. It does not, by
+        //    itself, demonstrate a pre-fix failure: empirically the pre-fix
+        //    strlen path reads GetByteArrayElements' empty-array pointer as an
+        //    empty string and resolves the same way — on a host JVM AND on a
+        //    real Android 15 arm64 ART emulator (the UB is benign on both).
+        //    The input_len == 0 fix is therefore a UB-hygiene + NULL-handling
+        //    correctness change; its teeth live in the Rust suite, where
+        //    parse_empty_input_null_ptr passes an explicit NULL pointer that
+        //    the pre-fix code rejected with ERR_NULL_INPUT and the fix accepts
+        //    as an empty document.
         st[0] = -1;
         byte[] outEmpty = nativeParseJson(new byte[0], st);
         check(st[0] == OK, "empty: status OK (input_len==0 is empty document)");

--- a/crates/supramark-markdown/packages/react-native/android/src/main/jni/__tests__/SupramarkMarkdownModule.java
+++ b/crates/supramark-markdown/packages/react-native/android/src/main/jni/__tests__/SupramarkMarkdownModule.java
@@ -1,0 +1,95 @@
+/*
+ * SupramarkMarkdownModule.java — TEST-ONLY host-JVM harness for the JNI bridge.
+ *
+ * This is NOT the production module (that one lives under
+ * android/src/main/java/... and extends ReactContextBaseJavaModule). It is
+ * a host stand-in that intentionally shares the exact fully-qualified name
+ * com.supramark.markdownnative.SupramarkMarkdownModule, because JNI binds
+ * native methods by mangled class name: the C symbols in
+ * supramark_markdown_jni.c are
+ * Java_com_supramark_markdownnative_SupramarkMarkdownModule_native*.
+ *
+ * It declares the same two static native methods and exercises the C JNI
+ * marshalling layer (byte[] <-> C bytes <-> FFI, status out-param, UTF-8
+ * round-trip) on a plain host JVM via scripts/test-android-jni.sh — no
+ * Android NDK, emulator, gradle or React Native needed. It does not cover
+ * the production Java Promise/Executor wrapper, only the C bridge.
+ */
+package com.supramark.markdownnative;
+
+import java.nio.charset.StandardCharsets;
+
+public final class SupramarkMarkdownModule {
+    // Status codes mirror the C ABI (SUPRAMARK_MARKDOWN_*).
+    static final int OK = 0;
+    static final int ERR_SERIALIZE = 1;
+    static final int ERR_NULL_INPUT = 2;
+
+    static native byte[] nativeParseJson(byte[] sourceUtf8, int[] statusOut);
+    static native String nativeGetVersion();
+
+    private static int failures = 0;
+
+    private static void check(boolean cond, String msg) {
+        System.out.println((cond ? "ok   - " : "FAIL - ") + msg);
+        if (!cond) {
+            failures++;
+        }
+    }
+
+    public static void main(String[] args) {
+        if (args.length < 1) {
+            System.err.println("usage: SupramarkMarkdownModule <path-to-jni-shared-lib>");
+            System.exit(2);
+        }
+        System.load(args[0]);
+
+        // 1. A normal document round-trips to AST v2 JSON with a root node.
+        int[] st = { -1 };
+        byte[] out = nativeParseJson("# Hello".getBytes(StandardCharsets.UTF_8), st);
+        check(st[0] == OK, "simple: status OK");
+        check(out != null, "simple: bytes non-null");
+        String json = out == null ? "" : new String(out, StandardCharsets.UTF_8);
+        check(json.contains("\"type\"") && json.contains("root"), "simple: JSON has root node");
+
+        // 2. Empty byte[] (length 0) is a valid empty document, not an error.
+        //    Scope note: this guards the bridge-level behaviour. It does not,
+        //    on this host JVM, reproduce the failure the input_len == 0 fix
+        //    targets: HotSpot's GetByteArrayElements over an empty array
+        //    happens to hand back a pointer that the pre-fix strlen path reads
+        //    as empty, so the test passes either way here. The fix matters on
+        //    real Android ART (non-NUL-terminated buffer); the NULL/empty FFI
+        //    contract itself is teeth-tested in the Rust suite
+        //    (parse_empty_input_null_ptr / parse_empty_input_explicit_len).
+        st[0] = -1;
+        byte[] outEmpty = nativeParseJson(new byte[0], st);
+        check(st[0] == OK, "empty: status OK (input_len==0 is empty document)");
+        check(outEmpty != null, "empty: bytes non-null");
+        String jsonEmpty = outEmpty == null ? "" : new String(outEmpty, StandardCharsets.UTF_8);
+        check(jsonEmpty.contains("\"type\"") && jsonEmpty.contains("root"), "empty: JSON has root node");
+
+        // 3. Null source array -> null result, status reports NULL_INPUT.
+        st[0] = -1;
+        byte[] outNull = nativeParseJson(null, st);
+        check(outNull == null, "null: result is null");
+        check(st[0] == ERR_NULL_INPUT, "null: status ERR_NULL_INPUT");
+
+        // 4. Invalid UTF-8 bytes -> null result, status NULL_INPUT.
+        st[0] = -1;
+        byte[] outBad = nativeParseJson(new byte[] { 0x23, (byte) 0xFF, (byte) 0xFE }, st);
+        check(outBad == null, "invalid-utf8: result is null");
+        check(st[0] == ERR_NULL_INPUT, "invalid-utf8: status ERR_NULL_INPUT");
+
+        // 5. Version string marshals back as a non-empty Java String.
+        String version = nativeGetVersion();
+        check(version != null && !version.isEmpty(), "version: non-empty string");
+
+        if (failures == 0) {
+            System.out.println("\nALL PASSED");
+            System.exit(0);
+        } else {
+            System.out.println("\n" + failures + " CHECK(S) FAILED");
+            System.exit(1);
+        }
+    }
+}

--- a/crates/supramark-markdown/packages/react-native/android/src/main/jni/__tests__/stubs/android/log.h
+++ b/crates/supramark-markdown/packages/react-native/android/src/main/jni/__tests__/stubs/android/log.h
@@ -1,0 +1,29 @@
+/*
+ * Minimal <android/log.h> stub — TEST ONLY.
+ *
+ * The JNI bridge logs errors via __android_log_print. On a host JVM (no
+ * Android NDK) that symbol/header is absent, so this stub routes the log
+ * to stderr, letting supramark_markdown_jni.c compile and run unchanged
+ * under scripts/test-android-jni.sh. It is NOT used in any real Android
+ * build, which links the genuine NDK <android/log.h>.
+ */
+#ifndef SUPRAMARK_TEST_ANDROID_LOG_H
+#define SUPRAMARK_TEST_ANDROID_LOG_H
+
+#include <stdarg.h>
+#include <stdio.h>
+
+enum { ANDROID_LOG_ERROR = 6 };
+
+static inline int __android_log_print(int prio, const char *tag, const char *fmt, ...) {
+    (void)prio;
+    fprintf(stderr, "[%s] ", tag ? tag : "");
+    va_list ap;
+    va_start(ap, fmt);
+    int r = vfprintf(stderr, fmt, ap);
+    va_end(ap);
+    fputc('\n', stderr);
+    return r;
+}
+
+#endif /* SUPRAMARK_TEST_ANDROID_LOG_H */

--- a/crates/supramark-markdown/packages/react-native/android/src/main/jni/include/supramark_markdown.h
+++ b/crates/supramark-markdown/packages/react-native/android/src/main/jni/include/supramark_markdown.h
@@ -1,0 +1,78 @@
+/* SPDX-License-Identifier: Apache-2.0 AND MIT */
+/*
+ * supramark_markdown.h — C ABI for libsupramark_markdown_native.{a,so,dylib}
+ *
+ * This header is the canonical contract between the native build
+ * artefact and any C / Objective-C / Swift / Kotlin / JNI consumer.
+ * The Rust impl lives in src/lib.rs; keep this file in sync with the
+ * #[no_mangle] entry points and SUPRAMARK_MARKDOWN_* constants there.
+ */
+
+#ifndef SUPRAMARK_MARKDOWN_H
+#define SUPRAMARK_MARKDOWN_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* ---- Error codes (must match SUPRAMARK_MARKDOWN_* in src/lib.rs) ---- */
+
+/* Parse succeeded; *out_buf / *out_len populated, caller owns buffer. */
+#define SUPRAMARK_MARKDOWN_OK               0
+/* AST serialization to JSON failed. */
+#define SUPRAMARK_MARKDOWN_ERR_SERIALIZE    1
+/* A required pointer was NULL, or input was not valid UTF-8. */
+#define SUPRAMARK_MARKDOWN_ERR_NULL_INPUT   2
+
+/*
+ * Parse a Markdown source string into AST v2 JSON.
+ *
+ * input      : pointer to the Markdown source bytes. May be either a
+ *              NUL-terminated C string (pass input_len = 0) or an
+ *              explicit-length byte buffer (pass input_len > 0). The
+ *              explicit-length form is preferred for large inputs.
+ * input_len  : number of bytes at `input`, or 0 to use strlen-style.
+ * out_buf    : on success, *out_buf is set to a heap-allocated UTF-8
+ *              JSON byte buffer. NOT NUL-terminated. Caller MUST
+ *              release with supramark_markdown_free.
+ * out_len    : on success, *out_len is set to the byte length of the
+ *              buffer at *out_buf.
+ *
+ * The returned JSON matches the schema produced by the wasm-bindgen
+ * wrapper `@supramark/markdown-web`'s `parse_json`, so JS consumers
+ * can `JSON.parse` it identically across Web / Node / RN runtimes.
+ *
+ * Returns one of the SUPRAMARK_MARKDOWN_* status codes. On non-OK
+ * return the out-params are zero-initialised (NULL / 0).
+ */
+int32_t supramark_markdown_parse_json(
+    const char* input, size_t input_len,
+    char** out_buf, size_t* out_len
+);
+
+/*
+ * Release a buffer previously returned by supramark_markdown_parse_json.
+ *
+ * Passing (NULL, 0) is a no-op. Passing a buffer that did not come
+ * from supramark_markdown_parse_json, or a `len` that does not match
+ * the original allocation, is undefined behaviour: the buffer is freed
+ * through Rust's global allocator and may not match the C runtime's
+ * free(3).
+ */
+void supramark_markdown_free(char* buf, size_t len);
+
+/*
+ * Returns a static, NUL-terminated UTF-8 version string identifying
+ * this build of libsupramark_markdown_native. The returned pointer is
+ * valid for the lifetime of the loaded library; do NOT free it.
+ */
+const char* supramark_markdown_version(void);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
+#endif /* SUPRAMARK_MARKDOWN_H */

--- a/crates/supramark-markdown/packages/react-native/android/src/main/jni/include/supramark_markdown.h
+++ b/crates/supramark-markdown/packages/react-native/android/src/main/jni/include/supramark_markdown.h
@@ -28,13 +28,22 @@ extern "C" {
 #define SUPRAMARK_MARKDOWN_ERR_NULL_INPUT   2
 
 /*
+ * Sentinel input_len that opts into the NUL-terminated C-string path
+ * (length computed via strlen). Every other value — including 0 — is an
+ * explicit byte length, so input_len == 0 is a valid empty document.
+ */
+#define SUPRAMARK_MARKDOWN_LEN_CSTRING      ((size_t)-1)
+
+/*
  * Parse a Markdown source string into AST v2 JSON.
  *
- * input      : pointer to the Markdown source bytes. May be either a
- *              NUL-terminated C string (pass input_len = 0) or an
- *              explicit-length byte buffer (pass input_len > 0). The
- *              explicit-length form is preferred for large inputs.
- * input_len  : number of bytes at `input`, or 0 to use strlen-style.
+ * input      : pointer to the Markdown source bytes. Pass the exact byte
+ *              length in input_len (the buffer need NOT be
+ *              NUL-terminated). For an empty document pass input_len = 0;
+ *              `input` is then not dereferenced and may be NULL.
+ * input_len  : number of bytes at `input`. 0 means an empty document.
+ *              Pass SUPRAMARK_MARKDOWN_LEN_CSTRING to treat `input` as a
+ *              NUL-terminated C string (length via strlen).
  * out_buf    : on success, *out_buf is set to a heap-allocated UTF-8
  *              JSON byte buffer. NOT NUL-terminated. Caller MUST
  *              release with supramark_markdown_free.

--- a/crates/supramark-markdown/packages/react-native/android/src/main/jni/supramark_markdown_jni.c
+++ b/crates/supramark-markdown/packages/react-native/android/src/main/jni/supramark_markdown_jni.c
@@ -1,0 +1,92 @@
+/*
+ * supramark_markdown_jni.c — JNI bridge between Java SupramarkMarkdownModule
+ * and the C ABI exported by libsupramark_markdown_native.so.
+ *
+ * Function naming follows JNI mangling for class
+ * com.supramark.markdownnative.SupramarkMarkdownModule — static native
+ * methods `nativeParseJson(byte[]) -> byte[]` and `nativeGetVersion() -> String`.
+ */
+
+#include <jni.h>
+#include <stdint.h>
+#include <android/log.h>
+
+#include "supramark_markdown.h"
+
+#define TAG "SupramarkMarkdownJNI"
+#define LOGE(...) __android_log_print(ANDROID_LOG_ERROR, TAG, __VA_ARGS__)
+
+JNIEXPORT jbyteArray JNICALL
+Java_com_supramark_markdownnative_SupramarkMarkdownModule_nativeParseJson(
+    JNIEnv *env, jclass cls, jbyteArray jSourceUtf8, jintArray jStatusOut)
+{
+    (void)cls;
+    if (jSourceUtf8 == NULL) {
+        if (jStatusOut != NULL) {
+            jint err = SUPRAMARK_MARKDOWN_ERR_NULL_INPUT;
+            (*env)->SetIntArrayRegion(env, jStatusOut, 0, 1, &err);
+        }
+        return NULL;
+    }
+
+    jsize srcLen = (*env)->GetArrayLength(env, jSourceUtf8);
+    jbyte *src = (*env)->GetByteArrayElements(env, jSourceUtf8, NULL);
+    if (src == NULL) {
+        if (jStatusOut != NULL) {
+            jint err = SUPRAMARK_MARKDOWN_ERR_NULL_INPUT;
+            (*env)->SetIntArrayRegion(env, jStatusOut, 0, 1, &err);
+        }
+        return NULL;
+    }
+
+    char *outBuf = NULL;
+    size_t outLen = 0;
+    int status = supramark_markdown_parse_json((const char *)src, (size_t)srcLen, &outBuf, &outLen);
+    (*env)->ReleaseByteArrayElements(env, jSourceUtf8, src, JNI_ABORT);
+
+    if (jStatusOut != NULL) {
+        jint s = status;
+        (*env)->SetIntArrayRegion(env, jStatusOut, 0, 1, &s);
+    }
+
+    if (status != SUPRAMARK_MARKDOWN_OK) {
+        LOGE("supramark_markdown_parse_json returned %d", status);
+        return NULL;
+    }
+
+    // JNI array lengths are signed 32-bit, so reject impossible JS payload sizes.
+    if (outLen > (size_t)INT32_MAX) {
+        supramark_markdown_free(outBuf, outLen);
+        if (jStatusOut != NULL) {
+            jint err = SUPRAMARK_MARKDOWN_ERR_SERIALIZE;
+            (*env)->SetIntArrayRegion(env, jStatusOut, 0, 1, &err);
+        }
+        return NULL;
+    }
+
+    jbyteArray result = (*env)->NewByteArray(env, (jsize)outLen);
+    // Allocation failure is reported as a serialization failure to JS.
+    if (result == NULL) {
+        supramark_markdown_free(outBuf, outLen);
+        if (jStatusOut != NULL) {
+            jint err = SUPRAMARK_MARKDOWN_ERR_SERIALIZE;
+            (*env)->SetIntArrayRegion(env, jStatusOut, 0, 1, &err);
+        }
+        return NULL;
+    }
+
+    // Return standard UTF-8 bytes to Java; Java owns decoding into a String.
+    (*env)->SetByteArrayRegion(env, result, 0, (jsize)outLen, (const jbyte *)outBuf);
+    supramark_markdown_free(outBuf, outLen);
+    return result;
+}
+
+JNIEXPORT jstring JNICALL
+Java_com_supramark_markdownnative_SupramarkMarkdownModule_nativeGetVersion(
+    JNIEnv *env, jclass cls)
+{
+    (void)cls;
+    const char *v = supramark_markdown_version();
+    if (v == NULL) return NULL;
+    return (*env)->NewStringUTF(env, v);
+}

--- a/crates/supramark-markdown/packages/react-native/ios/SupramarkMarkdownModule.h
+++ b/crates/supramark-markdown/packages/react-native/ios/SupramarkMarkdownModule.h
@@ -1,0 +1,28 @@
+/*
+ * SupramarkMarkdownModule.h — RN native module header.
+ *
+ * Bridges JS `parseJson(source)` calls to the C ABI exported by
+ * libsupramark_markdown_native.a:
+ *
+ *   int  supramark_markdown_parse_json(const char *input, size_t input_len,
+ *                                      char **out_buf, size_t *out_len);
+ *   void supramark_markdown_free(char *buf, size_t len);
+ *   const char *supramark_markdown_version(void);
+ *
+ * See ../../include/supramark_markdown.h for the full contract.
+ * Supports both old (RCTBridgeModule) and new (TurboModule) architectures.
+ */
+
+#import <React/RCTBridgeModule.h>
+
+#ifdef RCT_NEW_ARCH_ENABLED
+#import <SupramarkMarkdownNativeSpec/SupramarkMarkdownNativeSpec.h>
+#endif
+
+@interface SupramarkMarkdownModule : NSObject <RCTBridgeModule
+#ifdef RCT_NEW_ARCH_ENABLED
+  , NativeSupramarkMarkdownSpec
+#endif
+>
+
+@end

--- a/crates/supramark-markdown/packages/react-native/ios/SupramarkMarkdownModule.mm
+++ b/crates/supramark-markdown/packages/react-native/ios/SupramarkMarkdownModule.mm
@@ -1,0 +1,104 @@
+/*
+ * SupramarkMarkdownModule.mm — RN native module impl (iOS/macOS).
+ *
+ * Pulls Markdown source from JS, dispatches to a serial background
+ * queue, calls supramark_markdown_parse_json, and resolves the Promise
+ * with an UTF-8 AST v2 JSON string.
+ */
+
+#import "SupramarkMarkdownModule.h"
+#import "supramark_markdown.h"
+
+#import <React/RCTLog.h>
+
+@implementation SupramarkMarkdownModule {
+    dispatch_queue_t _parseQueue;
+}
+
+RCT_EXPORT_MODULE(SupramarkMarkdownNative)
+
+- (instancetype)init {
+    self = [super init];
+    if (self) {
+        _parseQueue = dispatch_queue_create("com.supramark.markdownnative.parse",
+                                            DISPATCH_QUEUE_SERIAL);
+    }
+    return self;
+}
+
++ (BOOL)requiresMainQueueSetup {
+    return NO;
+}
+
+#pragma mark - parseJson(source) -> Promise<string>
+
+RCT_EXPORT_METHOD(parseJson:(NSString *)source
+                  resolve:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject)
+{
+    if (source == nil) {
+        reject(@"NULL_INPUT", @"parseJson: source is null", nil);
+        return;
+    }
+    NSData *sourceData = [source dataUsingEncoding:NSUTF8StringEncoding];
+    if (sourceData == nil) {
+        reject(@"NULL_INPUT", @"parseJson: source is not valid UTF-8", nil);
+        return;
+    }
+
+    dispatch_async(_parseQueue, ^{
+        char *outBuf = NULL;
+        size_t outLen = 0;
+        int32_t status = supramark_markdown_parse_json((const char *)[sourceData bytes],
+                                                        [sourceData length],
+                                                        &outBuf,
+                                                        &outLen);
+        if (status != SUPRAMARK_MARKDOWN_OK) {
+            NSString *code;
+            switch (status) {
+                case SUPRAMARK_MARKDOWN_ERR_SERIALIZE:  code = @"SERIALIZE_ERROR"; break;
+                case SUPRAMARK_MARKDOWN_ERR_NULL_INPUT: code = @"NULL_INPUT"; break;
+                default:                                 code = @"UNKNOWN"; break;
+            }
+            reject(code,
+                   [NSString stringWithFormat:@"supramark_markdown_parse_json returned %d", status],
+                   nil);
+            return;
+        }
+        // Copy the buffer into NSString before freeing.
+        NSString *json = [[NSString alloc] initWithBytes:outBuf
+                                                  length:outLen
+                                                encoding:NSUTF8StringEncoding];
+        supramark_markdown_free(outBuf, outLen);
+        if (json == nil) {
+            reject(@"SERIALIZE_ERROR",
+                   @"supramark_markdown_parse_json returned bytes that aren't valid UTF-8",
+                   nil);
+            return;
+        }
+        resolve(json);
+    });
+}
+
+#pragma mark - getVersion() -> Promise<string>
+
+RCT_EXPORT_METHOD(getVersion:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject)
+{
+    const char *v = supramark_markdown_version();
+    if (v == NULL) {
+        reject(@"UNKNOWN", @"supramark_markdown_version returned NULL", nil);
+        return;
+    }
+    resolve([NSString stringWithUTF8String:v]);
+}
+
+#ifdef RCT_NEW_ARCH_ENABLED
+- (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:
+    (const facebook::react::ObjCTurboModule::InitParams &)params
+{
+    return std::make_shared<facebook::react::NativeSupramarkMarkdownSpecJSI>(params);
+}
+#endif
+
+@end

--- a/crates/supramark-markdown/packages/react-native/ios/__tests__/SupramarkMarkdownModuleTests.mm
+++ b/crates/supramark-markdown/packages/react-native/ios/__tests__/SupramarkMarkdownModuleTests.mm
@@ -1,0 +1,123 @@
+/*
+ * SupramarkMarkdownModuleTests.mm — XCTest for the iOS native bridge.
+ *
+ * Exercises the Objective-C marshalling layer of SupramarkMarkdownModule
+ * end to end: NSString source -> NSData -> C FFI -> NSString JSON, plus
+ * the promise resolve/reject contract. This is the one layer that the
+ * Rust unit tests and the JS adapter tests cannot reach, because it only
+ * exists on the Apple platform.
+ *
+ * Run via scripts/test-ios.sh (builds the host static lib, compiles this
+ * bundle against minimal RN header stubs, and runs it with `xcrun xctest`).
+ */
+#import <XCTest/XCTest.h>
+#import "SupramarkMarkdownModule.h"
+
+/*
+ * The bridge methods are exported via RCT_EXPORT_METHOD in the .mm, so RN
+ * calls them through runtime introspection and they aren't declared in
+ * the public header. Re-declare them here so the test can invoke them
+ * directly. This changes nothing in production code.
+ */
+@interface SupramarkMarkdownModule (Testing)
+- (void)parseJson:(NSString *)source
+          resolve:(RCTPromiseResolveBlock)resolve
+           reject:(RCTPromiseRejectBlock)reject;
+- (void)getVersion:(RCTPromiseResolveBlock)resolve
+            reject:(RCTPromiseRejectBlock)reject;
+@end
+
+@interface SupramarkMarkdownModuleTests : XCTestCase
+@end
+
+@implementation SupramarkMarkdownModuleTests {
+    SupramarkMarkdownModule *_module;
+}
+
+- (void)setUp {
+    [super setUp];
+    _module = [SupramarkMarkdownModule new];
+}
+
+/// Helper: call parseJson and return the resolved JSON string, failing
+/// the test if the bridge rejects instead.
+- (NSString *)parse:(NSString *)source {
+    XCTestExpectation *done = [self expectationWithDescription:@"parseJson settled"];
+    __block NSString *resolved = nil;
+    [_module parseJson:source
+               resolve:^(id result) {
+                   resolved = result;
+                   [done fulfill];
+               }
+                reject:^(NSString *code, NSString *message, NSError *error) {
+                    XCTFail(@"parseJson rejected unexpectedly: %@ / %@", code, message);
+                    [done fulfill];
+                }];
+    [self waitForExpectations:@[ done ] timeout:5.0];
+    return resolved;
+}
+
+/// A normal document round-trips to AST v2 JSON with a root node.
+- (void)testParseSimpleReturnsRootJSON {
+    NSString *json = [self parse:@"# Hello"];
+    XCTAssertNotNil(json);
+
+    NSData *data = [json dataUsingEncoding:NSUTF8StringEncoding];
+    NSError *jsonErr = nil;
+    NSDictionary *ast = [NSJSONSerialization JSONObjectWithData:data options:0 error:&jsonErr];
+    XCTAssertNil(jsonErr, @"bridge must return valid JSON");
+    XCTAssertEqualObjects(ast[@"type"], @"root");
+}
+
+/// Empty source is a valid empty document — the bridge must marshal an
+/// empty NSString (length 0) through the FFI and resolve to a root node,
+/// NOT reject.
+///
+/// Scope note: this guards the bridge-level behaviour. It does NOT, on a
+/// macOS host, reproduce the specific failure the `input_len == 0` fix
+/// targets, because `[@"" dataUsingEncoding:].bytes` returns a non-NULL
+/// pointer here, so even the pre-fix strlen path happens to read it as an
+/// empty C string. The fix matters where `bytes` is NULL (iOS device) or
+/// where the buffer isn't NUL-terminated (Android JNI); the NULL/empty
+/// FFI contract itself is teeth-tested in the Rust suite
+/// (parse_empty_input_null_ptr / parse_empty_input_explicit_len).
+- (void)testEmptyInputResolvesToEmptyRoot {
+    NSString *json = [self parse:@""];
+    XCTAssertNotNil(json, @"empty input must resolve, not reject");
+
+    NSData *data = [json dataUsingEncoding:NSUTF8StringEncoding];
+    NSDictionary *ast = [NSJSONSerialization JSONObjectWithData:data options:0 error:nil];
+    XCTAssertEqualObjects(ast[@"type"], @"root");
+}
+
+/// A nil source is rejected synchronously with the documented code,
+/// before any background dispatch.
+- (void)testNilSourceRejectsNullInput {
+    __block NSString *rejectCode = nil;
+    __block BOOL resolved = NO;
+    [_module parseJson:nil
+               resolve:^(id result) { resolved = YES; }
+                reject:^(NSString *code, NSString *message, NSError *error) {
+                    rejectCode = code;
+                }];
+    XCTAssertFalse(resolved);
+    XCTAssertEqualObjects(rejectCode, @"NULL_INPUT");
+}
+
+/// getVersion resolves with the linked library's non-empty version string.
+- (void)testGetVersionResolves {
+    XCTestExpectation *done = [self expectationWithDescription:@"getVersion settled"];
+    __block NSString *version = nil;
+    [_module getVersion:^(id result) {
+        version = result;
+        [done fulfill];
+    }
+                reject:^(NSString *code, NSString *message, NSError *error) {
+                    XCTFail(@"getVersion rejected: %@ / %@", code, message);
+                    [done fulfill];
+                }];
+    [self waitForExpectations:@[ done ] timeout:5.0];
+    XCTAssertGreaterThan(version.length, 0u);
+}
+
+@end

--- a/crates/supramark-markdown/packages/react-native/ios/__tests__/stubs/React/RCTBridgeModule.h
+++ b/crates/supramark-markdown/packages/react-native/ios/__tests__/stubs/React/RCTBridgeModule.h
@@ -1,0 +1,30 @@
+/*
+ * Minimal React Native header stub — TEST ONLY.
+ *
+ * `SupramarkMarkdownModule` is a self-contained bridge: its exported
+ * methods marshal NSString <-> the C FFI and report results through the
+ * promise blocks, without touching `self.bridge` or any RN runtime
+ * injection. So the marshalling layer can be unit tested against the
+ * documented RN block contract without linking the full React Native
+ * framework (which would require a CocoaPods install of React-Core).
+ *
+ * These typedefs / macros mirror the public shapes from
+ * React/RCTBridgeModule.h closely enough to compile and exercise the
+ * module exactly as RN would call it. They are NOT a reimplementation of
+ * RN — only what the module under test references.
+ */
+#import <Foundation/Foundation.h>
+
+typedef void (^RCTPromiseResolveBlock)(id result);
+typedef void (^RCTPromiseRejectBlock)(NSString *code, NSString *message, NSError *error);
+
+@protocol RCTBridgeModule <NSObject>
+@end
+
+/*
+ * In real RN these register the module with the bridge. The unit test
+ * instantiates the module directly, so registration is a no-op here and
+ * the method macro just emits a plain Objective-C instance method.
+ */
+#define RCT_EXPORT_MODULE(js_name)
+#define RCT_EXPORT_METHOD(...) -(void)__VA_ARGS__

--- a/crates/supramark-markdown/packages/react-native/ios/__tests__/stubs/React/RCTLog.h
+++ b/crates/supramark-markdown/packages/react-native/ios/__tests__/stubs/React/RCTLog.h
@@ -1,0 +1,9 @@
+/*
+ * Minimal React Native header stub — TEST ONLY.
+ *
+ * The module imports <React/RCTLog.h> but does not call any RCTLog*
+ * macros in the code paths under test, so an empty stub is enough to
+ * satisfy the import without linking React Native. See RCTBridgeModule.h
+ * in this directory for the rationale.
+ */
+#import <Foundation/Foundation.h>

--- a/crates/supramark-markdown/packages/react-native/package.json
+++ b/crates/supramark-markdown/packages/react-native/package.json
@@ -1,0 +1,57 @@
+{
+  "name": "@supramark/markdown-native-rn",
+  "version": "0.1.0",
+  "description": "React Native native FFI wrapper for supramark-markdown — Markdown source to AST v2 JSON via the supramark-markdown-native Rust staticlib on iOS / Android.",
+  "main": "lib/commonjs/index.js",
+  "module": "lib/module/index.js",
+  "types": "lib/typescript/index.d.ts",
+  "source": "src/index.ts",
+  "react-native": "src/index.ts",
+  "license": "Apache-2.0 AND MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/kookyleo/supramark.git",
+    "directory": "crates/supramark-markdown/packages/react-native"
+  },
+  "authors": ["Supramark contributors"],
+  "files": [
+    "src",
+    "lib",
+    "ios",
+    "android",
+    "scripts",
+    "!**/__tests__",
+    "!**/.gitkeep"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "test": "bun test",
+    "typescript": "tsc --noEmit",
+    "build": "if command -v bob >/dev/null 2>&1; then BROWSERSLIST_IGNORE_OLD_DATA=1 bob build; else echo 'react-native-builder-bob not installed; skipping build'; fi",
+    "prepack": "if command -v bob >/dev/null 2>&1; then BROWSERSLIST_IGNORE_OLD_DATA=1 bob build; fi",
+    "prepare-native": "node scripts/prepare-native.js"
+  },
+  "keywords": [
+    "react-native",
+    "markdown",
+    "parser",
+    "ast",
+    "supramark"
+  ],
+  "peerDependencies": {
+    "@supramark/core": "workspace:*",
+    "react": "*",
+    "react-native": "*"
+  },
+  "devDependencies": {},
+  "codegenConfig": {
+    "name": "SupramarkMarkdownNativeSpec",
+    "type": "modules",
+    "jsSrcsDir": "src",
+    "android": {
+      "javaPackageName": "com.supramark.markdownnative"
+    }
+  }
+}

--- a/crates/supramark-markdown/packages/react-native/scripts/build-native.sh
+++ b/crates/supramark-markdown/packages/react-native/scripts/build-native.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# 编译 supramark-markdown-native 的 iOS / Android 产物，并打包成
+# RN wrapper 包可消费的 xcframework + jniLibs 布局。
+#
+# 用法：
+#   scripts/build-native.sh           # 默认构建 iOS + Android（如果环境齐全）
+#   scripts/build-native.sh --ios     # 只构建 iOS
+#   scripts/build-native.sh --android # 只构建 Android
+#
+# 前置条件：
+#   - Rust 工具链 + 已安装 target：
+#       rustup target add aarch64-apple-ios aarch64-apple-ios-sim x86_64-apple-ios
+#       rustup target add aarch64-linux-android armv7-linux-androideabi x86_64-linux-android i686-linux-android
+#   - Android 还需要 cargo-ndk（cargo install cargo-ndk）和 $ANDROID_NDK_HOME
+#   - Xcode（用于 xcodebuild / lipo）
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PKG_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+# PKG_DIR = crates/supramark-markdown/packages/react-native
+# 往上 4 级到 repo root: packages → supramark-markdown → crates → root
+REPO_ROOT="$(cd "${PKG_DIR}/../../../.." && pwd)"
+CRATE_NAME="supramark-markdown-native"
+LIB_NAME="libsupramark_markdown_native.a"
+SO_NAME="libsupramark_markdown_native.so"
+HEADER_DIR="${PKG_DIR}/../native/include"
+XCFRAMEWORK_OUT="${REPO_ROOT}/target/ios-xcframeworks/SupramarkMarkdown.xcframework"
+
+BUILD_IOS=0
+BUILD_ANDROID=0
+
+if [[ $# -eq 0 ]]; then
+  BUILD_IOS=1
+  BUILD_ANDROID=1
+fi
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --ios)     BUILD_IOS=1; shift ;;
+    --android) BUILD_ANDROID=1; shift ;;
+    *) echo "unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+echo "==> Repo root: ${REPO_ROOT}"
+echo "==> Package:   ${PKG_DIR}"
+
+# 所有 cargo 命令在 repo root 跑，确保找到 workspace Cargo.toml
+cd "${REPO_ROOT}"
+
+# ----------------------------------------------------------------------------
+# iOS
+# ----------------------------------------------------------------------------
+if [[ "${BUILD_IOS}" -eq 1 ]]; then
+  echo ""
+  echo "==> [iOS] Building device (aarch64-apple-ios)"
+  cargo build --release --target aarch64-apple-ios -p "${CRATE_NAME}"
+
+  echo ""
+  echo "==> [iOS] Building simulator (aarch64-apple-ios-sim)"
+  cargo build --release --target aarch64-apple-ios-sim -p "${CRATE_NAME}"
+
+  echo ""
+  echo "==> [iOS] Building simulator (x86_64-apple-ios)"
+  cargo build --release --target x86_64-apple-ios -p "${CRATE_NAME}"
+
+  echo ""
+  echo "==> [iOS] Lipo sim slices → target/ios-sim-universal"
+  mkdir -p "${REPO_ROOT}/target/ios-sim-universal/release"
+  lipo -create \
+    "${REPO_ROOT}/target/aarch64-apple-ios-sim/release/${LIB_NAME}" \
+    "${REPO_ROOT}/target/x86_64-apple-ios/release/${LIB_NAME}" \
+    -output "${REPO_ROOT}/target/ios-sim-universal/release/${LIB_NAME}"
+
+  echo ""
+  echo "==> [iOS] Assembling xcframework"
+  "${REPO_ROOT}/scripts/build-ios-xcframework.sh" \
+    "${CRATE_NAME}" \
+    "${HEADER_DIR}" \
+    "${LIB_NAME}" \
+    "${XCFRAMEWORK_OUT}"
+fi
+
+# ----------------------------------------------------------------------------
+# Android
+# ----------------------------------------------------------------------------
+if [[ "${BUILD_ANDROID}" -eq 1 ]]; then
+  if ! command -v cargo-ndk >/dev/null 2>&1; then
+    echo ""
+    echo "==> [Android] SKIPPED: cargo-ndk not found."
+    echo "    Install with: cargo install cargo-ndk"
+    echo "    Then re-run: scripts/build-native.sh --android"
+  else
+    if [[ -z "${ANDROID_NDK_HOME:-}" ]]; then
+      echo "==> [Android] SKIPPED: ANDROID_NDK_HOME not set."
+      exit 1
+    fi
+    echo ""
+    echo "==> [Android] Building 4 ABIs via cargo-ndk"
+    cargo ndk -t arm64-v8a -t armeabi-v7a -t x86_64 -t x86 \
+      build --release -p "${CRATE_NAME}"
+  fi
+fi
+
+# ----------------------------------------------------------------------------
+# Stage into RN package layout
+# ----------------------------------------------------------------------------
+echo ""
+echo "==> Staging artefacts into RN package (prepare-native.js)"
+cd "${PKG_DIR}"
+node scripts/prepare-native.js
+
+echo ""
+echo "==> Done."
+echo "    iOS xcframework: ${XCFRAMEWORK_OUT}"
+echo "    Android jniLibs: ${PKG_DIR}/android/src/main/jniLibs/"

--- a/crates/supramark-markdown/packages/react-native/scripts/prepare-native.js
+++ b/crates/supramark-markdown/packages/react-native/scripts/prepare-native.js
@@ -1,0 +1,129 @@
+#!/usr/bin/env node
+/*
+ * prepare-native.js — bring the cargo-produced supramark-markdown-native
+ * libs into the RN package's local layout so podspec / Gradle / CMake
+ * reference stable paths.
+ *
+ * Run this AFTER:
+ *   - `cargo build --release --target <ios-triple>  -p supramark-markdown-native`
+ *   - `scripts/build-ios-xcframework.sh ...` (at repo root, produces
+ *     target/ios-xcframeworks/SupramarkMarkdown.xcframework)
+ *   - `cargo ndk -t arm64-v8a -t armeabi-v7a -t x86_64 -t x86 build --release
+ *      -p supramark-markdown-native`
+ *
+ * Then run `npm run prepare-native` (or `node scripts/prepare-native.js`).
+ * Idempotent — re-running just refreshes.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+// crates/supramark-markdown/packages/react-native/scripts/ → 5 levels up to repo root
+const REPO_ROOT = path.resolve(__dirname, '..', '..', '..', '..', '..');
+const PKG_DIR = path.resolve(__dirname, '..');
+const TARGET_DIR = path.join(REPO_ROOT, 'target');
+
+const IOS_XCFRAMEWORK_SRC = path.join(
+  TARGET_DIR,
+  'ios-xcframeworks',
+  'SupramarkMarkdown.xcframework'
+);
+const IOS_FRAMEWORKS_DEST = path.join(PKG_DIR, 'ios', 'Frameworks');
+
+const ANDROID_ABIS = {
+  'arm64-v8a':    'aarch64-linux-android',
+  'armeabi-v7a':  'armv7-linux-androideabi',
+  'x86_64':       'x86_64-linux-android',
+  'x86':          'i686-linux-android',
+};
+const ANDROID_JNILIBS_DEST = path.join(PKG_DIR, 'android', 'src', 'main', 'jniLibs');
+
+// C ABI header —— 拷贝到包内，让 Android CMake 能自包含找到（不依赖
+// monorepo 内的相对路径；file: 协议安装后包会被拷贝到消费者的 node_modules，
+// 相对路径会断裂）。
+const NATIVE_HEADER_SRC = path.join(
+  REPO_ROOT,
+  'crates',
+  'supramark-markdown',
+  'packages',
+  'native',
+  'include'
+);
+const ANDROID_JNI_INCLUDE_DEST = path.join(PKG_DIR, 'android', 'src', 'main', 'jni', 'include');
+
+function copyDirRecursive(src, dest) {
+  fs.mkdirSync(dest, { recursive: true });
+  for (const entry of fs.readdirSync(src, { withFileTypes: true })) {
+    const s = path.join(src, entry.name);
+    const d = path.join(dest, entry.name);
+    if (entry.isDirectory()) copyDirRecursive(s, d);
+    else if (entry.isSymbolicLink()) {
+      const link = fs.readlinkSync(s);
+      fs.symlinkSync(link, d);
+    } else fs.copyFileSync(s, d);
+  }
+}
+
+function fileExists(p) {
+  try { fs.accessSync(p); return true; } catch { return false; }
+}
+
+function prepareIOS() {
+  if (!fileExists(IOS_XCFRAMEWORK_SRC)) {
+    console.warn(`⚠  iOS xcframework not found at:\n   ${IOS_XCFRAMEWORK_SRC}`);
+    console.warn(`   Run scripts/build-ios-xcframework.sh from the repo root first.`);
+    return false;
+  }
+  fs.rmSync(IOS_FRAMEWORKS_DEST, { recursive: true, force: true });
+  fs.mkdirSync(IOS_FRAMEWORKS_DEST, { recursive: true });
+  copyDirRecursive(IOS_XCFRAMEWORK_SRC, path.join(IOS_FRAMEWORKS_DEST, 'SupramarkMarkdown.xcframework'));
+  console.log(`✓ iOS: copied SupramarkMarkdown.xcframework → ${path.relative(REPO_ROOT, IOS_FRAMEWORKS_DEST)}`);
+  return true;
+}
+
+function prepareAndroid() {
+  let anyFound = false;
+  for (const [abi, rustTriple] of Object.entries(ANDROID_ABIS)) {
+    const src = path.join(TARGET_DIR, rustTriple, 'release', 'libsupramark_markdown_native.so');
+    if (!fileExists(src)) {
+      console.warn(`⚠  Android ${abi}: missing ${path.relative(REPO_ROOT, src)} (skip)`);
+      continue;
+    }
+    const destDir = path.join(ANDROID_JNILIBS_DEST, abi);
+    fs.mkdirSync(destDir, { recursive: true });
+    fs.copyFileSync(src, path.join(destDir, 'libsupramark_markdown_native.so'));
+    anyFound = true;
+    console.log(`✓ Android ${abi}: copied .so → jniLibs/${abi}/`);
+  }
+  if (!anyFound) {
+    console.warn(`   Run \`cargo ndk -t arm64-v8a -t armeabi-v7a -t x86_64 -t x86 build --release -p supramark-markdown-native\` first.`);
+  }
+  return anyFound;
+}
+
+const ios = prepareIOS();
+const android = prepareAndroid();
+
+// 拷贝 C ABI header 到包内（Android CMake 自包含用；iOS 靠 xcframework 内的 Headers）
+function prepareHeader() {
+  if (!fileExists(NATIVE_HEADER_SRC)) {
+    console.warn(`⚠  Native header not found at:\n   ${NATIVE_HEADER_SRC}`);
+    return false;
+  }
+  fs.mkdirSync(ANDROID_JNI_INCLUDE_DEST, { recursive: true });
+  for (const entry of fs.readdirSync(NATIVE_HEADER_SRC)) {
+    fs.copyFileSync(path.join(NATIVE_HEADER_SRC, entry), path.join(ANDROID_JNI_INCLUDE_DEST, entry));
+  }
+  console.log(`✓ Android: copied headers → ${path.relative(REPO_ROOT, ANDROID_JNI_INCLUDE_DEST)}/`);
+  return true;
+}
+const header = prepareHeader();
+
+if (!ios && !android) {
+  console.error('No native artefacts found. Build the Rust crate first.');
+  process.exit(1);
+}
+if (!header) {
+  console.error('Native header missing. Cannot proceed.');
+  process.exit(1);
+}

--- a/crates/supramark-markdown/packages/react-native/scripts/test-android-device.sh
+++ b/crates/supramark-markdown/packages/react-native/scripts/test-android-device.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+#
+# test-android-device.sh — run the JNI bridge test on a connected Android
+# device or emulator (real ART), no gradle / React Native app needed.
+#
+# Complements scripts/test-android-jni.sh (which runs the same harness on a
+# host JVM). This one cross-compiles the native crate for the device ABI with
+# cargo-ndk, links supramark_markdown_jni.c into a self-contained .so with the
+# NDK toolchain, dexes the host harness with d8, pushes both to the device and
+# runs them on ART via app_process. It exercises the exact JNI binding on the
+# real Android runtime — GetByteArrayElements, NewByteArray, etc.
+#
+# Requires: a JDK, Android SDK (ANDROID_HOME) with platform-tools + NDK +
+# build-tools, cargo + cargo-ndk, the matching `rustup target`, and a single
+# device/emulator visible to `adb`.
+#
+# Usage:
+#   crates/supramark-markdown/packages/react-native/scripts/test-android-device.sh
+set -euo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+PKG="$(cd "$HERE/.." && pwd)"
+REPO="$(cd "$PKG" && git rev-parse --show-toplevel)"
+
+: "${ANDROID_HOME:=${ANDROID_SDK_ROOT:-$HOME/Library/Android/sdk}}"
+: "${ANDROID_NDK_HOME:=$(ls -d "$ANDROID_HOME"/ndk/* 2>/dev/null | sort -V | tail -1)}"
+ADB="$ANDROID_HOME/platform-tools/adb"
+NATIVE_MANIFEST="$REPO/crates/supramark-markdown/packages/native/Cargo.toml"
+NATIVE_INCLUDE="$REPO/crates/supramark-markdown/packages/native/include"
+JNI_DIR="$PKG/android/src/main/jni"
+HARNESS="$JNI_DIR/__tests__/SupramarkMarkdownModule.java"
+
+# Locate a JDK with javac.
+if [ -z "${JAVA_HOME:-}" ] || [ ! -x "${JAVA_HOME}/bin/javac" ]; then
+  JAVA_HOME="$(/usr/libexec/java_home 2>/dev/null || true)"
+fi
+if [ ! -x "${JAVA_HOME:-}/bin/javac" ] && command -v brew >/dev/null 2>&1; then
+  JAVA_HOME="$(brew --prefix openjdk 2>/dev/null)/libexec/openjdk.jdk/Contents/Home"
+fi
+[ -x "${JAVA_HOME:-}/bin/javac" ] || { echo "no JDK (javac) found; set JAVA_HOME" >&2; exit 1; }
+
+[ -n "$("$ADB" devices | sed '1d' | grep -w device || true)" ] || { echo "no adb device/emulator connected" >&2; exit 1; }
+
+# Map the device ABI to its rustup target + NDK clang prefix.
+ABI="$("$ADB" shell getprop ro.product.cpu.abi | tr -d '\r')"
+case "$ABI" in
+  arm64-v8a)   RUST_TRIPLE=aarch64-linux-android;     NDK_CLANG=aarch64-linux-android24-clang ;;
+  armeabi-v7a) RUST_TRIPLE=armv7-linux-androideabi;   NDK_CLANG=armv7a-linux-androideabi24-clang ;;
+  x86_64)      RUST_TRIPLE=x86_64-linux-android;      NDK_CLANG=x86_64-linux-android24-clang ;;
+  x86)         RUST_TRIPLE=i686-linux-android;        NDK_CLANG=i686-linux-android24-clang ;;
+  *) echo "unsupported device ABI: $ABI" >&2; exit 1 ;;
+esac
+case "$(uname)" in Darwin) NDK_HOST=darwin-x86_64 ;; *) NDK_HOST=linux-x86_64 ;; esac
+CLANG="$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/$NDK_HOST/bin/$NDK_CLANG"
+echo "device ABI=$ABI  rust=$RUST_TRIPLE"
+
+OUT="$(mktemp -d)"
+
+echo "==> [1/4] Cross-compiling native static lib ($ABI) with cargo-ndk"
+cargo ndk -t "$ABI" build --manifest-path "$NATIVE_MANIFEST"
+LIBA="$REPO/target/$RUST_TRIPLE/debug/libsupramark_markdown_native.a"
+[ -f "$LIBA" ] || { echo "static lib not found at $LIBA" >&2; exit 1; }
+
+echo "==> [2/4] Linking self-contained libsupramark_markdown_jni.so (NDK)"
+SO="$OUT/libsupramark_markdown_jni.so"
+"$CLANG" -shared -fPIC -O0 -g -I"$NATIVE_INCLUDE" \
+  "$JNI_DIR/supramark_markdown_jni.c" "$LIBA" -llog -o "$SO"
+
+echo "==> [3/4] Building dex harness with d8"
+CLASSES="$OUT/classes"; mkdir -p "$CLASSES"
+"$JAVA_HOME/bin/javac" --release 17 -d "$CLASSES" "$HARNESS"
+D8="$(ls -d "$ANDROID_HOME"/build-tools/* | sort -V | tail -1)/d8"
+"$D8" --output "$OUT/harness.jar" "$CLASSES/com/supramark/markdownnative/SupramarkMarkdownModule.class"
+
+echo "==> [4/4] Pushing to device and running on ART"
+"$ADB" push "$SO" /data/local/tmp/ >/dev/null
+"$ADB" push "$OUT/harness.jar" /data/local/tmp/ >/dev/null
+exec "$ADB" shell "cd /data/local/tmp && CLASSPATH=harness.jar app_process /system/bin com.supramark.markdownnative.SupramarkMarkdownModule /data/local/tmp/libsupramark_markdown_jni.so"

--- a/crates/supramark-markdown/packages/react-native/scripts/test-android-jni.sh
+++ b/crates/supramark-markdown/packages/react-native/scripts/test-android-jni.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+#
+# test-android-jni.sh — build and run the JNI bridge test on a host JVM.
+#
+# supramark_markdown_jni.c marshals Java byte[] <-> the C FFI. That C layer
+# is plain JNI (only <android/log.h> is Android-specific, stubbed here), so
+# it can be exercised on a host JVM without an Android NDK, emulator, gradle
+# or React Native. This script:
+#
+#   1. builds the supramark-markdown-native static lib for the host arch,
+#   2. compiles supramark_markdown_jni.c into a host JNI shared library
+#      (against the host JDK headers + the minimal <android/log.h> stub),
+#   3. compiles the host test harness and runs it under `java`.
+#
+# It covers the C JNI marshalling, NOT the production Java Promise/Executor
+# wrapper and NOT the Android ART runtime — an on-device/emulator
+# instrumented test would be a separate, heavier effort.
+#
+# Requires: a JDK (JAVA_HOME or discoverable), a C toolchain, a Rust
+# toolchain (cargo). Usage:
+#   crates/supramark-markdown/packages/react-native/scripts/test-android-jni.sh
+set -euo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+PKG="$(cd "$HERE/.." && pwd)"
+REPO="$(cd "$PKG" && git rev-parse --show-toplevel)"
+
+NATIVE_MANIFEST="$REPO/crates/supramark-markdown/packages/native/Cargo.toml"
+NATIVE_INCLUDE="$REPO/crates/supramark-markdown/packages/native/include"
+JNI_DIR="$PKG/android/src/main/jni"
+TEST_DIR="$JNI_DIR/__tests__"
+STUBS="$TEST_DIR/stubs"
+
+# Locate a JDK with headers (jni.h).
+if [ -z "${JAVA_HOME:-}" ] || [ ! -f "${JAVA_HOME}/include/jni.h" ]; then
+  JAVA_HOME="$(/usr/libexec/java_home 2>/dev/null || true)"
+fi
+if [ ! -f "${JAVA_HOME:-}/include/jni.h" ] && command -v brew >/dev/null 2>&1; then
+  JAVA_HOME="$(brew --prefix openjdk 2>/dev/null)/libexec/openjdk.jdk/Contents/Home"
+fi
+[ -f "${JAVA_HOME:-}/include/jni.h" ] || { echo "no JDK headers; set JAVA_HOME to a JDK with include/jni.h" >&2; exit 1; }
+echo "JAVA_HOME=$JAVA_HOME"
+
+echo "==> [1/3] Building native static lib for host"
+cargo build --manifest-path "$NATIVE_MANIFEST"
+LIB="$REPO/target/debug/libsupramark_markdown_native.a"
+[ -f "$LIB" ] || { echo "static lib not found at $LIB" >&2; exit 1; }
+
+echo "==> [2/3] Compiling JNI shared library"
+OUT="$(mktemp -d)"
+case "$(uname)" in
+  Darwin) SO="$OUT/libsupramark_markdown_jni.dylib"; SHARED=(-dynamiclib); OSLIBS=(-framework CoreFoundation -framework Security);;
+  *)      SO="$OUT/libsupramark_markdown_jni.so";    SHARED=(-shared);      OSLIBS=(-lm -lpthread -ldl);;
+esac
+clang "${SHARED[@]}" -fPIC -O0 -g \
+  -I"$JAVA_HOME/include" -I"$JAVA_HOME/include/darwin" -I"$JAVA_HOME/include/linux" \
+  -I"$NATIVE_INCLUDE" -I"$STUBS" \
+  "$JNI_DIR/supramark_markdown_jni.c" \
+  "$LIB" "${OSLIBS[@]}" \
+  -o "$SO"
+
+echo "==> [3/3] Compiling and running host JNI test"
+CLASSES="$OUT/classes"
+mkdir -p "$CLASSES"
+"$JAVA_HOME/bin/javac" -d "$CLASSES" "$TEST_DIR/SupramarkMarkdownModule.java"
+exec "$JAVA_HOME/bin/java" --enable-native-access=ALL-UNNAMED \
+  -cp "$CLASSES" com.supramark.markdownnative.SupramarkMarkdownModule "$SO"

--- a/crates/supramark-markdown/packages/react-native/scripts/test-ios.sh
+++ b/crates/supramark-markdown/packages/react-native/scripts/test-ios.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+#
+# test-ios.sh — build and run the iOS native bridge XCTest on a Mac.
+#
+# The SupramarkMarkdownModule bridge marshals NSString <-> the C FFI; that
+# layer only exists on the Apple platform and cannot be covered by the
+# Rust or JS test suites. This script:
+#
+#   1. builds the supramark-markdown-native static lib for the host arch,
+#   2. compiles the bridge + XCTest into a macOS .xctest bundle against
+#      the minimal RN header stubs in ios/__tests__/stubs,
+#   3. runs it with `xcrun xctest`.
+#
+# Requires: macOS, Xcode (xcrun/clang), a Rust toolchain (cargo).
+# Usage: crates/supramark-markdown/packages/react-native/scripts/test-ios.sh
+set -euo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+PKG="$(cd "$HERE/.." && pwd)"
+REPO="$(cd "$PKG" && git rev-parse --show-toplevel)"
+
+NATIVE_MANIFEST="$REPO/crates/supramark-markdown/packages/native/Cargo.toml"
+NATIVE_INCLUDE="$REPO/crates/supramark-markdown/packages/native/include"
+IOS_DIR="$PKG/ios"
+TEST_DIR="$IOS_DIR/__tests__"
+STUBS="$TEST_DIR/stubs"
+
+echo "==> [1/3] Building native static lib for host"
+cargo build --manifest-path "$NATIVE_MANIFEST"
+LIB="$REPO/target/debug/libsupramark_markdown_native.a"
+[ -f "$LIB" ] || { echo "static lib not found at $LIB" >&2; exit 1; }
+
+echo "==> [2/3] Compiling .xctest bundle"
+SDK="$(xcrun --show-sdk-path)"
+PLATFORM="$(xcrun --show-sdk-platform-path)"
+FWPATH="$PLATFORM/Developer/Library/Frameworks"
+
+OUT="$(mktemp -d)"
+BUNDLE="$OUT/SupramarkMarkdownModuleTests.xctest"
+mkdir -p "$BUNDLE/Contents/MacOS"
+BIN="$BUNDLE/Contents/MacOS/SupramarkMarkdownModuleTests"
+
+clang++ -g -O0 -fobjc-arc -std=c++17 \
+  -isysroot "$SDK" \
+  -I"$IOS_DIR" -I"$NATIVE_INCLUDE" -I"$STUBS" \
+  -F"$FWPATH" -Wl,-rpath,"$FWPATH" \
+  -bundle \
+  "$IOS_DIR/SupramarkMarkdownModule.mm" \
+  "$TEST_DIR/SupramarkMarkdownModuleTests.mm" \
+  "$LIB" \
+  -framework Foundation -framework XCTest \
+  -framework CoreFoundation -framework Security \
+  -o "$BIN"
+
+cat > "$BUNDLE/Contents/Info.plist" <<'PLIST'
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CFBundleDevelopmentRegion</key><string>en</string>
+  <key>CFBundleExecutable</key><string>SupramarkMarkdownModuleTests</string>
+  <key>CFBundleIdentifier</key><string>com.supramark.markdownnative.tests</string>
+  <key>CFBundleInfoDictionaryVersion</key><string>6.0</string>
+  <key>CFBundleName</key><string>SupramarkMarkdownModuleTests</string>
+  <key>CFBundlePackageType</key><string>BNDL</string>
+  <key>CFBundleVersion</key><string>1</string>
+</dict>
+</plist>
+PLIST
+
+echo "==> [3/3] Running tests"
+exec xcrun xctest "$BUNDLE"

--- a/crates/supramark-markdown/packages/react-native/src/NativeSupramarkMarkdown.ts
+++ b/crates/supramark-markdown/packages/react-native/src/NativeSupramarkMarkdown.ts
@@ -1,0 +1,18 @@
+/**
+ * TurboModule spec for SupramarkMarkdownNative (new React Native architecture).
+ *
+ * Codegen picks this up to emit Objective-C / Java bindings. The
+ * `import * as TurboModuleRegistry` form keeps the file harmless when
+ * codegen isn't run (e.g. old-arch fallback in `index.ts`).
+ */
+import type { TurboModule } from 'react-native';
+import { TurboModuleRegistry } from 'react-native';
+
+export interface Spec extends TurboModule {
+  /** Markdown source → AST v2 JSON string. Rejects on parse / FFI error. */
+  parseJson(source: string): Promise<string>;
+  /** Static version string of the linked libsupramark_markdown_native. */
+  getVersion(): Promise<string>;
+}
+
+export default TurboModuleRegistry.getEnforcing<Spec>('SupramarkMarkdownNative');

--- a/crates/supramark-markdown/packages/react-native/src/index.ts
+++ b/crates/supramark-markdown/packages/react-native/src/index.ts
@@ -1,0 +1,75 @@
+/**
+ * @supramark/markdown-native-rn
+ *
+ * Importing this package side-registers a Markdown parser adapter with
+ * `@supramark/core`'s native parser registry. From there, `parse(source)`
+ * discovers it and routes Markdown source through the linked
+ * `libsupramark_markdown_native` static lib instead of the wasm
+ * `@supramark/markdown-web` bundle.
+ *
+ * Host usage:
+ *
+ * ```ts
+ * import '@supramark/markdown-native-rn';   // side-effect register
+ * import { parse } from '@supramark/core';
+ *
+ * const ast = await parse(markdown);
+ * ```
+ *
+ * Metro config on the host side should stub `@supramark/markdown-web`
+ * to an empty module (mirroring how `@kookyleo/*-web` wasm packages
+ * are stubbed for the diagram engines) so the wasm bundle never loads.
+ *
+ * registry API 从 `@supramark/core/rn` 导入（不污染 web 入口，模式对齐
+ * `@supramark/engines/rn`）。
+ */
+import { NativeModules, Platform } from 'react-native';
+import { registerNativeParserAdapter } from '@supramark/core/rn';
+
+const LINKING_ERROR =
+  `The package '@supramark/markdown-native-rn' doesn't seem to be linked. Make sure:\n\n` +
+  Platform.select({
+    ios: '- You have run \`pod install\`\n',
+    android: '',
+    default: '',
+  }) +
+  '- You rebuilt the app after installing the package\n' +
+  '- You are not using Expo Go\n';
+
+interface NativeSupramarkMarkdownModule {
+  parseJson(source: string): Promise<string>;
+  getVersion(): Promise<string>;
+}
+
+function resolveNative(): NativeSupramarkMarkdownModule {
+  // TurboModule (new arch) first.
+  try {
+    const turbo = require('./NativeSupramarkMarkdown').default;
+    if (turbo) return turbo as NativeSupramarkMarkdownModule;
+  } catch {
+    // not codegen'd or new-arch disabled — fall through
+  }
+  // Bridge-based fallback (old arch).
+  const bridged = NativeModules.SupramarkMarkdownNative;
+  if (!bridged) {
+    return new Proxy({} as NativeSupramarkMarkdownModule, {
+      get() {
+        throw new Error(LINKING_ERROR);
+      },
+    });
+  }
+  return bridged as NativeSupramarkMarkdownModule;
+}
+
+const native = resolveNative();
+
+registerNativeParserAdapter({
+  parseJson: async (source: string) => native.parseJson(source),
+  getVersion: async () => native.getVersion(),
+});
+
+/** Re-exported for diagnostics (returns the linked `supramark_markdown_version()`). */
+export const getNativeVersion = (): Promise<string> => native.getVersion();
+
+/** Direct access to the native parse entry, bypassing the registry. */
+export const parseJsonNative = (source: string): Promise<string> => native.parseJson(source);

--- a/crates/supramark-markdown/packages/react-native/src/index.ts
+++ b/crates/supramark-markdown/packages/react-native/src/index.ts
@@ -41,16 +41,38 @@ interface NativeSupramarkMarkdownModule {
   getVersion(): Promise<string>;
 }
 
-function resolveNative(): NativeSupramarkMarkdownModule {
-  // TurboModule (new arch) first.
+/**
+ * Load the codegen'd TurboModule (new arch), or `null` when codegen
+ * didn't run / new-arch is disabled. Kept separate from {@link
+ * resolveNative} so the selection logic stays a pure, testable function.
+ */
+function loadTurboModule(): NativeSupramarkMarkdownModule | null {
   try {
     const turbo = require('./NativeSupramarkMarkdown').default;
-    if (turbo) return turbo as NativeSupramarkMarkdownModule;
+    return (turbo as NativeSupramarkMarkdownModule) ?? null;
   } catch {
     // not codegen'd or new-arch disabled — fall through
+    return null;
   }
+}
+
+/**
+ * Pick the native module implementation, preferring the New Architecture
+ * TurboModule over the legacy bridge. When neither is available the
+ * package wasn't linked, so return a Proxy that throws an actionable
+ * error on first use (rather than crashing at import time).
+ *
+ * Exported for unit tests — pass the candidates explicitly so the
+ * fallback order can be exercised without relying on import-time module
+ * resolution.
+ */
+export function resolveNative(
+  turbo: NativeSupramarkMarkdownModule | null | undefined,
+  bridged: NativeSupramarkMarkdownModule | null | undefined
+): NativeSupramarkMarkdownModule {
+  // TurboModule (new arch) first.
+  if (turbo) return turbo;
   // Bridge-based fallback (old arch).
-  const bridged = NativeModules.SupramarkMarkdownNative;
   if (!bridged) {
     return new Proxy({} as NativeSupramarkMarkdownModule, {
       get() {
@@ -58,10 +80,10 @@ function resolveNative(): NativeSupramarkMarkdownModule {
       },
     });
   }
-  return bridged as NativeSupramarkMarkdownModule;
+  return bridged;
 }
 
-const native = resolveNative();
+const native = resolveNative(loadTurboModule(), NativeModules.SupramarkMarkdownNative);
 
 registerNativeParserAdapter({
   parseJson: async (source: string) => native.parseJson(source),

--- a/crates/supramark-markdown/packages/react-native/tsconfig.json
+++ b/crates/supramark-markdown/packages/react-native/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2020", "DOM"],
+    "jsx": "react-jsx",
+    "strict": true,
+    "noImplicitAny": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "lib", "android", "ios"]
+}

--- a/packages/core/__tests__/parser-native-adapter.test.ts
+++ b/packages/core/__tests__/parser-native-adapter.test.ts
@@ -1,0 +1,90 @@
+import {
+  __resetNativeParserRegistryForTests,
+  getNativeParserAdapter,
+  listNativeParserAdapters,
+  parseViaNative,
+  registerNativeParserAdapter,
+  type NativeParserAdapter,
+} from '../src/parser-native-adapter';
+import { loadRustMarkdownModule } from '../src/plugin-loader-rn';
+
+describe('native markdown parser adapter', () => {
+  beforeEach(() => {
+    // 每个用例从空 registry 开始，避免 last-wins 状态串到下一个测试。
+    __resetNativeParserRegistryForTests();
+  });
+
+  it('未注册 native adapter 时返回空路由结果', async () => {
+    expect(getNativeParserAdapter()).toBeUndefined();
+    expect(listNativeParserAdapters()).toEqual([]);
+    expect(await parseViaNative('# title')).toBeNull();
+  });
+
+  it('注册 native adapter 后通过 parseViaNative 返回 AST JSON', async () => {
+    // 模拟 RN native module 返回的 AST v2 JSON 字符串。
+    const rootJson = JSON.stringify({ type: 'root', ast_version: 2, children: [] });
+
+    // 注册一个最小 native adapter，验证 registry 能把 Markdown source 转发过去。
+    const adapter: NativeParserAdapter = {
+      parseJson: async source => JSON.stringify({ source, parsed: rootJson }),
+      getVersion: async () => 'test-native',
+    };
+
+    registerNativeParserAdapter(adapter);
+
+    expect(getNativeParserAdapter()).toBe(adapter);
+    expect(listNativeParserAdapters()).toEqual([adapter]);
+    expect(await adapter.getVersion?.()).toBe('test-native');
+    expect(await parseViaNative('# title')).toBe(
+      JSON.stringify({ source: '# title', parsed: rootJson })
+    );
+  });
+
+  it('多次注册 native adapter 时 last-wins，但保留诊断列表顺序', async () => {
+    // 第一个 adapter 模拟旧 native module 实例。
+    const firstAdapter: NativeParserAdapter = {
+      parseJson: async () => JSON.stringify({ type: 'root', from: 'first' }),
+    };
+
+    // 第二个 adapter 模拟 hot reload 或测试替换后的 native module 实例。
+    const secondAdapter: NativeParserAdapter = {
+      parseJson: async () => JSON.stringify({ type: 'root', from: 'second' }),
+    };
+
+    registerNativeParserAdapter(firstAdapter);
+    registerNativeParserAdapter(secondAdapter);
+
+    expect(getNativeParserAdapter()).toBe(secondAdapter);
+    expect(listNativeParserAdapters()).toEqual([firstAdapter, secondAdapter]);
+    expect(await parseViaNative('source')).toBe(JSON.stringify({ type: 'root', from: 'second' }));
+  });
+
+  it('RN loader 未注册 native adapter 时抛出明确接入错误', async () => {
+    // 保存 RN loader 的错误对象，断言它没有静默回退到 wasm。
+    let thrown: unknown;
+
+    try {
+      await loadRustMarkdownModule();
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(Error);
+    expect((thrown as Error).message).toContain('RN runtime requires native markdown parser adapter');
+    expect((thrown as Error).message).toContain("import '@supramark/markdown-native-rn'");
+  });
+
+  it('RN loader 已注册 native adapter 时暴露异步 parseJson', async () => {
+    // 模拟 native bridge 的 Promise<string> 返回值，覆盖 RN TurboModule 异步路径。
+    const nativeJson = JSON.stringify({ type: 'root', ast_version: 2, children: [] });
+
+    registerNativeParserAdapter({
+      parseJson: async source => JSON.stringify({ source, nativeJson }),
+    });
+
+    const mod = await loadRustMarkdownModule();
+
+    expect(typeof mod.parseJson).toBe('function');
+    expect(await mod.parseJson?.('hello')).toBe(JSON.stringify({ source: 'hello', nativeJson }));
+  });
+});

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -12,6 +12,10 @@
       "react-native": "./src/index.rn.ts",
       "import": "./src/index.ts",
       "default": "./src/index.ts"
+    },
+    "./rn": {
+      "types": "./src/index.rn.ts",
+      "default": "./src/index.rn.ts"
     }
   },
   "license": "Apache-2.0",

--- a/packages/core/src/index.rn.ts
+++ b/packages/core/src/index.rn.ts
@@ -33,6 +33,19 @@ export {
   registerContainerHook,
 } from './syntax/container.js';
 
+// Native parser adapter registry —— 供 RN native wrapper 包
+// (如 `@supramark/markdown-native-rn`) side-effect 注册。
+// Web / Node 不会注册，plugin.ts 自动回退到 wasm。
+// 仅从 RN 入口导出（不污染 web 入口），模式对齐 `@supramark/engines/rn`。
+export {
+  type NativeParseJsonFn,
+  type NativeParserAdapter,
+  registerNativeParserAdapter,
+  getNativeParserAdapter,
+  listNativeParserAdapters,
+  parseViaNative,
+} from './parser-native-adapter.js';
+
 /**
  * AST v2 parser facade.
  *

--- a/packages/core/src/parser-native-adapter.ts
+++ b/packages/core/src/parser-native-adapter.ts
@@ -1,0 +1,76 @@
+/**
+ * Native parser adapter registry.
+ *
+ * `supramark-markdown` Rust crate 编译为三种产物：
+ *   - `packages/web`   → wasm-bindgen，给 Web / Node 消费
+ *   - `packages/native` → staticlib / cdylib，给 RN iOS / Android 消费
+ *   - 主 crate 本身     → rlib，给其他 Rust crate 依赖
+ *
+ * native 产物通过 RN TurboModule / Old NativeModule 暴露给 JS，具体
+ * bridge 代码在 consumer 侧 npm 包（`@supramark/markdown-native-rn`）
+ * 里，因为 native module 形态是平台 / linker 相关的。
+ *
+ * 本文件是 **routing layer**：consumer 在启动时注册一个 parser adapter，
+ * `plugin.ts` 的 `loadRustMarkdownModule()` 在 RN 下优先走 native adapter，
+ * 没有注册时回退到 wasm（Web / Node 路径不变）。
+ *
+ * 这与 `@supramark/engines` 的 `registerNativeEngineAdapter` 模式对齐。
+ */
+
+/**
+ * Native parser adapter 的一次调用。
+ *
+ * @param source Markdown 源文本
+ * @returns      AST v2 JSON 字符串（与 `@supramark/markdown-web` 的
+ *               `parse_json` 输出同 schema）。Throws on parse / FFI error.
+ */
+export type NativeParseJsonFn = (source: string) => Promise<string>;
+
+export interface NativeParserAdapter {
+  /** 解析 Markdown 源文本，返回 AST v2 JSON 字符串。 */
+  parseJson: NativeParseJsonFn;
+  /** 可选：返回 native 库版本号，用于诊断。 */
+  getVersion?: () => Promise<string>;
+}
+
+const registry: NativeParserAdapter[] = [];
+let installed: NativeParserAdapter | undefined;
+
+/**
+ * 注册 native parser adapter。多次注册 last-wins，便于测试 / 热替换。
+ *
+ * 通常由 native wrapper 包的 side-effect import 调用：
+ *
+ * ```ts
+ * import '@supramark/markdown-native-rn';
+ * ```
+ */
+export function registerNativeParserAdapter(adapter: NativeParserAdapter): void {
+  registry.push(adapter);
+  installed = adapter;
+}
+
+/** 取回当前注册的 adapter，没有则返回 `undefined`。 */
+export function getNativeParserAdapter(): NativeParserAdapter | undefined {
+  return installed;
+}
+
+/** 列出所有已注册的 adapter（按注册顺序）。主要给诊断用。 */
+export function listNativeParserAdapters(): NativeParserAdapter[] {
+  return [...registry];
+}
+
+/**
+ * 通过 native adapter 解析。未注册则返回 `null`，让 caller 回退到 wasm。
+ */
+export async function parseViaNative(source: string): Promise<string | null> {
+  const adapter = installed;
+  if (!adapter) return null;
+  return adapter.parseJson(source);
+}
+
+/** 测试辅助 —— 清空 registry。不从 package barrel 导出。 */
+export function __resetNativeParserRegistryForTests(): void {
+  registry.length = 0;
+  installed = undefined;
+}

--- a/packages/core/src/plugin-loader-rn.ts
+++ b/packages/core/src/plugin-loader-rn.ts
@@ -1,0 +1,31 @@
+/**
+ * React Native 的 Rust markdown module 加载器。
+ *
+ * RN 下 markdown 解析走 native FFI（`@supramark/markdown-native-rn` 注册的
+ * adapter），不加载 wasm。此文件**不 import** `@supramark/markdown-web`，
+ * 因此 metro 打包 RN bundle 时不会扫描到 wasm 相关代码，避免 lazy bundle
+ * 与静态 require 冲突导致的 "unknown module" 错误。
+ *
+ * 此文件只被 `@supramark/core` 的 RN 入口（`index.rn.ts`）引用。
+ */
+
+import { getNativeParserAdapter } from './parser-native-adapter.js';
+
+type RustMarkdownModule = {
+  parse?: (source: string) => unknown;
+  parseJson?: (source: string) => string | Promise<string>;
+};
+
+export async function loadRustMarkdownModule(): Promise<RustMarkdownModule> {
+  // RN 下 native adapter 必须已注册（由 `@supramark/markdown-native-rn`
+  // side-effect import 触发）。未注册时抛明确错误，而不是回退到 wasm。
+  const nativeAdapter = getNativeParserAdapter();
+  if (nativeAdapter) {
+    return { parseJson: nativeAdapter.parseJson };
+  }
+
+  throw new Error(
+    "RN runtime requires native markdown parser adapter. " +
+      "Add `import '@supramark/markdown-native-rn'` at app entry to register it."
+  );
+}

--- a/packages/core/src/plugin-loader-web.ts
+++ b/packages/core/src/plugin-loader-web.ts
@@ -1,0 +1,79 @@
+/**
+ * Web / Node 的 Rust markdown module 加载器。
+ *
+ * 通过 wasm-bindgen 产物 `@supramark/markdown-web` 加载 Rust parser。
+ * 此文件只被 `@supramark/core` 的 web 入口（`index.ts`）引用，
+ * RN 入口（`index.rn.ts`）走 `plugin-loader-rn.ts`，完全不 import 此文件，
+ * 因此 metro 打包 RN bundle 时不会扫描到 `@supramark/markdown-web`。
+ */
+
+type RustMarkdownModule = {
+  parse?: (source: string) => unknown;
+  parseJson?: (source: string) => string | Promise<string>;
+};
+
+// Node package subpath：只在服务端运行时尝试，不能让浏览器 bundler 静态解析。
+const MARKDOWN_WEB_NODE_PACKAGE = '@supramark/markdown-web/node';
+// Node fallback 产物路径：只在 package subpath 加载失败时运行时尝试。
+const MARKDOWN_WEB_NODE_DIST = '../../../crates/supramark-markdown/packages/web/dist/node.js';
+// Browser fallback 产物路径：只在 package main 加载失败时运行时尝试。
+const MARKDOWN_WEB_BROWSER_DIST = '../../../crates/supramark-markdown/packages/web/dist/index.js';
+
+type RuntimeGlobal = typeof globalThis & {
+  Bun?: unknown;
+  process?: {
+    versions?: { node?: string };
+    env?: Record<string, string | undefined>;
+    cwd?: () => string;
+  };
+};
+
+export async function loadRustMarkdownModule(): Promise<RustMarkdownModule> {
+  const errors: unknown[] = [];
+
+  if (!isServerRuntime()) {
+    try {
+      return (await import('@supramark/markdown-web')) as RustMarkdownModule;
+    } catch (error) {
+      errors.push(error);
+    }
+  }
+
+  // Server runtime 候选：每个候选都写成静态字符串字面量，让 Metro 在
+  // 静态分析时走 resolveRequest（宿主 metro.config.js 可 stub）。
+  if (isServerRuntime()) {
+    try {
+      return await importRustMarkdownModule(MARKDOWN_WEB_NODE_PACKAGE);
+    } catch (error) {
+      errors.push(error);
+    }
+    try {
+      return await importRustMarkdownModule(MARKDOWN_WEB_NODE_DIST);
+    } catch (error) {
+      errors.push(error);
+    }
+  }
+
+  // 兜底候选：直接路径（Web/Node）。
+  try {
+    return await importRustMarkdownModule(MARKDOWN_WEB_BROWSER_DIST);
+  } catch (error) {
+    errors.push(error);
+  }
+
+  throw new Error(
+    `Unable to load supramark-markdown parser. Build @supramark/markdown-web first. Tried ${errors.length} module candidates.`
+  );
+}
+
+function isServerRuntime(): boolean {
+  const runtime = globalThis as RuntimeGlobal;
+  return runtime.Bun !== undefined || Boolean(runtime.process?.versions?.node);
+}
+
+/**
+ * 运行时加载 dist fallback，避免 TypeScript 把构建产物路径当成源码依赖解析。
+ */
+async function importRustMarkdownModule(specifier: string): Promise<RustMarkdownModule> {
+  return (await import(/* @vite-ignore */ specifier)) as RustMarkdownModule;
+}

--- a/packages/core/src/plugin-loader.ts
+++ b/packages/core/src/plugin-loader.ts
@@ -1,0 +1,17 @@
+/**
+ * Rust markdown module 加载器入口（中转文件）。
+ *
+ * 实际实现拆成两个平台文件：
+ *   - `plugin-loader-web.ts` —— Web / Node，import wasm
+ *   - `plugin-loader-rn.ts` —— RN，走 native FFI
+ *
+ * `plugin.ts` 统一从这里 import `loadRustMarkdownModule`，metro 通过
+ * 宿主 `metro.config.js` 的 sourceMap 把 `./plugin-loader.js` 解析到
+ * 对应平台实现。这样 RN bundle 里根本不出现 `@supramark/markdown-web`
+ * 的 import，避免 lazy bundle 与静态 require 冲突。
+ *
+ * 默认 re-export web 实现（供 Node / Bun / Web 直接使用，不依赖 metro 配置）。
+ * RN 宿主必须在 metro.config.js 显式映射 `'./plugin-loader.js'` 或
+ * `'@supramark/core/plugin-loader'` 到 `plugin-loader-rn.ts`。
+ */
+export { loadRustMarkdownModule } from './plugin-loader-web.js';

--- a/packages/core/src/plugin.ts
+++ b/packages/core/src/plugin.ts
@@ -1,5 +1,6 @@
 import type { SupramarkRootNode } from './ast.js';
 import { type SupramarkConfig } from './feature.js';
+import { loadRustMarkdownModule } from './plugin-loader.js';
 
 /**
  * 插件解析上下文，提供给插件访问原始数据和共享状态。
@@ -50,16 +51,9 @@ export interface SupramarkParseOptions {
 
 type RustMarkdownModule = {
   parse?: (source: string) => unknown;
-  parseJson?: (source: string) => string;
-};
-
-type RuntimeGlobal = typeof globalThis & {
-  Bun?: unknown;
-  process?: {
-    versions?: { node?: string };
-    env?: Record<string, string | undefined>;
-    cwd?: () => string;
-  };
+  // wasm 版同步返回 string；native TurboModule 跨 bridge 异步返回 Promise。
+  // 两种都支持，调用处统一 await。
+  parseJson?: (source: string) => string | Promise<string>;
 };
 
 /**
@@ -80,57 +74,10 @@ async function parseWithRustMarkdown(source: string): Promise<SupramarkRootNode>
     return mod.parse(source) as SupramarkRootNode;
   }
   if (typeof mod.parseJson === 'function') {
-    return JSON.parse(mod.parseJson(source)) as SupramarkRootNode;
+    return JSON.parse(await mod.parseJson(source)) as SupramarkRootNode;
   }
 
   throw new Error('supramark-markdown module does not expose parse(source) or parseJson(source).');
-}
-
-async function loadRustMarkdownModule(): Promise<RustMarkdownModule> {
-  const errors: unknown[] = [];
-
-  if (!isServerRuntime()) {
-    try {
-      return (await import('@supramark/markdown-web')) as RustMarkdownModule;
-    } catch (error) {
-      errors.push(error);
-    }
-  }
-
-  for (const specifier of rustModuleCandidates()) {
-    try {
-      return (await import(/* @vite-ignore */ specifier)) as RustMarkdownModule;
-    } catch (error) {
-      errors.push(error);
-    }
-  }
-
-  const cli = await parseWithRustCliModule();
-  if (cli) {
-    return cli;
-  }
-
-  throw new Error(
-    `Unable to load supramark-markdown parser. Build @supramark/markdown-web first. Tried ${errors.length} module candidates.`
-  );
-}
-
-function rustModuleCandidates(): string[] {
-  const candidates: string[] = [];
-
-  if (isServerRuntime()) {
-    candidates.push(
-      '@supramark/markdown-web/node',
-      '../../../crates/supramark-markdown/packages/web/dist/node.js'
-    );
-  }
-
-  candidates.push(
-    '@supramark/markdown-web',
-    '../../../crates/supramark-markdown/packages/web/dist/index.js'
-  );
-
-  return candidates;
 }
 
 async function applyPlugins(
@@ -196,30 +143,6 @@ function sortPluginsByDependencies(plugins: SupramarkPlugin[]): SupramarkPlugin[
   }
 
   return sorted;
-}
-
-function isServerRuntime(): boolean {
-  const runtime = globalThis as RuntimeGlobal;
-  return runtime.Bun !== undefined || Boolean(runtime.process?.versions?.node);
-}
-
-async function parseWithRustCliModule(): Promise<RustMarkdownModule | null> {
-  if (!isServerRuntime()) {
-    return null;
-  }
-
-  return {
-    parse: (source: string) => parseWithRustCli(source),
-  };
-}
-
-function parseWithRustCli(source: string): SupramarkRootNode {
-  const runtime = globalThis as RuntimeGlobal;
-  const cwd = runtime.process?.cwd?.() ?? '.';
-
-  throw new Error(
-    `supramark-markdown wasm wrapper is not built for this runtime. Run "bun --filter @supramark/markdown-web build" before parsing. Current cwd: ${cwd}. Source length: ${source.length}.`
-  );
 }
 
 /**

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -16,6 +16,8 @@
     "paths": {
       "@supramark/core": ["packages/core/src/index.ts"],
       "@supramark/cli": ["packages/cli/src/index.ts"],
+      "@supramark/markdown-web": ["crates/supramark-markdown/packages/web/src/index.ts"],
+      "@supramark/markdown-web/node": ["crates/supramark-markdown/packages/web/src/node.ts"],
 
       "@supramark/engines": ["packages/engines/src/index.ts"],
       "@supramark/engines/types": ["packages/engines/src/types.ts"],


### PR DESCRIPTION
RN 下无法加载 wasm，原 Markdown parser 无可用入口。照图表引擎
（d2/mermaid/plantuml）的 native FFI 模式，给 markdown parser 补上对称的 native 路径。一份 Rust 源码，三个编译目标
（wasm / native / rlib），公开合同统一为 source -> AST v2 JSON。

改动：

1. Rust native wrapper crate（crates/supramark-markdown/packages/native）
   - crate-type = [staticlib, cdylib, rlib]
   - C-ABI: supramark_markdown_parse_json / free / version
   - 内部调主 crate parse() → serde_json → JSON bytes

2. RN TurboModule wrapper 包（crates/supramark-markdown/packages/react-native）
   - @supramark/markdown-native-rn
   - iOS ObjC bridge + Android JNI/Java，支持新旧架构
   - src/index.ts side-effect 注册 adapter

3. @supramark/core 入口分流
   - 新增 parser-native-adapter.ts：native parser registry
   - 新增 plugin-loader-{web,rn}.ts：plugin.ts 通过中转层分流， RN 入口完全不 import @supramark/markdown-web，避免 metro lazy bundle 与静态 require 冲突
   - index.rn.ts 导出 registry API，package.json 加 ./rn exports

4. 构建脚本 build-native.sh + prepare-native.js
   - iOS xcframework / Android jniLibs