### PR TITLE
fix(engines/rn): 兼容 graphviz-anywhere-rn 的 CJS 命名导出

### DIFF
--- a/packages/engines/__tests__/graphviz-rn-exports.test.ts
+++ b/packages/engines/__tests__/graphviz-rn-exports.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'bun:test';
+import { resolveGraphvizAnywhereRnExports } from '../src/graphviz';
+
+// `@kookyleo/graphviz-anywhere-rn` ships a CommonJS main carrying both named
+// exports and a default export. Metro's `await import(...)` may or may not
+// hoist the named exports, so the adapter has to tolerate both namespace
+// shapes. These tests pin that resolution down without a real RN runtime.
+
+const renderDot = async (_dot: string, _engine: string, _format: string) => '<svg></svg>';
+const getVersion = async () => '12.2.1';
+
+describe('resolveGraphvizAnywhereRnExports', () => {
+  it('reads named exports hoisted onto the namespace (ESM-style)', () => {
+    const resolved = resolveGraphvizAnywhereRnExports({ renderDot, getVersion });
+    expect(resolved.renderDot).toBe(renderDot);
+    expect(resolved.getVersion).toBe(getVersion);
+  });
+
+  it('reaches through `default` when Metro does not hoist named exports', () => {
+    const resolved = resolveGraphvizAnywhereRnExports({
+      default: { renderDot, getVersion },
+    });
+    expect(resolved.renderDot).toBe(renderDot);
+    expect(resolved.getVersion).toBe(getVersion);
+  });
+
+  it('prefers the named export when both shapes are present', () => {
+    const defaultRenderDot = async () => '<svg data-from="default"></svg>';
+    const resolved = resolveGraphvizAnywhereRnExports({
+      renderDot,
+      default: { renderDot: defaultRenderDot },
+    });
+    expect(resolved.renderDot).toBe(renderDot);
+  });
+
+  it('returns getVersion undefined when neither shape provides it', () => {
+    const resolved = resolveGraphvizAnywhereRnExports({ renderDot });
+    expect(resolved.renderDot).toBe(renderDot);
+    expect(resolved.getVersion).toBeUndefined();
+  });
+
+  it('throws a clear error when renderDot is absent from both shapes', () => {
+    expect(() => resolveGraphvizAnywhereRnExports({ default: { getVersion } })).toThrow(
+      /renderDot/
+    );
+    expect(() => resolveGraphvizAnywhereRnExports({})).toThrow(/renderDot/);
+    expect(() => resolveGraphvizAnywhereRnExports(null)).toThrow(/renderDot/);
+  });
+});

--- a/packages/engines/src/graphviz/index.ts
+++ b/packages/engines/src/graphviz/index.ts
@@ -78,6 +78,56 @@ export async function renderGraphvizSvg(
   return adapter.renderToSvg(code, pickGraphvizDiagramOptions(options));
 }
 
+/** The functions the RN graphviz adapters need from the native package. */
+export interface GraphvizAnywhereRnExports {
+  renderDot: (dot: string, engine: string, format: string) => Promise<string>;
+  getVersion?: () => Promise<string>;
+}
+
+/**
+ * Resolve `renderDot` / `getVersion` from the dynamically-imported
+ * `@kookyleo/graphviz-anywhere-rn` module across CJS/ESM interop shapes.
+ *
+ * The package `main` points at a CommonJS build that exposes both named
+ * exports (`renderDot`, `getVersion`) and a default export bundling the same
+ * functions. Under Metro, `await import(...)` of that build does not always
+ * hoist the named exports — it can hand back `{ default: { renderDot, ... } }`,
+ * leaving `mod.renderDot` undefined. Reaching through `default` lets both the
+ * named-export and default-wrapped shapes resolve.
+ *
+ * These are standalone module functions (they close over the native module,
+ * not `this`), so no binding is needed.
+ */
+export function resolveGraphvizAnywhereRnExports(
+  mod: unknown
+): GraphvizAnywhereRnExports {
+  const ns = mod as
+    | { renderDot?: unknown; getVersion?: unknown; default?: unknown }
+    | null
+    | undefined;
+  const fallback = ns?.default as
+    | { renderDot?: unknown; getVersion?: unknown }
+    | undefined;
+
+  const renderDot = ns?.renderDot ?? fallback?.renderDot;
+  if (typeof renderDot !== 'function') {
+    throw new DiagramRenderError(
+      '@kookyleo/graphviz-anywhere-rn did not export a renderDot function ' +
+        '(checked both named and default exports)',
+      { engine: 'graphviz', code: 'render_error' }
+    );
+  }
+
+  const getVersion = ns?.getVersion ?? fallback?.getVersion;
+  return {
+    renderDot: renderDot as GraphvizAnywhereRnExports['renderDot'],
+    getVersion:
+      typeof getVersion === 'function'
+        ? (getVersion as GraphvizAnywhereRnExports['getVersion'])
+        : undefined,
+  };
+}
+
 function isRecord(value: unknown): value is Record<string, any> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
 }

--- a/packages/engines/src/graphviz/rn-adapter.ts
+++ b/packages/engines/src/graphviz/rn-adapter.ts
@@ -2,22 +2,28 @@ import type {
   GraphvizCapabilities,
   GraphvizRenderAdapter,
 } from '../types.js';
-import { GRAPHVIZ_LAYOUT_ENGINES, pickGraphvizDiagramOptions } from './index.js';
+import {
+  GRAPHVIZ_LAYOUT_ENGINES,
+  pickGraphvizDiagramOptions,
+  resolveGraphvizAnywhereRnExports,
+} from './index.js';
 
 let cached: Promise<GraphvizRenderAdapter> | null = null;
 
 async function loadAdapter(): Promise<GraphvizRenderAdapter> {
-  const module = await import('@kookyleo/graphviz-anywhere-rn');
+  const mod = await import('@kookyleo/graphviz-anywhere-rn');
+  // Tolerate the CJS/ESM interop shapes Metro produces for this package's
+  // CommonJS main; see resolveGraphvizAnywhereRnExports.
+  const { renderDot, getVersion } = resolveGraphvizAnywhereRnExports(mod);
 
   return {
     async renderToSvg(code, rawOptions) {
       const opt = pickGraphvizDiagramOptions(rawOptions);
-      return module.renderDot(code, (opt.layoutEngine ?? 'dot') as any, 'svg');
+      return renderDot(code, (opt.layoutEngine ?? 'dot') as any, 'svg');
     },
     async getCapabilities(): Promise<GraphvizCapabilities> {
       return {
-        graphvizVersion:
-          typeof module.getVersion === 'function' ? await module.getVersion() : undefined,
+        graphvizVersion: getVersion ? await getVersion() : undefined,
         engines: [...GRAPHVIZ_LAYOUT_ENGINES],
         formats: ['svg'],
       };

--- a/packages/engines/src/rn.ts
+++ b/packages/engines/src/rn.ts
@@ -111,17 +111,22 @@ function createReactNativeGraphvizAdapterLoader(): () => Promise<GraphvizRenderA
 }
 
 async function loadReactNativeGraphvizAdapter(): Promise<GraphvizRenderAdapter> {
-  const module = await import('@kookyleo/graphviz-anywhere-rn');
+  const mod = await import('@kookyleo/graphviz-anywhere-rn');
+  // CJS/ESM 互操作：包的 main 指向 lib/commonjs/index.js（CJS），
+  // metro 的 await import() 可能返回 { default: { renderDot, ... } }
+  // 而不提升命名导出。兼容两种形式。
+  const renderDot = (mod.renderDot ?? mod.default?.renderDot).bind(mod.default ?? mod);
+  const getVersion = mod.getVersion ?? mod.default?.getVersion;
 
   return {
     async renderToSvg(code, rawOptions) {
       const graphvizOptions = pickGraphvizDiagramOptions(rawOptions);
-      return module.renderDot(code, (graphvizOptions.layoutEngine ?? 'dot') as any, 'svg');
+      return renderDot(code, (graphvizOptions.layoutEngine ?? 'dot') as any, 'svg');
     },
     async getCapabilities(): Promise<GraphvizCapabilities> {
       return {
         graphvizVersion:
-          typeof module.getVersion === 'function' ? await module.getVersion() : undefined,
+          typeof getVersion === 'function' ? await getVersion() : undefined,
         engines: [...GRAPHVIZ_LAYOUT_ENGINES],
         formats: ['svg'],
       };

--- a/packages/engines/src/rn.ts
+++ b/packages/engines/src/rn.ts
@@ -2,6 +2,7 @@ import { createDiagramEngine } from './engine';
 import {
   GRAPHVIZ_LAYOUT_ENGINES,
   pickGraphvizDiagramOptions,
+  resolveGraphvizAnywhereRnExports,
 } from './graphviz';
 import { loadEchartsSvgRender, loadVegaLiteSvgRender } from './js-chart-loaders';
 import { getNativeEngineAdapter, renderViaNative } from './rn-native-adapter';
@@ -112,11 +113,9 @@ function createReactNativeGraphvizAdapterLoader(): () => Promise<GraphvizRenderA
 
 async function loadReactNativeGraphvizAdapter(): Promise<GraphvizRenderAdapter> {
   const mod = await import('@kookyleo/graphviz-anywhere-rn');
-  // CJS/ESM 互操作：包的 main 指向 lib/commonjs/index.js（CJS），
-  // metro 的 await import() 可能返回 { default: { renderDot, ... } }
-  // 而不提升命名导出。兼容两种形式。
-  const renderDot = (mod.renderDot ?? mod.default?.renderDot).bind(mod.default ?? mod);
-  const getVersion = mod.getVersion ?? mod.default?.getVersion;
+  // Tolerate the CJS/ESM interop shapes Metro produces for this package's
+  // CommonJS main; see resolveGraphvizAnywhereRnExports.
+  const { renderDot, getVersion } = resolveGraphvizAnywhereRnExports(mod);
 
   return {
     async renderToSvg(code, rawOptions) {
@@ -125,8 +124,7 @@ async function loadReactNativeGraphvizAdapter(): Promise<GraphvizRenderAdapter> 
     },
     async getCapabilities(): Promise<GraphvizCapabilities> {
       return {
-        graphvizVersion:
-          typeof getVersion === 'function' ? await getVersion() : undefined,
+        graphvizVersion: getVersion ? await getVersion() : undefined,
         engines: [...GRAPHVIZ_LAYOUT_ENGINES],
         formats: ['svg'],
       };


### PR DESCRIPTION
@kookyleo/graphviz-anywhere-rn 的 main 指向 CJS 构建，Metro 的 await import() 不提升命名导出，返回 { default: { renderDot, ... } }。 原代码 module.renderDot 拿到 undefined，RN 下渲染 dot 图表时抛
TypeError: module.renderDot is not a function。

改为 mod.renderDot ?? mod.default?.renderDot 兼容两种形式，.bind() 保证 this 指向正确。getVersion 同理处理。