### PR TITLE
fix(rn,web): 适配 AST v2 opaque container，修复容器正文丢失与列表 inline 渲染

### DIFF
--- a/packages/core/__tests__/expand-opaque-containers.test.ts
+++ b/packages/core/__tests__/expand-opaque-containers.test.ts
@@ -1,0 +1,117 @@
+import { parse, expandOpaqueContainers } from '../src/plugin';
+import type { SupramarkNode, SupramarkRootNode } from '../src/ast';
+
+function findContainers(node: SupramarkNode, out: any[] = []): any[] {
+  const n = node as any;
+  if (n && typeof n === 'object') {
+    if (n.type === 'container') out.push(n);
+    for (const child of n.children ?? []) findContainers(child, out);
+  }
+  return out;
+}
+
+function hasNodeOfType(node: any, type: string): boolean {
+  if (!node || typeof node !== 'object') return false;
+  if (node.type === type) return true;
+  return (node.children ?? []).some((c: any) => hasNodeOfType(c, type));
+}
+
+describe('expandOpaqueContainers', () => {
+  describe('via parse() (integration)', () => {
+    it('expands a transparent container (no data) by re-parsing its markdown body', async () => {
+      const root = await parse(':::note Title\nhello **bold** world\n:::\n');
+      const [note] = findContainers(root);
+
+      expect(note).toBeDefined();
+      expect(note.name).toBe('note');
+      // Body was raw markdown on `value`; it is now parsed into children and
+      // `value` is cleared.
+      expect(note.value).toBeUndefined();
+      expect(note.children.length).toBeGreaterThan(0);
+      expect(note.children[0].type).toBe('paragraph');
+      // The inline emphasis survived the round-trip.
+      expect(hasNodeOfType(note, 'strong')).toBe(true);
+    });
+
+    it('leaves a genuinely-opaque container (carries data) untouched', async () => {
+      const root = await parse(':::map\ncenter: [1, 2]\nzoom: 5\n:::\n');
+      const [map] = findContainers(root);
+
+      expect(map).toBeDefined();
+      expect(map.name).toBe('map');
+      // The Rust parser populated structured data; the raw value must be kept
+      // verbatim and the body must NOT be parsed as markdown.
+      expect(map.data).toBeDefined();
+      expect(typeof map.value).toBe('string');
+      expect(map.value).toContain('center');
+      expect(map.children.length).toBe(0);
+    });
+
+  });
+
+  describe('discriminator and idempotency (unit)', () => {
+    function makeRoot(children: any[]): SupramarkRootNode {
+      return { type: 'root', children } as unknown as SupramarkRootNode;
+    }
+
+    it('expands an opaque container with no data and a markdown value', async () => {
+      const root = makeRoot([
+        { type: 'container', name: 'note', mode: 'opaque', value: '# Heading', children: [] },
+      ]);
+      await expandOpaqueContainers(root);
+      const note: any = root.children[0];
+
+      expect(note.value).toBeUndefined();
+      expect(hasNodeOfType(note, 'heading')).toBe(true);
+    });
+
+    it('never touches an opaque container that carries data', async () => {
+      const root = makeRoot([
+        {
+          type: 'container',
+          name: 'html',
+          mode: 'opaque',
+          value: '<b>raw</b>',
+          data: { html: '<b>raw</b>' },
+          children: [],
+        },
+      ]);
+      await expandOpaqueContainers(root);
+      const html: any = root.children[0];
+
+      // data-bearing container is left byte-for-byte intact.
+      expect(html.value).toBe('<b>raw</b>');
+      expect(html.children.length).toBe(0);
+    });
+
+    it('recurses into nested parents to expand containers at any depth', async () => {
+      // The opaque container is buried inside a blockquote, not at the top
+      // level — the walk must descend into arbitrary parents to reach it.
+      const root = makeRoot([
+        {
+          type: 'blockquote',
+          children: [
+            { type: 'container', name: 'note', mode: 'opaque', value: 'deep **x**', children: [] },
+          ],
+        },
+      ]);
+      await expandOpaqueContainers(root);
+      const note: any = (root.children[0] as any).children[0];
+
+      expect(note.value).toBeUndefined();
+      expect(hasNodeOfType(note, 'strong')).toBe(true);
+    });
+
+    it('is idempotent: a second pass over an expanded tree changes nothing', async () => {
+      const root = makeRoot([
+        { type: 'container', name: 'note', mode: 'opaque', value: 'plain *text*', children: [] },
+      ]);
+      await expandOpaqueContainers(root);
+      const afterFirst = JSON.stringify(root);
+      await expandOpaqueContainers(root);
+      const afterSecond = JSON.stringify(root);
+
+      expect(afterSecond).toBe(afterFirst);
+    });
+  });
+});

--- a/packages/core/src/index.rn.ts
+++ b/packages/core/src/index.rn.ts
@@ -56,7 +56,7 @@ export {
  * @param options - 解析选项(可选 AST 后处理插件)
  * @returns Supramark AST v2
  */
-export { parse } from './plugin.js';
+export { parse, expandOpaqueContainers } from './plugin.js';
 
 /**
  * 预设(Presets)

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -55,7 +55,7 @@ export {
  * @param options - 解析选项（可选 AST 后处理插件）
  * @returns Supramark AST v2
  */
-export { parse } from './plugin.js';
+export { parse, expandOpaqueContainers } from './plugin.js';
 
 /**
  * 预设（Presets）

--- a/packages/core/src/plugin.ts
+++ b/packages/core/src/plugin.ts
@@ -1,4 +1,4 @@
-import type { SupramarkRootNode } from './ast.js';
+import type { SupramarkNode, SupramarkParentNode, SupramarkRootNode } from './ast.js';
 import { type SupramarkConfig } from './feature.js';
 import { loadRustMarkdownModule } from './plugin-loader.js';
 
@@ -64,8 +64,53 @@ export async function parse(
   options: SupramarkParseOptions = {}
 ): Promise<SupramarkRootNode> {
   const root = await parseWithRustMarkdown(source);
+  await expandOpaqueContainers(root);
   await applyPlugins(root, source, options.plugins ?? []);
   return root;
+}
+
+/**
+ * Expand "transparent" containers: re-parse the body of an opaque container
+ * (which the native parser leaves as a raw markdown string on `value`) into an
+ * AST subtree and put it back on `children`.
+ *
+ * Background: in AST v2 all container scanning happens in the Rust parser, so
+ * every `:::name` container is emitted as `mode: 'opaque'` — body on `value`,
+ * `children` empty. The names the parser recognises (map / vison / html /
+ * weather) also carry structured `data` (their body is YAML / HTML / JSON, not
+ * markdown, and must be left untouched). Every other container (note and the
+ * other admonitions, plus custom containers) has no `data`; its body is
+ * markdown and must be expanded here, otherwise renderers that read `children`
+ * silently drop the body.
+ *
+ * Discriminator: `mode === 'opaque'` and `data` empty and `value` non-empty →
+ * a transparent container, expand it. A genuinely-opaque container (one that
+ * carries `data`, e.g. map) is left exactly as-is — never re-parsed, never has
+ * its `value` cleared.
+ *
+ * Idempotent: an already-expanded container has its `value` cleared, so a
+ * second pass only walks the tree without re-parsing. This single entry point
+ * lives in `parse()` so Web / RN / Node share it and renderers need no copy.
+ */
+export async function expandOpaqueContainers(node: SupramarkNode): Promise<void> {
+  const children = (node as Partial<SupramarkParentNode>).children;
+  if (!Array.isArray(children)) {
+    return;
+  }
+  for (const child of children) {
+    if (
+      child.type === 'container' &&
+      child.mode === 'opaque' &&
+      child.data == null &&
+      typeof child.value === 'string' &&
+      child.value.length > 0
+    ) {
+      const sub = await parseWithRustMarkdown(child.value);
+      child.children = sub.children;
+      child.value = undefined;
+    }
+    await expandOpaqueContainers(child);
+  }
 }
 
 async function parseWithRustMarkdown(source: string): Promise<SupramarkRootNode> {

--- a/packages/renderers/rn/src/Supramark.tsx
+++ b/packages/renderers/rn/src/Supramark.tsx
@@ -35,6 +35,7 @@ import type {
 } from '@supramark/core';
 import {
   parse,
+  expandOpaqueContainers,
   isFeatureEnabled,
   isDiagramFeatureEnabled,
   getFeatureOptionsAs,
@@ -53,46 +54,6 @@ import {
 import { ErrorBoundary, ErrorInfo, ErrorDisplay } from './ErrorBoundary';
 
 type RenderedNode = any;
-
-/**
- * 递归遍历 AST，对 `mode: 'opaque'` 且有 `value` 的 container，
- * 用 parse(value) 解析 value 成 AST 子树，填回 container.children。
- *
- * 新 AST v2 的 opaque container children 为空，正文在 value（原始 markdown 字符串）。
- * Rust parser 不认 feature 插件 JS 侧注册的 registerContainerHook，把所有 :::xxx
- * 当 opaque 处理。这里在主组件异步上下文里预解析，renderNode 就能同步渲染 children。
- *
- * 递归处理已填充的 children（可能嵌套 opaque container）。
- */
-async function expandOpaqueContainers(node: SupramarkNode): Promise<void> {
-  if (!node || typeof node !== 'object' || !('children' in node)) {
-    return;
-  }
-  const parent = node as { children: SupramarkNode[] };
-  for (let i = 0; i < parent.children.length; i++) {
-    const child = parent.children[i] as SupramarkNode & {
-      mode?: string;
-      value?: string;
-    };
-    if (
-      child &&
-      typeof child === 'object' &&
-      child.mode === 'opaque' &&
-      typeof child.value === 'string' &&
-      child.value.length > 0
-    ) {
-      try {
-        const sub = await parse(child.value);
-        (child as { children: SupramarkNode[] }).children = sub.children;
-        // 清空 value，避免 renderNode 误判再次解析
-        child.value = undefined;
-      } catch {
-        // 解析失败保留原 children（可能为空），renderNode 走 fallback
-      }
-    }
-    await expandOpaqueContainers(child);
-  }
-}
 
 function getDefinitionTerms(item: SupramarkDefinitionItemNode): SupramarkDefinitionTermNode[] {
   return item.children.filter(

--- a/packages/renderers/rn/src/Supramark.tsx
+++ b/packages/renderers/rn/src/Supramark.tsx
@@ -54,6 +54,46 @@ import { ErrorBoundary, ErrorInfo, ErrorDisplay } from './ErrorBoundary';
 
 type RenderedNode = any;
 
+/**
+ * 递归遍历 AST，对 `mode: 'opaque'` 且有 `value` 的 container，
+ * 用 parse(value) 解析 value 成 AST 子树，填回 container.children。
+ *
+ * 新 AST v2 的 opaque container children 为空，正文在 value（原始 markdown 字符串）。
+ * Rust parser 不认 feature 插件 JS 侧注册的 registerContainerHook，把所有 :::xxx
+ * 当 opaque 处理。这里在主组件异步上下文里预解析，renderNode 就能同步渲染 children。
+ *
+ * 递归处理已填充的 children（可能嵌套 opaque container）。
+ */
+async function expandOpaqueContainers(node: SupramarkNode): Promise<void> {
+  if (!node || typeof node !== 'object' || !('children' in node)) {
+    return;
+  }
+  const parent = node as { children: SupramarkNode[] };
+  for (let i = 0; i < parent.children.length; i++) {
+    const child = parent.children[i] as SupramarkNode & {
+      mode?: string;
+      value?: string;
+    };
+    if (
+      child &&
+      typeof child === 'object' &&
+      child.mode === 'opaque' &&
+      typeof child.value === 'string' &&
+      child.value.length > 0
+    ) {
+      try {
+        const sub = await parse(child.value);
+        (child as { children: SupramarkNode[] }).children = sub.children;
+        // 清空 value，避免 renderNode 误判再次解析
+        child.value = undefined;
+      } catch {
+        // 解析失败保留原 children（可能为空），renderNode 走 fallback
+      }
+    }
+    await expandOpaqueContainers(child);
+  }
+}
+
 function getDefinitionTerms(item: SupramarkDefinitionItemNode): SupramarkDefinitionTermNode[] {
   return item.children.filter(
     (child): child is SupramarkDefinitionTermNode => child.type === 'definition_term'
@@ -156,6 +196,12 @@ export const Supramark: React.FC<SupramarkProps> = ({
     (async () => {
       try {
         const parsed = ast ?? (await parse(markdown, { config }));
+        // Post-process：递归解析 opaque container 的 value。
+        // 新 AST v2 的 opaque container children 为空，正文在 value（原始 markdown）。
+        // Rust parser 不认 feature 插件 JS 侧注册的 registerContainerHook，
+        // 把所有 :::xxx 当 opaque 处理。这里在主组件异步上下文里把 value 解析成
+        // AST 子树填回 children，renderNode 就能正常渲染。
+        await expandOpaqueContainers(parsed);
         const highlightedMap = await preHighlightAll(
           collectCodeHighlightTasks(parsed.children, config, codeHighlightTheme),
           codeHighlighter
@@ -363,17 +409,24 @@ function renderNode(
       }
 
       // 内置处理：admonition 类型 (note, tip, warning, etc.)
+      // opaque container 的 children 已在主组件 useEffect 里通过 expandOpaqueContainers
+      // 预解析填充（parse(value) → children）。这里直接渲染 children。
+      // Column 布局：title 一行，正文一行。
       if (SUPRAMARK_ADMONITION_KINDS.includes(containerName as any)) {
         const title = container.params || (container.data?.title as string | undefined);
         const kind = containerName;
+        const admonitionContainerStyle = { flexDirection: 'column' as const, marginBottom: 4 };
+
+        const renderAdmonitionContent = () =>
+          container.children.map((child, index) =>
+            renderNode(child, index, styles, highlighted, config, onOpenHtmlPage, containerRenderers)
+          );
 
         if (!isFeatureGroupEnabled(config, ['@supramark/feature-admonition'])) {
           return (
-            <View key={key} style={styles.listItem}>
+            <View key={key} style={admonitionContainerStyle}>
               {title ? <Text style={styles.listItemText}>{title}</Text> : null}
-              <Text style={styles.listItemText}>
-                {renderInlineNodes(container.children, styles, highlighted, config)}
-              </Text>
+              {renderAdmonitionContent()}
             </View>
           );
         }
@@ -383,24 +436,20 @@ function renderNode(
         if (Array.isArray(adOptions.kinds) && adOptions.kinds.length > 0) {
           if (!adOptions.kinds.includes(kind)) {
             return (
-              <View key={key} style={styles.listItem}>
+              <View key={key} style={admonitionContainerStyle}>
                 {title ? <Text style={styles.listItemText}>{title}</Text> : null}
-                <Text style={styles.listItemText}>
-                  {renderInlineNodes(container.children, styles, highlighted, config)}
-                </Text>
+                {renderAdmonitionContent()}
               </View>
             );
           }
         }
 
         return (
-          <View key={key} style={styles.listItem}>
+          <View key={key} style={admonitionContainerStyle}>
             {title ? (
               <Text style={[styles.listItemText, { fontWeight: '600' }]}>{title}</Text>
             ) : null}
-            <Text style={styles.listItemText}>
-              {renderInlineNodes(container.children, styles, highlighted, config)}
-            </Text>
+            {renderAdmonitionContent()}
           </View>
         );
       }
@@ -433,6 +482,10 @@ function renderNode(
         getFeatureOptionsAs<{ compact?: boolean }>(config, '@supramark/feature-definition-list') ??
         {};
       const isCompact = defOptions.compact !== false; // 默认紧凑
+      // Column 布局：term 一行，description 缩进一行。
+      // 避免 row 布局下 description 被 term 挤压导致 Text 不换行。
+      const defItemStyle = { flexDirection: 'column' as const, marginBottom: 4 };
+      const defDescriptionStyle = { paddingLeft: 16 };
       if (!isFeatureGroupEnabled(config, ['@supramark/feature-definition-list'])) {
         // 禁用时，将定义列表退化为普通列表样式
         return (
@@ -442,14 +495,14 @@ function renderNode(
               const terms = getDefinitionTerms(defItem);
               const descriptions = getDefinitionDescriptions(defItem);
               return (
-                <View key={index} style={styles.listItem}>
+                <View key={index} style={defItemStyle}>
                   {terms.map((term, termIndex) => (
                     <Text key={`term-${termIndex}`} style={[styles.listItemText, { fontWeight: '600' }]}>
                       {renderInlineNodes(term.children, styles, highlighted, config)}
                     </Text>
                   ))}
                   {descriptions.map((description, descriptionIndex) => (
-                    <View key={`description-${descriptionIndex}`}>
+                    <View key={`description-${descriptionIndex}`} style={defDescriptionStyle}>
                       {description.children.map((child, childIndex) =>
                         renderNode(
                           child,
@@ -476,14 +529,14 @@ function renderNode(
             const terms = getDefinitionTerms(defItem);
             const descriptions = getDefinitionDescriptions(defItem);
             return (
-              <View key={index} style={styles.listItem}>
+              <View key={index} style={defItemStyle}>
                 {terms.map((term, termIndex) => (
                   <Text key={`term-${termIndex}`} style={[styles.listItemText, { fontWeight: '600' }]}>
                     {renderInlineNodes(term.children, styles, highlighted, config)}
                   </Text>
                 ))}
                 {descriptions.map((description, idx) => (
-                  <View key={idx}>
+                  <View key={idx} style={defDescriptionStyle}>
                     {description.children.map((child, childIndex) =>
                       renderNode(
                         child,
@@ -506,23 +559,25 @@ function renderNode(
     }
     case 'footnote_definition': {
       const def = node as SupramarkFootnoteDefinitionNode;
+      // 新 AST v2 的 footnote_definition.children 是 block 节点（paragraph 等），
+      // 不是 inline 节点。用 renderNode 渲染 children，避免 renderInlineNodes 跳过 block 节点。
+      const renderFootnoteContent = () =>
+        def.children.map((child, childIndex) =>
+          renderNode(child, childIndex, styles, highlighted, config, onOpenHtmlPage, containerRenderers)
+        );
       // 第一阶段：简单以「[n] 内容」形式追加在文末
       if (!isFeatureGroupEnabled(config, ['@supramark/feature-footnote'])) {
         // 禁用脚注 Feature 时，直接渲染为普通段落
         return (
           <View key={key} style={styles.listItem}>
-            <Text style={styles.listItemText}>
-              {renderInlineNodes(def.children, styles, highlighted, config)}
-            </Text>
+            <Text style={styles.listItemText}>{renderFootnoteContent()}</Text>
           </View>
         );
       }
       return (
         <View key={key} style={styles.listItem}>
           <Text style={styles.bullet}>[{def.index}]</Text>
-          <Text style={styles.listItemText}>
-            {renderInlineNodes(def.children, styles, highlighted, config)}
-          </Text>
+          <View style={styles.listItemText}>{renderFootnoteContent()}</View>
         </View>
       );
     }

--- a/packages/renderers/web/src/Supramark.tsx
+++ b/packages/renderers/web/src/Supramark.tsx
@@ -37,6 +37,7 @@ import { type DiagramRenderResult, type DiagramRenderService } from '@supramark/
 import { createWebDiagramEngine } from '@supramark/engines/web';
 import {
   parse,
+  expandOpaqueContainers,
   isFeatureEnabled,
   isDiagramFeatureEnabled,
   getFeatureOptionsAs,
@@ -100,46 +101,6 @@ type CodeHighlightTask = {
   meta?: string;
   theme?: string;
 };
-
-/**
- * 递归遍历 AST，对 `mode: 'opaque'` 且有 `value` 的 container，
- * 用 parse(value) 解析 value 成 AST 子树，填回 container.children。
- *
- * 新 AST v2 的 opaque container children 为空，正文在 value（原始 markdown 字符串）。
- * Rust parser 不认 feature 插件 JS 侧注册的 registerContainerHook，把所有 :::xxx
- * 当 opaque 处理。这里在主组件异步上下文里预解析，renderNode 就能同步渲染 children。
- *
- * 递归处理已填充的 children（可能嵌套 opaque container）。
- */
-async function expandOpaqueContainers(node: SupramarkNode): Promise<void> {
-  if (!node || typeof node !== 'object' || !('children' in node)) {
-    return;
-  }
-  const parent = node as { children: SupramarkNode[] };
-  for (let i = 0; i < parent.children.length; i++) {
-    const child = parent.children[i] as SupramarkNode & {
-      mode?: string;
-      value?: string;
-    };
-    if (
-      child &&
-      typeof child === 'object' &&
-      child.mode === 'opaque' &&
-      typeof child.value === 'string' &&
-      child.value.length > 0
-    ) {
-      try {
-        const sub = await parse(child.value);
-        (child as { children: SupramarkNode[] }).children = sub.children;
-        // 清空 value，避免 renderNode 误判再次解析
-        child.value = undefined;
-      } catch {
-        // 解析失败保留原 children（可能为空），renderNode 走 fallback
-      }
-    }
-    await expandOpaqueContainers(child);
-  }
-}
 
 function getDefinitionTerms(item: SupramarkDefinitionItemNode): SupramarkDefinitionTermNode[] {
   return item.children.filter(

--- a/packages/renderers/web/src/Supramark.tsx
+++ b/packages/renderers/web/src/Supramark.tsx
@@ -101,6 +101,46 @@ type CodeHighlightTask = {
   theme?: string;
 };
 
+/**
+ * 递归遍历 AST，对 `mode: 'opaque'` 且有 `value` 的 container，
+ * 用 parse(value) 解析 value 成 AST 子树，填回 container.children。
+ *
+ * 新 AST v2 的 opaque container children 为空，正文在 value（原始 markdown 字符串）。
+ * Rust parser 不认 feature 插件 JS 侧注册的 registerContainerHook，把所有 :::xxx
+ * 当 opaque 处理。这里在主组件异步上下文里预解析，renderNode 就能同步渲染 children。
+ *
+ * 递归处理已填充的 children（可能嵌套 opaque container）。
+ */
+async function expandOpaqueContainers(node: SupramarkNode): Promise<void> {
+  if (!node || typeof node !== 'object' || !('children' in node)) {
+    return;
+  }
+  const parent = node as { children: SupramarkNode[] };
+  for (let i = 0; i < parent.children.length; i++) {
+    const child = parent.children[i] as SupramarkNode & {
+      mode?: string;
+      value?: string;
+    };
+    if (
+      child &&
+      typeof child === 'object' &&
+      child.mode === 'opaque' &&
+      typeof child.value === 'string' &&
+      child.value.length > 0
+    ) {
+      try {
+        const sub = await parse(child.value);
+        (child as { children: SupramarkNode[] }).children = sub.children;
+        // 清空 value，避免 renderNode 误判再次解析
+        child.value = undefined;
+      } catch {
+        // 解析失败保留原 children（可能为空），renderNode 走 fallback
+      }
+    }
+    await expandOpaqueContainers(child);
+  }
+}
+
 function getDefinitionTerms(item: SupramarkDefinitionItemNode): SupramarkDefinitionTermNode[] {
   return item.children.filter(
     (child): child is SupramarkDefinitionTermNode => child.type === 'definition_term'
@@ -177,6 +217,12 @@ export const Supramark: React.FC<SupramarkWebProps> = ({
         });
 
         const parsed = ast ?? (await parse(markdown, { config }));
+        // Post-process：递归解析 opaque container 的 value。
+        // 新 AST v2 的 opaque container children 为空，正文在 value（原始 markdown）。
+        // Rust parser 不认 feature 插件 JS 侧注册的 registerContainerHook，
+        // 把所有 :::xxx 当 opaque 处理。这里在主组件异步上下文里把 value 解析成
+        // AST 子树填回 children，renderNode 就能正常渲染。
+        await expandOpaqueContainers(parsed);
         const renderTasks = collectRenderTasks(parsed.children, config);
         const highlightTasks = collectCodeHighlightTasks(
           parsed.children,
@@ -814,6 +860,18 @@ function renderNode(
     }
     case 'text':
       return <React.Fragment key={key}>{(node as SupramarkTextNode).value}</React.Fragment>;
+    case 'strong':
+    case 'emphasis':
+    case 'delete':
+    case 'inline_code':
+    case 'math_inline':
+    case 'link':
+    case 'image':
+    case 'break':
+    case 'footnote_reference':
+      // Rust parser 把 list_item.children 等场景的 inline 节点扁平铺开（非 paragraph 包裹），
+      // renderNode 遍历到这些类型时委托给 renderInlineNode，避免走 default 返回 null 吞掉内容。
+      return renderInlineNode(node, key, classNames, rendered, highlighted, config);
     default:
       return null;
   }


### PR DESCRIPTION
Rust parser 把所有 :::xxx 容器解析为 opaque——正文放在 `value` 字段， `children` 为空数组。renderer 原本直接读 `children`，导致容器类节点正文 静默丢失。另外 web 端 list_item 渲染漏处理扁平 inline 节点，导致列表内
加粗/删除线被吞掉。

- 新增 expandOpaqueContainers 后处理（web + rn）：useEffect 里递归遍历 AST，对 opaque container 用 parse(value) 把正文填回 children。
- 修复 admonition 正文不渲染（web + rn）：children 填充后恢复；rn 端 另将 renderInlineNodes 改为 renderNode 处理 block 子节点。
- 修复 admonition 标题被正文挤出（rn) ：改为 column 布局。
- 修复 definition-list 描述不换行溢出（rn）：改为 column 布局，description 缩进。
- 修复 footnote 内容不渲染（rn）：renderInlineNodes 改为 renderNode 处理 block 子节点。web 端原有扁平化逻辑不受影响。
- 修复列表内加粗/删除线等 inline 节点不渲染（web）：list_item.children 被 Rust parser 扁平铺开，renderNode 缺 inline case 走 default 吞掉。 补上 inline case 委托 renderInlineNode。