### PR TITLE
refactor: replace explicit any; make no-explicit-any an error

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -28,9 +28,9 @@ module.exports = {
   },
   rules: {
     // TypeScript 相关
-    // This repo integrates with many untyped JS ecosystems (markdown-it plugins, renderer bridges).
-    // Keep visibility on `any`, but don't block CI on it.
-    '@typescript-eslint/no-explicit-any': 'warn',
+    // Explicit `any` is forbidden. Use precise types, generics, or `unknown` with a
+    // narrowing guard. Untyped third-party boundaries should be wrapped in minimal interfaces.
+    '@typescript-eslint/no-explicit-any': 'error',
     '@typescript-eslint/explicit-module-boundary-types': 'off',
     '@typescript-eslint/no-unused-vars': [
       'warn',

--- a/crates/graphviz-anywhere/examples/react-native/App.tsx
+++ b/crates/graphviz-anywhere/examples/react-native/App.tsx
@@ -64,9 +64,10 @@ export default function App() {
     try {
       const svg = await renderDot(dotSource, engine, 'svg');
       setSvgOutput(svg);
-    } catch (e: any) {
-      const code = e?.code || GraphvizErrorCode.UNKNOWN;
-      const message = e?.message || 'Unknown rendering error';
+    } catch (e: unknown) {
+      const err = e as { code?: string; message?: string } | null | undefined;
+      const code = err?.code || GraphvizErrorCode.UNKNOWN;
+      const message = err?.message || 'Unknown rendering error';
       setError(`[${code}] ${message}`);
     } finally {
       setLoading(false);

--- a/crates/graphviz-anywhere/packages/web/src/__tests__/index.test.ts
+++ b/crates/graphviz-anywhere/packages/web/src/__tests__/index.test.ts
@@ -4,6 +4,7 @@ import {
   createServerWasmRenderer,
   createWorkerWasmRenderer,
   GraphvizWebError,
+  type GraphvizWorkerRequest,
 } from '../index';
 import { createMockVizWasmModule } from './mocks/viz-wasm';
 
@@ -274,7 +275,7 @@ describe('createWorkerWasmRenderer', () => {
     const mockWorker = {
       addEventListener: vi.fn(),
       removeEventListener: vi.fn(),
-      postMessage: vi.fn((msg: any) => {
+      postMessage: vi.fn((msg: GraphvizWorkerRequest) => {
         // Simulate worker response
         const response = {
           id: msg.id,

--- a/crates/graphviz-anywhere/packages/web/src/__tests__/shared.test.ts
+++ b/crates/graphviz-anywhere/packages/web/src/__tests__/shared.test.ts
@@ -31,7 +31,7 @@ describe('GraphvizWebError', () => {
   it('creates error with cause', () => {
     const cause = new Error('Original error');
     const error = new GraphvizWebError('RENDER_FAILED', 'Wrapped error', { cause });
-    expect((error as any).cause).toBe(cause);
+    expect((error as { cause?: unknown }).cause).toBe(cause);
   });
 
   it('has correct error codes', () => {

--- a/crates/vison/vison-renderers/rn/VisonRNRenderer.tsx
+++ b/crates/vison/vison-renderers/rn/VisonRNRenderer.tsx
@@ -1,24 +1,29 @@
 import React, { useMemo, useState } from 'react';
 import { View, Text, Image, StyleSheet, ActivityIndicator } from 'react-native';
+import type { StyleProp, ViewStyle, TextStyle, ImageStyle } from 'react-native';
 import Markdown from 'react-native-markdown-display';
 import { VisonComponent } from '../shared/types';
+
+// React Native's bundled @types/react differs from the workspace React types
+// (e.g. on bigint in ReactNode); derive the node type from Text's own children.
+type RNNode = React.ComponentProps<typeof Text>['children'];
 
 /**
  * 生产级 React Native 渲染器
  * 增加特性：图片占位符、错误捕获、性能优化 (Memo)
  */
 
-const VisonImage: React.FC<{ props: any; style: any }> = ({ props, style }) => {
+const VisonImage: React.FC<{ props: Record<string, unknown>; style: StyleProp<ViewStyle> }> = ({ props, style }) => {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(false);
 
   return (
-    <View style={[style, { backgroundColor: '#F0F0F0', justifyContent: 'center', alignItems: 'center', overflow: 'hidden' }]}>
+    <View style={[style as StyleProp<ViewStyle>, { backgroundColor: '#F0F0F0', justifyContent: 'center', alignItems: 'center', overflow: 'hidden' }]}>
       {loading && <ActivityIndicator size="small" color="#999" style={{ position: 'absolute' }} />}
       {error && <Text style={{ color: '#FF4D4F', fontSize: 10 }}>Error</Text>}
       <Image
-        source={{ uri: props.src }}
-        style={[style, { position: 'absolute', width: '100%', height: '100%' }]}
+        source={{ uri: props.src as string | undefined }}
+        style={[style as StyleProp<ImageStyle>, { position: 'absolute', width: '100%', height: '100%' }]}
         onLoadEnd={() => setLoading(false)}
         onError={() => {
           setLoading(false);
@@ -33,7 +38,7 @@ export const VisonRNRenderer: React.FC<{ data: VisonComponent }> = React.memo(({
   const { type, props = {}, style = {}, children } = data;
 
   // 使用 useMemo 避免多余重绘
-  const containerStyle = useMemo(() => style, [style]);
+  const containerStyle = useMemo(() => style as StyleProp<ViewStyle & TextStyle>, [style]);
 
   try {
     switch (type) {
@@ -47,7 +52,7 @@ export const VisonRNRenderer: React.FC<{ data: VisonComponent }> = React.memo(({
         );
 
       case 'text':
-        return <Text style={containerStyle}>{props.text}</Text>;
+        return <Text style={containerStyle}>{props.text as RNNode}</Text>;
 
       case 'image':
         return <VisonImage props={props} style={containerStyle} />;
@@ -57,12 +62,12 @@ export const VisonRNRenderer: React.FC<{ data: VisonComponent }> = React.memo(({
           <View style={containerStyle}>
             <Markdown
               style={{
-                body: { color: style.color, fontSize: style.fontSize, lineHeight: style.lineHeight },
+                body: { color: style.color as string | undefined, fontSize: style.fontSize as number | undefined, lineHeight: style.lineHeight as number | undefined },
                 heading1: { marginTop: 0 },
                 paragraph: { marginVertical: 4 }
               }}
             >
-              {props.content}
+              {props.content as string}
             </Markdown>
           </View>
         );
@@ -71,9 +76,9 @@ export const VisonRNRenderer: React.FC<{ data: VisonComponent }> = React.memo(({
         return (
           <View
             style={{
-              height: style.borderWidth || 1,
-              backgroundColor: style.borderColor || '#EEE',
-              marginVertical: style.margin || 8,
+              height: (style.borderWidth as number) || 1,
+              backgroundColor: (style.borderColor as string) || '#EEE',
+              marginVertical: (style.margin as number) || 8,
               width: '100%',
             }}
           />

--- a/crates/vison/vison-renderers/shared/types.ts
+++ b/crates/vison/vison-renderers/shared/types.ts
@@ -3,7 +3,7 @@ export type ComponentType = 'container' | 'text' | 'image' | 'markdown' | 'divid
 export interface VisonComponent {
   version?: string;
   type: ComponentType;
-  props?: Record<string, any>;
-  style?: Record<string, any>;
+  props?: Record<string, unknown>;
+  style?: Record<string, unknown>;
   children?: VisonComponent[];
 }

--- a/crates/vison/vison-renderers/web/VisonWebRenderer.tsx
+++ b/crates/vison/vison-renderers/web/VisonWebRenderer.tsx
@@ -8,7 +8,7 @@ import { VisonComponent } from '../shared/types';
  */
 
 // 图片组件：处理加载中与加载失败状态
-const VisonImage: React.FC<{ props: any; style: any }> = ({ props, style }) => {
+const VisonImage: React.FC<{ props: Record<string, unknown>; style: React.CSSProperties }> = ({ props, style }) => {
   const [status, setStatus] = useState<'loading' | 'error' | 'loaded'>('loading');
 
   const containerStyle: React.CSSProperties = {
@@ -30,7 +30,7 @@ const VisonImage: React.FC<{ props: any; style: any }> = ({ props, style }) => {
         <div style={{ position: 'absolute', color: '#FF4D4F', fontSize: '12px' }}>Image Error</div>
       )}
       <img
-        src={props.src}
+        src={props.src as string | undefined}
         alt=""
         style={{
           width: '100%',
@@ -66,9 +66,9 @@ export const VisonWebRenderer: React.FC<{ data: VisonComponent }> = React.memo((
     // 转换 Vison 样式到 CSS
     Object.entries(style).forEach(([key, value]) => {
       if (typeof value === 'number' && !['opacity', 'fontWeight', 'lineHeight'].includes(key)) {
-        (s as any)[key] = `${value}px`;
+        (s as Record<string, unknown>)[key] = `${value}px`;
       } else {
-        (s as any)[key] = value;
+        (s as Record<string, unknown>)[key] = value;
       }
     });
 
@@ -87,7 +87,7 @@ export const VisonWebRenderer: React.FC<{ data: VisonComponent }> = React.memo((
         );
 
       case 'text':
-        return <span style={baseStyle}>{props.text}</span>;
+        return <span style={baseStyle}>{props.text as React.ReactNode}</span>;
 
       case 'image':
         return <VisonImage props={props} style={baseStyle} />;
@@ -95,7 +95,7 @@ export const VisonWebRenderer: React.FC<{ data: VisonComponent }> = React.memo((
       case 'markdown':
         return (
           <div style={{ ...baseStyle, display: 'block' }} className="vison-markdown">
-            <ReactMarkdown skipHtml={true}>{props.content}</ReactMarkdown>
+            <ReactMarkdown skipHtml={true}>{props.content as string}</ReactMarkdown>
           </div>
         );
 
@@ -103,9 +103,9 @@ export const VisonWebRenderer: React.FC<{ data: VisonComponent }> = React.memo((
         return (
           <div
             style={{
-              height: style.borderWidth || 1,
-              backgroundColor: style.borderColor || '#EEE',
-              margin: `${style.margin || 8}px 0`,
+              height: (style.borderWidth as React.CSSProperties['height']) || 1,
+              backgroundColor: (style.borderColor as string) || '#EEE',
+              margin: `${(style.margin as number) || 8}px 0`,
               width: '100%',
             }}
           />

--- a/packages/core/__tests__/expand-opaque-containers.test.ts
+++ b/packages/core/__tests__/expand-opaque-containers.test.ts
@@ -1,19 +1,31 @@
 import { parse, expandOpaqueContainers } from '../src/plugin';
-import type { SupramarkNode, SupramarkRootNode } from '../src/ast';
+import type {
+  SupramarkNode,
+  SupramarkRootNode,
+  SupramarkParentNode,
+  SupramarkContainerNode,
+} from '../src/ast';
 
-function findContainers(node: SupramarkNode, out: any[] = []): any[] {
-  const n = node as any;
+// Test-local view of a node that may carry children, used to walk an arbitrary tree.
+type NodeWithChildren = SupramarkNode & { children?: SupramarkNode[] };
+
+function findContainers(
+  node: SupramarkNode,
+  out: SupramarkContainerNode[] = []
+): SupramarkContainerNode[] {
+  const n = node as NodeWithChildren;
   if (n && typeof n === 'object') {
-    if (n.type === 'container') out.push(n);
+    if (n.type === 'container') out.push(n as SupramarkContainerNode);
     for (const child of n.children ?? []) findContainers(child, out);
   }
   return out;
 }
 
-function hasNodeOfType(node: any, type: string): boolean {
+function hasNodeOfType(node: SupramarkNode, type: string): boolean {
   if (!node || typeof node !== 'object') return false;
   if (node.type === type) return true;
-  return (node.children ?? []).some((c: any) => hasNodeOfType(c, type));
+  const children = (node as NodeWithChildren).children ?? [];
+  return children.some((c: SupramarkNode) => hasNodeOfType(c, type));
 }
 
 describe('expandOpaqueContainers', () => {
@@ -50,7 +62,7 @@ describe('expandOpaqueContainers', () => {
   });
 
   describe('discriminator and idempotency (unit)', () => {
-    function makeRoot(children: any[]): SupramarkRootNode {
+    function makeRoot(children: SupramarkNode[]): SupramarkRootNode {
       return { type: 'root', children } as unknown as SupramarkRootNode;
     }
 
@@ -59,7 +71,7 @@ describe('expandOpaqueContainers', () => {
         { type: 'container', name: 'note', mode: 'opaque', value: '# Heading', children: [] },
       ]);
       await expandOpaqueContainers(root);
-      const note: any = root.children[0];
+      const note = root.children[0] as SupramarkContainerNode;
 
       expect(note.value).toBeUndefined();
       expect(hasNodeOfType(note, 'heading')).toBe(true);
@@ -77,7 +89,7 @@ describe('expandOpaqueContainers', () => {
         },
       ]);
       await expandOpaqueContainers(root);
-      const html: any = root.children[0];
+      const html = root.children[0] as SupramarkContainerNode;
 
       // data-bearing container is left byte-for-byte intact.
       expect(html.value).toBe('<b>raw</b>');
@@ -96,7 +108,7 @@ describe('expandOpaqueContainers', () => {
         },
       ]);
       await expandOpaqueContainers(root);
-      const note: any = (root.children[0] as any).children[0];
+      const note = (root.children[0] as SupramarkParentNode).children[0] as SupramarkContainerNode;
 
       expect(note.value).toBeUndefined();
       expect(hasNodeOfType(note, 'strong')).toBe(true);

--- a/packages/core/__tests__/feature-config.test.ts
+++ b/packages/core/__tests__/feature-config.test.ts
@@ -18,6 +18,7 @@ import {
   type SupramarkNode,
   type SupramarkFeature,
 } from '../src/feature';
+import type { SupramarkDiagramNode } from '../src/ast';
 
 function createTestFeature(id: string, type: string): SupramarkFeature<SupramarkNode> {
   return {
@@ -263,7 +264,7 @@ describe('Feature 配置系统', () => {
           ast: {
             type: 'diagram',
             selector: (node: SupramarkNode) =>
-              node.type === 'diagram' && (node as any).engine === 'mermaid',
+              node.type === 'diagram' && (node as SupramarkDiagramNode).engine === 'mermaid',
           },
         },
       });
@@ -274,7 +275,7 @@ describe('Feature 配置系统', () => {
           ast: {
             type: 'diagram',
             selector: (node: SupramarkNode) =>
-              node.type === 'diagram' && (node as any).engine === 'vega-lite',
+              node.type === 'diagram' && (node as SupramarkDiagramNode).engine === 'vega-lite',
           },
         },
       });

--- a/packages/core/__tests__/parser.test.ts
+++ b/packages/core/__tests__/parser.test.ts
@@ -1,5 +1,15 @@
 import { parse } from '../src/plugin';
-import type { SupramarkRootNode } from '../src/ast';
+import type {
+  SupramarkRootNode,
+  SupramarkNode,
+  SupramarkTextNode,
+  SupramarkParentNode,
+  SupramarkHeadingNode,
+  SupramarkCodeNode,
+  SupramarkListNode,
+  SupramarkListItemNode,
+  SupramarkDiagramNode,
+} from '../src/ast';
 
 describe('parse', () => {
   describe('AST v2 合同', () => {
@@ -17,8 +27,8 @@ describe('parse', () => {
 
     it('应该省略普通列表项的 v2 可选字段', async () => {
       const ast = await parse('- plain item');
-      const list = ast.children[0] as any;
-      const item = list.children[0] as any;
+      const list = ast.children[0] as SupramarkListNode;
+      const item = list.children[0] as SupramarkListItemNode;
 
       expect(list.type).toBe('list');
       expect(Object.prototype.hasOwnProperty.call(list, 'start')).toBe(false);
@@ -27,17 +37,17 @@ describe('parse', () => {
 
     it('应该输出 definition list v2 children 结构', async () => {
       const ast = await parse('Term\n:   Definition');
-      const list = ast.children[0] as any;
-      const item = list.children[0] as any;
+      const list = ast.children[0] as SupramarkParentNode;
+      const item = list.children[0] as SupramarkParentNode;
 
       expect(list.type).toBe('definition_list');
       expect(item.type).toBe('definition_item');
       expect(Object.prototype.hasOwnProperty.call(item, 'term')).toBe(false);
       expect(Object.prototype.hasOwnProperty.call(item, 'descriptions')).toBe(false);
       expect(item.children[0].type).toBe('definition_term');
-      expect(item.children[0].children[0].value).toBe('Term');
+      expect(((item.children[0] as SupramarkParentNode).children[0] as SupramarkTextNode).value).toBe('Term');
       expect(item.children[1].type).toBe('definition_description');
-      expect(item.children[1].children[0].type).toBe('paragraph');
+      expect((item.children[1] as SupramarkParentNode).children[0].type).toBe('paragraph');
     });
   });
 
@@ -57,9 +67,9 @@ describe('parse', () => {
 
       expect(ast.children).toHaveLength(2);
       expect(ast.children[0].type).toBe('heading');
-      expect((ast.children[0] as any).depth).toBe(1);
+      expect((ast.children[0] as SupramarkHeadingNode).depth).toBe(1);
       expect(ast.children[1].type).toBe('heading');
-      expect((ast.children[1] as any).depth).toBe(2);
+      expect((ast.children[1] as SupramarkHeadingNode).depth).toBe(2);
     });
 
     it('应该解析列表', async () => {
@@ -68,7 +78,7 @@ describe('parse', () => {
 
       expect(ast.children).toHaveLength(1);
       expect(ast.children[0].type).toBe('list');
-      expect((ast.children[0] as any).children).toHaveLength(3);
+      expect((ast.children[0] as SupramarkListNode).children).toHaveLength(3);
     });
 
     it('应该解析代码块', async () => {
@@ -77,7 +87,7 @@ describe('parse', () => {
 
       expect(ast.children).toHaveLength(1);
       expect(ast.children[0].type).toBe('code');
-      expect((ast.children[0] as any).lang).toBe('javascript');
+      expect((ast.children[0] as SupramarkCodeNode).lang).toBe('javascript');
     });
   });
 
@@ -86,32 +96,32 @@ describe('parse', () => {
       const markdown = 'This is **bold** text.';
       const ast = await parse(markdown);
 
-      const paragraph = ast.children[0] as any;
-      expect(paragraph.children.some((node: any) => node.type === 'strong')).toBe(true);
+      const paragraph = ast.children[0] as SupramarkParentNode;
+      expect(paragraph.children.some((node: SupramarkNode) => node.type === 'strong')).toBe(true);
     });
 
     it('应该解析斜体文本', async () => {
       const markdown = 'This is *italic* text.';
       const ast = await parse(markdown);
 
-      const paragraph = ast.children[0] as any;
-      expect(paragraph.children.some((node: any) => node.type === 'emphasis')).toBe(true);
+      const paragraph = ast.children[0] as SupramarkParentNode;
+      expect(paragraph.children.some((node: SupramarkNode) => node.type === 'emphasis')).toBe(true);
     });
 
     it('应该解析链接', async () => {
       const markdown = '[Link](https://example.com)';
       const ast = await parse(markdown);
 
-      const paragraph = ast.children[0] as any;
-      expect(paragraph.children.some((node: any) => node.type === 'link')).toBe(true);
+      const paragraph = ast.children[0] as SupramarkParentNode;
+      expect(paragraph.children.some((node: SupramarkNode) => node.type === 'link')).toBe(true);
     });
 
     it('应该解析行内代码', async () => {
       const markdown = 'This is `code` inline.';
       const ast = await parse(markdown);
 
-      const paragraph = ast.children[0] as any;
-      expect(paragraph.children.some((node: any) => node.type === 'inline_code')).toBe(true);
+      const paragraph = ast.children[0] as SupramarkParentNode;
+      expect(paragraph.children.some((node: SupramarkNode) => node.type === 'inline_code')).toBe(true);
     });
   });
 
@@ -120,18 +130,18 @@ describe('parse', () => {
       const markdown = 'This is ~~deleted~~ text.';
       const ast = await parse(markdown);
 
-      const paragraph = ast.children[0] as any;
-      expect(paragraph.children.some((node: any) => node.type === 'delete')).toBe(true);
+      const paragraph = ast.children[0] as SupramarkParentNode;
+      expect(paragraph.children.some((node: SupramarkNode) => node.type === 'delete')).toBe(true);
     });
 
     it('应该解析任务列表', async () => {
       const markdown = '- [x] Task 1\n- [ ] Task 2';
       const ast = await parse(markdown);
 
-      const list = ast.children[0] as any;
+      const list = ast.children[0] as SupramarkListNode;
       expect(list.type).toBe('list');
-      expect(list.children[0].checked).toBe(true);
-      expect(list.children[1].checked).toBe(false);
+      expect((list.children[0] as SupramarkListItemNode).checked).toBe(true);
+      expect((list.children[1] as SupramarkListItemNode).checked).toBe(false);
     });
 
     it('应该解析表格', async () => {
@@ -150,7 +160,7 @@ describe('parse', () => {
 
       expect(ast.children).toHaveLength(1);
       expect(ast.children[0].type).toBe('diagram');
-      expect((ast.children[0] as any).engine).toBe('mermaid');
+      expect((ast.children[0] as SupramarkDiagramNode).engine).toBe('mermaid');
     });
 
     it('应该解析 plantuml 代码块为 diagram 节点', async () => {
@@ -159,7 +169,7 @@ describe('parse', () => {
 
       expect(ast.children).toHaveLength(1);
       expect(ast.children[0].type).toBe('diagram');
-      expect((ast.children[0] as any).engine).toBe('plantuml');
+      expect((ast.children[0] as SupramarkDiagramNode).engine).toBe('plantuml');
     });
   });
 
@@ -168,15 +178,15 @@ describe('parse', () => {
       const markdown = 'Inline math: $E = mc^2$';
       const ast = await parse(markdown);
 
-      const paragraph = ast.children[0] as any;
-      expect(paragraph.children.some((node: any) => node.type === 'math_inline')).toBe(true);
+      const paragraph = ast.children[0] as SupramarkParentNode;
+      expect(paragraph.children.some((node: SupramarkNode) => node.type === 'math_inline')).toBe(true);
     });
 
     it('应该解析块级公式', async () => {
       const markdown = '$$\n\\int_0^1 x^2 dx\n$$';
       const ast = await parse(markdown);
 
-      expect(ast.children.some((node: any) => node.type === 'math_block')).toBe(true);
+      expect(ast.children.some((node: SupramarkNode) => node.type === 'math_block')).toBe(true);
     });
   });
 

--- a/packages/core/__tests__/validateFeature.test.ts
+++ b/packages/core/__tests__/validateFeature.test.ts
@@ -8,7 +8,7 @@ import type { SupramarkNode } from '../src/ast';
 describe('validateFeature', () => {
   describe('基本验证', () => {
     it('应该通过完整的 Feature 定义', () => {
-      const feature: any = {
+      const feature = {
         metadata: {
           id: '@supramark/feature-test',
           name: 'Test Feature',
@@ -38,13 +38,13 @@ describe('validateFeature', () => {
         },
       };
 
-      const result = validateFeature(feature);
+      const result = validateFeature(feature as unknown as Parameters<typeof validateFeature>[0]);
       expect(result.valid).toBe(true);
       expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0);
     });
 
     it('应该检测到缺少 id', () => {
-      const feature: any = {
+      const feature = {
         metadata: {
           name: 'Test Feature',
           version: '1.0.0',
@@ -56,13 +56,13 @@ describe('validateFeature', () => {
         },
       };
 
-      const result = validateFeature(feature);
+      const result = validateFeature(feature as unknown as Parameters<typeof validateFeature>[0]);
       expect(result.valid).toBe(false);
       expect(result.errors.some(e => e.code === 'metadata-id-required')).toBe(true);
     });
 
     it('应该检测到 id 格式错误', () => {
-      const feature: any = {
+      const feature = {
         metadata: {
           id: 'invalid-id',
           name: 'Test Feature',
@@ -75,13 +75,13 @@ describe('validateFeature', () => {
         },
       };
 
-      const result = validateFeature(feature);
+      const result = validateFeature(feature as unknown as Parameters<typeof validateFeature>[0]);
       expect(result.valid).toBe(false);
       expect(result.errors.some(e => e.code === 'metadata-id-format')).toBe(true);
     });
 
     it('应该检测到版本号格式错误', () => {
-      const feature: any = {
+      const feature = {
         metadata: {
           id: '@supramark/feature-test',
           name: 'Test Feature',
@@ -94,13 +94,13 @@ describe('validateFeature', () => {
         },
       };
 
-      const result = validateFeature(feature);
+      const result = validateFeature(feature as unknown as Parameters<typeof validateFeature>[0]);
       expect(result.valid).toBe(false);
       expect(result.errors.some(e => e.code === 'metadata-version-semver')).toBe(true);
     });
 
     it('应该检测到缺少 AST type', () => {
-      const feature: any = {
+      const feature = {
         metadata: {
           id: '@supramark/feature-test',
           name: 'Test Feature',
@@ -111,7 +111,7 @@ describe('validateFeature', () => {
         },
       };
 
-      const result = validateFeature(feature);
+      const result = validateFeature(feature as unknown as Parameters<typeof validateFeature>[0]);
       expect(result.valid).toBe(false);
       expect(result.errors.some(e => e.code === 'ast-type-required')).toBe(true);
     });
@@ -119,7 +119,7 @@ describe('validateFeature', () => {
 
   describe('警告检查', () => {
     it('应该警告缺少 description', () => {
-      const feature: any = {
+      const feature = {
         metadata: {
           id: '@supramark/feature-test',
           name: 'Test Feature',
@@ -132,7 +132,7 @@ describe('validateFeature', () => {
         },
       };
 
-      const result = validateFeature(feature);
+      const result = validateFeature(feature as unknown as Parameters<typeof validateFeature>[0]);
       expect(result.errors.some(e => e.code === 'metadata-description-required')).toBe(true);
       expect(result.errors.find(e => e.code === 'metadata-description-required')?.severity).toBe(
         'warning'
@@ -140,7 +140,7 @@ describe('validateFeature', () => {
     });
 
     it('应该警告 required 只包含 type', () => {
-      const feature: any = {
+      const feature = {
         metadata: {
           id: '@supramark/feature-test',
           name: 'Test Feature',
@@ -159,12 +159,12 @@ describe('validateFeature', () => {
         },
       };
 
-      const result = validateFeature(feature);
+      const result = validateFeature(feature as unknown as Parameters<typeof validateFeature>[0]);
       expect(result.errors.some(e => e.code === 'ast-interface-required-nonempty')).toBe(true);
     });
 
     it('应该警告 fields 缺少定义', () => {
-      const feature: any = {
+      const feature = {
         metadata: {
           id: '@supramark/feature-test',
           name: 'Test Feature',
@@ -184,14 +184,14 @@ describe('validateFeature', () => {
         },
       };
 
-      const result = validateFeature(feature);
+      const result = validateFeature(feature as unknown as Parameters<typeof validateFeature>[0]);
       expect(result.errors.some(e => e.code === 'ast-interface-fields-defined')).toBe(true);
     });
   });
 
   describe('建议检查', () => {
     it('应该建议添加 tags', () => {
-      const feature: any = {
+      const feature = {
         metadata: {
           id: '@supramark/feature-test',
           name: 'Test Feature',
@@ -204,13 +204,13 @@ describe('validateFeature', () => {
         },
       };
 
-      const result = validateFeature(feature);
+      const result = validateFeature(feature as unknown as Parameters<typeof validateFeature>[0]);
       expect(result.errors.some(e => e.code === 'metadata-tags-nonempty')).toBe(true);
       expect(result.errors.find(e => e.code === 'metadata-tags-nonempty')?.severity).toBe('info');
     });
 
     it('应该建议提供 examples', () => {
-      const feature: any = {
+      const feature = {
         metadata: {
           id: '@supramark/feature-test',
           name: 'Test Feature',
@@ -223,7 +223,7 @@ describe('validateFeature', () => {
         },
       };
 
-      const result = validateFeature(feature);
+      const result = validateFeature(feature as unknown as Parameters<typeof validateFeature>[0]);
       expect(result.errors.some(e => e.code === 'ast-examples-provided')).toBe(true);
       expect(result.errors.find(e => e.code === 'ast-examples-provided')?.severity).toBe('info');
     });
@@ -231,7 +231,7 @@ describe('validateFeature', () => {
 
   describe('严格模式', () => {
     it('严格模式下警告应该导致验证失败', () => {
-      const feature: any = {
+      const feature = {
         metadata: {
           id: '@supramark/feature-test',
           name: 'Test Feature',
@@ -245,12 +245,12 @@ describe('validateFeature', () => {
         },
       };
 
-      const result = validateFeature(feature, { strict: true });
+      const result = validateFeature(feature as unknown as Parameters<typeof validateFeature>[0], { strict: true });
       expect(result.valid).toBe(false);
     });
 
     it('严格模式下建议不应该导致验证失败', () => {
-      const feature: any = {
+      const feature = {
         metadata: {
           id: '@supramark/feature-test',
           name: 'Test Feature',
@@ -267,14 +267,14 @@ describe('validateFeature', () => {
         },
       };
 
-      const result = validateFeature(feature, { strict: true });
+      const result = validateFeature(feature as unknown as Parameters<typeof validateFeature>[0], { strict: true });
       expect(result.valid).toBe(true);
     });
   });
 
   describe('生产模式', () => {
     it('生产模式下应该要求 interface', () => {
-      const feature: any = {
+      const feature = {
         metadata: {
           id: '@supramark/feature-test',
           name: 'Test Feature',
@@ -288,13 +288,13 @@ describe('validateFeature', () => {
         },
       };
 
-      const result = validateFeature(feature, { production: true });
+      const result = validateFeature(feature as unknown as Parameters<typeof validateFeature>[0], { production: true });
       expect(result.valid).toBe(false);
       expect(result.errors.some(e => e.code === 'ast-interface-required-production')).toBe(true);
     });
 
     it('生产模式下应该要求至少一个渲染器', () => {
-      const feature: any = {
+      const feature = {
         metadata: {
           id: '@supramark/feature-test',
           name: 'Test Feature',
@@ -314,13 +314,13 @@ describe('validateFeature', () => {
         renderers: {},
       };
 
-      const result = validateFeature(feature, { production: true });
+      const result = validateFeature(feature as unknown as Parameters<typeof validateFeature>[0], { production: true });
       expect(result.valid).toBe(false);
       expect(result.errors.some(e => e.code === 'renderers-required-production')).toBe(true);
     });
 
     it('生产模式下应该建议提供测试', () => {
-      const feature: any = {
+      const feature = {
         metadata: {
           id: '@supramark/feature-test',
           name: 'Test Feature',
@@ -339,7 +339,7 @@ describe('validateFeature', () => {
         },
       };
 
-      const result = validateFeature(feature, { production: true });
+      const result = validateFeature(feature as unknown as Parameters<typeof validateFeature>[0], { production: true });
       expect(result.errors.some(e => e.code === 'testing-recommended-production')).toBe(true);
     });
   });

--- a/packages/core/src/container-extension.ts
+++ b/packages/core/src/container-extension.ts
@@ -35,7 +35,7 @@ export function parseContainerParams(raw: string | undefined | null): ContainerP
     }
 
     if (ch === '"' || ch === "'") {
-      quote = ch as any;
+      quote = ch as '"' | "'";
       continue;
     }
 

--- a/packages/core/src/container-feature.ts
+++ b/packages/core/src/container-feature.ts
@@ -12,7 +12,8 @@
  * @packageDocumentation
  */
 
-import type { ExampleDefinition } from './feature.js';
+import type { ExampleDefinition, SupramarkConfig } from './feature.js';
+import type { SupramarkContainerNode, SupramarkNode } from './ast.js';
 
 // ============================================================================
 // ContainerFeature 接口
@@ -140,15 +141,15 @@ export interface ContainerFeature {
  */
 export interface ContainerWebRenderArgs {
   /** AST 节点 */
-  node: any;
+  node: SupramarkContainerNode;
   /** React key */
   key: number;
   /** CSS 类名映射 */
   classNames: Record<string, string>;
   /** Supramark 配置 */
-  config?: any;
+  config?: SupramarkConfig;
   /** 渲染子节点的函数 */
-  renderChildren: (children: any[]) => any;
+  renderChildren: (children: SupramarkNode[]) => unknown;
 }
 
 /**
@@ -156,22 +157,22 @@ export interface ContainerWebRenderArgs {
  *
  * 每个 runtime.web.tsx 的渲染函数必须符合此签名。
  */
-export type ContainerWebRenderer = (args: ContainerWebRenderArgs) => any;
+export type ContainerWebRenderer = (args: ContainerWebRenderArgs) => unknown;
 
 /**
  * Container RN 渲染函数的参数
  */
 export interface ContainerRNRenderArgs {
   /** AST 节点 */
-  node: any;
+  node: SupramarkContainerNode;
   /** React key */
   key: number;
   /** RN 样式映射 */
-  styles: Record<string, any>;
+  styles: Record<string, unknown>;
   /** Supramark 配置 */
-  config?: any;
+  config?: SupramarkConfig;
   /** 渲染子节点的函数 */
-  renderChildren: (children: any[]) => any;
+  renderChildren: (children: SupramarkNode[]) => unknown;
 }
 
 /**
@@ -179,7 +180,7 @@ export interface ContainerRNRenderArgs {
  *
  * 每个 runtime.rn.tsx 的渲染函数必须符合此签名。
  */
-export type ContainerRNRenderer = (args: ContainerRNRenderArgs) => any;
+export type ContainerRNRenderer = (args: ContainerRNRenderArgs) => unknown;
 
 // ============================================================================
 // Examples 接口（重导出）

--- a/packages/core/src/feature.ts
+++ b/packages/core/src/feature.ts
@@ -718,7 +718,7 @@ export interface RenderContext<TPlatform> {
  * Core 包保持框架无关性，不直接依赖 React 类型。
  * 上层应用会将此类型实例化为 React.ReactNode。
  */
-export type RenderOutput<TPlatform> = TPlatform extends 'cli' ? string : any;
+export type RenderOutput<TPlatform> = TPlatform extends 'cli' ? string : unknown;
 
 /**
  * React Native 样式类型（简化）
@@ -1193,7 +1193,7 @@ export class FeatureRegistry {
   // 注册表内部使用 any，避免对节点类型做过度约束。
   // 这样既可以注册针对特定节点子集的 Feature（如 SupramarkDiagramNode），
   // 也不会影响外部通过 SupramarkNode 做统一查询。
-  private static features = new Map<string, SupramarkFeature<any>>();
+  private static features = new Map<string, SupramarkFeature<SupramarkNode>>();
 
   /**
    * 注册一个 Feature
@@ -1201,14 +1201,17 @@ export class FeatureRegistry {
    * @param feature - Feature 定义
    * @throws 如果 Feature ID 已存在
    */
-  static register(feature: SupramarkFeature<any>): void {
+  static register<TNode extends SupramarkNode>(feature: SupramarkFeature<TNode>): void {
     const id = feature.metadata.id;
 
     if (this.features.has(id)) {
       throw new Error(`Feature "${id}" is already registered`);
     }
 
-    this.features.set(id, feature);
+    // A feature is registered for a specific node subtype (e.g. SupramarkDiagramNode),
+    // but the registry stores them under the common SupramarkNode contract. The widening
+    // is sound because the registry never calls node-specific functions with a wider node.
+    this.features.set(id, feature as unknown as SupramarkFeature<SupramarkNode>);
   }
 
   /**
@@ -1217,7 +1220,7 @@ export class FeatureRegistry {
    * @param id - Feature ID
    * @returns Feature 定义，如果不存在则返回 undefined
    */
-  static get(id: string): SupramarkFeature<any> | undefined {
+  static get(id: string): SupramarkFeature<SupramarkNode> | undefined {
     return this.features.get(id);
   }
 
@@ -1226,7 +1229,7 @@ export class FeatureRegistry {
    *
    * @returns Feature 列表
    */
-  static list(): Array<SupramarkFeature<any>> {
+  static list(): Array<SupramarkFeature<SupramarkNode>> {
     return Array.from(this.features.values());
   }
 
@@ -1248,7 +1251,7 @@ export class FeatureRegistry {
    * @param node - AST 节点
    * @returns 匹配的 Feature 列表
    */
-  static findByNode(node: SupramarkNode): Array<SupramarkFeature<any>> {
+  static findByNode(node: SupramarkNode): Array<SupramarkFeature<SupramarkNode>> {
     return this.list().filter(feature => {
       const ast = feature.syntax.ast;
 

--- a/packages/core/src/presets.ts
+++ b/packages/core/src/presets.ts
@@ -1,4 +1,5 @@
 import type { SupramarkFeature } from './feature.js';
+import type { SupramarkNode } from './ast.js';
 
 /**
  * 预设配置类型
@@ -6,7 +7,7 @@ import type { SupramarkFeature } from './feature.js';
 export interface SupramarkPreset {
   name: string;
   description: string;
-  features: SupramarkFeature<any>[];
+  features: SupramarkFeature<SupramarkNode>[];
 }
 
 /**
@@ -15,7 +16,7 @@ export interface SupramarkPreset {
 export function createPreset(
   name: string,
   description: string,
-  features: SupramarkFeature<any>[]
+  features: SupramarkFeature<SupramarkNode>[]
 ): SupramarkPreset {
   return { name, description, features };
 }

--- a/packages/engines/src/graphviz/index.ts
+++ b/packages/engines/src/graphviz/index.ts
@@ -55,13 +55,13 @@ export function pickGraphvizDiagramOptions(
     picked.reduce = options.reduce;
   }
   if (isRecord(options?.graphAttributes)) {
-    picked.graphAttributes = options.graphAttributes;
+    picked.graphAttributes = options.graphAttributes as GraphvizDiagramOptions['graphAttributes'];
   }
   if (isRecord(options?.nodeAttributes)) {
-    picked.nodeAttributes = options.nodeAttributes;
+    picked.nodeAttributes = options.nodeAttributes as GraphvizDiagramOptions['nodeAttributes'];
   }
   if (isRecord(options?.edgeAttributes)) {
-    picked.edgeAttributes = options.edgeAttributes;
+    picked.edgeAttributes = options.edgeAttributes as GraphvizDiagramOptions['edgeAttributes'];
   }
   if (Array.isArray(options?.images)) {
     picked.images = options.images.filter(isGraphvizImageSize);
@@ -128,7 +128,7 @@ export function resolveGraphvizAnywhereRnExports(
   };
 }
 
-function isRecord(value: unknown): value is Record<string, any> {
+function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 

--- a/packages/engines/src/graphviz/rn-adapter.ts
+++ b/packages/engines/src/graphviz/rn-adapter.ts
@@ -19,7 +19,7 @@ async function loadAdapter(): Promise<GraphvizRenderAdapter> {
   return {
     async renderToSvg(code, rawOptions) {
       const opt = pickGraphvizDiagramOptions(rawOptions);
-      return renderDot(code, (opt.layoutEngine ?? 'dot') as any, 'svg');
+      return renderDot(code, opt.layoutEngine ?? 'dot', 'svg');
     },
     async getCapabilities(): Promise<GraphvizCapabilities> {
       return {

--- a/packages/engines/src/host-bridge.ts
+++ b/packages/engines/src/host-bridge.ts
@@ -61,8 +61,9 @@ function fallbackBox(text: string, size: number): MeasureResult {
 export function installHostMetricsBridge(): void {
   if (installed) return;
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const g = globalThis as any;
+  const g = globalThis as unknown as {
+    supramark?: { measureText?: MeasureFn } & Record<string, unknown>;
+  };
   const existing = g.supramark;
   if (existing && typeof existing.measureText === 'function') {
     installed = true;

--- a/packages/engines/src/mathjax/index.ts
+++ b/packages/engines/src/mathjax/index.ts
@@ -37,10 +37,12 @@ async function ensureRenderer(): Promise<MathJaxRenderer> {
 }
 
 function extractSvg(adaptor: MathJaxRenderer['adaptor'], node: unknown): string {
-  const asAny = node as any;
-  const svgNode = asAny && typeof adaptor.firstChild === 'function' ? adaptor.firstChild(asAny) : null;
+  type AdaptorNode = Parameters<MathJaxRenderer['adaptor']['outerHTML']>[0];
+  const adaptorNode = node as AdaptorNode;
+  const svgNode =
+    adaptorNode && typeof adaptor.firstChild === 'function' ? adaptor.firstChild(adaptorNode) : null;
 
-  const target = svgNode ?? asAny;
+  const target = (svgNode ?? adaptorNode) as AdaptorNode;
   const svg = adaptor.outerHTML(target);
   if (!svg || !svg.includes('<svg')) {
     throw new Error('MathJax did not produce SVG output');

--- a/packages/engines/src/mermaid/index.ts
+++ b/packages/engines/src/mermaid/index.ts
@@ -302,8 +302,12 @@ async function ensureLoaded(): Promise<
   // as a side effect of the ESM import (`import * as wasm from "./*.wasm"`).
   // Some wasm-bindgen builds still ship a default `init()` — probe
   // defensively so a re-init does not throw.
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const mod: any = await import('@actrium/mermaid-little-web' as string);
+  const mod = (await import('@actrium/mermaid-little-web' as string)) as {
+    default?: unknown;
+    init?: unknown;
+    convert?: unknown;
+    render?: unknown;
+  };
 
   const init =
     (typeof mod.default === 'function' && mod.default) ||

--- a/packages/engines/src/optional-deps.d.ts
+++ b/packages/engines/src/optional-deps.d.ts
@@ -14,8 +14,14 @@ declare module '@actrium/mermaid-little-web' {
 }
 
 declare module 'mathjax-full/js/mathjax.js' {
+  /** Opaque DOM-like node handle produced and consumed by the lite adaptor. */
+  type MathJaxNode = unknown;
+  /** Minimal shape of the document returned by `mathjax.document`. */
+  interface MathJaxDocument {
+    convert(input: string, options?: Record<string, unknown>): MathJaxNode;
+  }
   export const mathjax: {
-    document(input?: string, options?: Record<string, unknown>): any;
+    document(input?: string, options?: Record<string, unknown>): MathJaxDocument;
   };
 }
 
@@ -32,11 +38,19 @@ declare module 'mathjax-full/js/output/svg.js' {
 }
 
 declare module 'mathjax-full/js/adaptors/liteAdaptor.js' {
-  export function liteAdaptor(): any;
+  /** Opaque DOM-like node handle used by the lite adaptor. */
+  type LiteAdaptorNode = unknown;
+  /** Minimal shape of the lite adaptor used by the math engine. */
+  export interface LiteAdaptor {
+    firstChild(node: LiteAdaptorNode): LiteAdaptorNode;
+    outerHTML(node: LiteAdaptorNode): string;
+  }
+  export function liteAdaptor(): LiteAdaptor;
 }
 
 declare module 'mathjax-full/js/handlers/html.js' {
-  export function RegisterHTMLHandler(adaptor: any): void;
+  import type { LiteAdaptor } from 'mathjax-full/js/adaptors/liteAdaptor.js';
+  export function RegisterHTMLHandler(adaptor: LiteAdaptor): void;
 }
 
 declare module 'mathjax-full/js/input/tex/AllPackages.js' {

--- a/packages/engines/src/rn.ts
+++ b/packages/engines/src/rn.ts
@@ -120,7 +120,7 @@ async function loadReactNativeGraphvizAdapter(): Promise<GraphvizRenderAdapter> 
   return {
     async renderToSvg(code, rawOptions) {
       const graphvizOptions = pickGraphvizDiagramOptions(rawOptions);
-      return renderDot(code, (graphvizOptions.layoutEngine ?? 'dot') as any, 'svg');
+      return renderDot(code, graphvizOptions.layoutEngine ?? 'dot', 'svg');
     },
     async getCapabilities(): Promise<GraphvizCapabilities> {
       return {

--- a/packages/engines/src/web.ts
+++ b/packages/engines/src/web.ts
@@ -9,6 +9,18 @@ import type {
   GraphvizRenderAdapter,
 } from './types';
 
+/**
+ * Minimal shape of a wasm-bindgen ESM module probed defensively for an
+ * init entry and a sync convert/render entry.
+ */
+interface WasmRenderModule {
+  default?: unknown;
+  init?: unknown;
+  convert?: unknown;
+  render?: unknown;
+  renderSvg?: unknown;
+}
+
 export interface WebGraphvizAdapterOptions {
   adapter?: GraphvizRenderAdapter;
   loadAdapter?: () => Promise<GraphvizRenderAdapter>;
@@ -64,7 +76,6 @@ export function createWebDiagramEngine(
  * wrapper backed by `@actrium/graphviz-anywhere-web` (pre-loaded) so the
  * wasm call site can invoke it without returning to the JS event loop.
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 async function loadWebPlantumlRender(): Promise<DiagramRenderFn> {
   // Install the host text-metrics bridge before loading the wasm so the
   // wasm's metrics-host-callback impl can resolve `supramark.measureText`
@@ -77,12 +88,12 @@ async function loadWebPlantumlRender(): Promise<DiagramRenderFn> {
   const ensureGraphvizBridge = async () => {
     if (!graphvizBridgePromise) {
       graphvizBridgePromise = (async () => {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const { Graphviz } = await import('@actrium/graphviz-anywhere-web' as string);
         const graphviz = await Graphviz.load();
 
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const g = globalThis as any;
+        const g = globalThis as unknown as {
+          __graphviz_anywhere_render?: (dot: string, engine?: string, format?: string) => string;
+        };
         if (typeof g.__graphviz_anywhere_render !== 'function') {
           g.__graphviz_anywhere_render = (
             dot: string,
@@ -104,8 +115,9 @@ async function loadWebPlantumlRender(): Promise<DiagramRenderFn> {
         // Load the wasm module. wasm-bindgen's ESM-wasm build initialises via
         // the `import * from '*.wasm'` side effect, so no separate init call is
         // needed. Some builds still ship a default `init()` — probe defensively.
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const puml: any = await import('@actrium/plantuml-little-web' as string);
+        const puml = (await import(
+          '@actrium/plantuml-little-web' as string
+        )) as WasmRenderModule;
 
         const init =
           (typeof puml.default === 'function' && puml.default) ||
@@ -186,10 +198,8 @@ function plantumlNeedsGraphviz(code: string): boolean {
  * still ship a default `init()` — we probe defensively and `await` it if
  * present, swallowing errors caused by re-init.
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 async function loadWebD2Render(): Promise<DiagramRenderFn> {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const d2: any = await import('@actrium/d2-little-web' as string);
+  const d2 = (await import('@actrium/d2-little-web' as string)) as WasmRenderModule;
 
   const init =
     (typeof d2.default === 'function' && d2.default) ||

--- a/packages/features/cards/vison/src/feature.ts
+++ b/packages/features/cards/vison/src/feature.ts
@@ -1,6 +1,7 @@
 import type {
   SupramarkContainerNode,
   SupramarkNode,
+  SupramarkRootNode,
   FeatureConfigWithOptions,
   SupramarkConfig,
   SupramarkFeature,
@@ -161,8 +162,10 @@ export const visonFeature: SupramarkFeature<SupramarkVisonContainerNode> = {
         {
           name: 'Vison container produces a vison-named container node',
           input: ':::vison\n{ "version": "1", "type": "text" }\n:::',
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          validate: (result: any) => result?.children?.[0]?.name === 'vison',
+          validate: (result: unknown) =>
+            ((result as SupramarkRootNode | undefined)?.children?.[0] as
+              | SupramarkContainerNode
+              | undefined)?.name === 'vison',
           platforms: ['web', 'rn'],
         },
       ],

--- a/packages/features/cards/vison/src/runtime.rn.tsx
+++ b/packages/features/cards/vison/src/runtime.rn.tsx
@@ -8,17 +8,22 @@
 
 import React, { useEffect, useState } from 'react';
 import { ActivityIndicator, StyleSheet, Text, View } from 'react-native';
+import type { SupramarkContainerNode } from '@supramark/core';
 import type { VisonContainerData, VisonSpec } from './feature.js';
 
 // Loose typing for the RN renderer args — the core ContainerRendererRN
 // signature lives in @supramark/rn but we don't want a hard dep here.
 interface RNContainerArgs {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  node: any;
+  node: SupramarkContainerNode;
   key: string | number;
 }
 
 type VisonRNRendererComponent = React.ComponentType<{ data: VisonSpec }>;
+
+interface VisonRNModule {
+  VisonRNRenderer?: VisonRNRendererComponent;
+  default?: VisonRNRendererComponent;
+}
 
 let cachedRenderer: VisonRNRendererComponent | null = null;
 let rendererPromise: Promise<VisonRNRendererComponent> | null = null;
@@ -26,8 +31,7 @@ let rendererPromise: Promise<VisonRNRendererComponent> | null = null;
 async function loadRenderer(): Promise<VisonRNRendererComponent> {
   if (cachedRenderer) return cachedRenderer;
   if (!rendererPromise) {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    rendererPromise = import('@actrium/vison-rn' as string).then((mod: any) => {
+    rendererPromise = import('@actrium/vison-rn' as string).then((mod: VisonRNModule) => {
       const Component = mod.VisonRNRenderer ?? mod.default;
       if (!Component) {
         throw new Error('@actrium/vison-rn did not export VisonRNRenderer');

--- a/packages/features/cards/vison/src/runtime.web.tsx
+++ b/packages/features/cards/vison/src/runtime.web.tsx
@@ -12,14 +12,18 @@ import type { VisonContainerData, VisonSpec } from './feature.js';
 
 type VisonWebRendererComponent = React.ComponentType<{ data: VisonSpec }>;
 
+interface VisonWebModule {
+  VisonWebRenderer?: VisonWebRendererComponent;
+  default?: VisonWebRendererComponent;
+}
+
 let cachedRenderer: VisonWebRendererComponent | null = null;
 let rendererPromise: Promise<VisonWebRendererComponent> | null = null;
 
 async function loadRenderer(): Promise<VisonWebRendererComponent> {
   if (cachedRenderer) return cachedRenderer;
   if (!rendererPromise) {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    rendererPromise = import('@actrium/vison-web' as string).then((mod: any) => {
+    rendererPromise = import('@actrium/vison-web' as string).then((mod: VisonWebModule) => {
       const Component = mod.VisonWebRenderer ?? mod.default;
       if (!Component) {
         throw new Error('@actrium/vison-web did not export VisonWebRenderer');

--- a/packages/features/containers/admonition/src/feature.ts
+++ b/packages/features/containers/admonition/src/feature.ts
@@ -22,6 +22,7 @@ import {
   type ContainerFeature,
   type ContainerHook,
   type ContainerHookContext,
+  type SupramarkContainerNode,
 } from '@supramark/core';
 
 type ContainerTokenLike = {
@@ -65,7 +66,7 @@ function createAdmonitionContainerHook(kind: string): ContainerHook {
     opaque: false,
     onOpen(ctx: ContainerHookContext) {
       const title = parseTitle(ctx.token, kind);
-      const node = {
+      const node: SupramarkContainerNode = {
         type: 'container' as const,
         name: 'admonition',
         params: ctx.token.info ? String(ctx.token.info) : undefined,
@@ -76,11 +77,11 @@ function createAdmonitionContainerHook(kind: string): ContainerHook {
         children: [],
       };
       const parent = ctx.stack[ctx.stack.length - 1];
-      parent.children.push(node as any);
-      ctx.stack.push(node as any);
+      parent.children.push(node);
+      ctx.stack.push(node);
     },
     onClose(ctx: ContainerHookContext) {
-      const top = ctx.stack[ctx.stack.length - 1] as any;
+      const top = ctx.stack[ctx.stack.length - 1] as SupramarkContainerNode;
       if (top && top.type === 'container' && top.name === 'admonition') {
         ctx.stack.pop();
       }

--- a/packages/features/containers/admonition/src/runtime.rn.tsx
+++ b/packages/features/containers/admonition/src/runtime.rn.tsx
@@ -8,7 +8,12 @@
 
 import React from 'react';
 import { View, Text } from 'react-native';
-import type { ContainerRNRenderArgs } from '@supramark/core';
+import type { StyleProp, ViewStyle, TextStyle } from 'react-native';
+import type { ContainerRNRenderArgs, FeatureConfig } from '@supramark/core';
+
+// React Native's bundled @types/react differs from the workspace React types
+// (e.g. on bigint in ReactNode); derive the node type from Text's own children.
+type RNNode = React.ComponentProps<typeof Text>['children'];
 
 /**
  * RN 渲染器 for :::note, :::tip, :::warning 等
@@ -20,28 +25,30 @@ export function renderAdmonitionContainerRN({
   config,
   renderChildren,
 }: ContainerRNRenderArgs): React.ReactNode {
-  const title = node?.data?.title;
+  const title = node?.data?.title as RNNode;
+  const viewStyle = styles.listItem as StyleProp<ViewStyle>;
+  const textStyle = styles.listItemText as StyleProp<TextStyle>;
 
   // Feature enable 检查：如果禁用，退化为普通样式
   const isEnabled =
     !config || !config.features || config.features.length === 0
       ? true
-      : (config.features.find((f: any) => f.id === '@supramark/feature-admonition')?.enabled ??
+      : (config.features.find((f: FeatureConfig) => f.id === '@supramark/feature-admonition')?.enabled ??
         true);
 
   if (!isEnabled) {
     return (
-      <View key={key} style={styles.listItem}>
-        {title ? <Text style={styles.listItemText}>{title}</Text> : null}
-        <Text style={styles.listItemText}>{renderChildren(node.children ?? [])}</Text>
+      <View key={key} style={viewStyle}>
+        {title ? <Text style={textStyle}>{title}</Text> : null}
+        <Text style={textStyle}>{renderChildren(node.children ?? []) as RNNode}</Text>
       </View>
     );
   }
 
   return (
-    <View key={key} style={styles.listItem}>
-      {title ? <Text style={[styles.listItemText, { fontWeight: '600' }]}>{title}</Text> : null}
-      <Text style={styles.listItemText}>{renderChildren(node.children ?? [])}</Text>
+    <View key={key} style={viewStyle}>
+      {title ? <Text style={[textStyle, { fontWeight: '600' }]}>{title}</Text> : null}
+      <Text style={textStyle}>{renderChildren(node.children ?? []) as RNNode}</Text>
     </View>
   );
 }

--- a/packages/features/containers/admonition/src/runtime.web.tsx
+++ b/packages/features/containers/admonition/src/runtime.web.tsx
@@ -7,7 +7,7 @@
  */
 
 import React from 'react';
-import type { ContainerWebRenderArgs } from '@supramark/core';
+import type { ContainerWebRenderArgs, FeatureConfig } from '@supramark/core';
 
 /**
  * Web 渲染器 for :::note, :::tip, :::warning 等
@@ -19,14 +19,14 @@ export function renderAdmonitionContainerWeb({
   config,
   renderChildren,
 }: ContainerWebRenderArgs): React.ReactNode {
-  const kind = node?.data?.kind ?? 'note';
-  const title = node?.data?.title;
+  const kind = (node?.data?.kind as string | undefined) ?? 'note';
+  const title = node?.data?.title as React.ReactNode;
 
   // Feature enable 检查：如果禁用，退化为普通段落
   const isEnabled =
     !config || !config.features || config.features.length === 0
       ? true
-      : (config.features.find((f: any) => f.id === '@supramark/feature-admonition')?.enabled ??
+      : (config.features.find((f: FeatureConfig) => f.id === '@supramark/feature-admonition')?.enabled ??
         true);
 
   if (!isEnabled) {
@@ -34,7 +34,7 @@ export function renderAdmonitionContainerWeb({
       <p key={key} className={classNames.paragraph}>
         {title ? <strong>{title}</strong> : null}
         {title ? ' ' : null}
-        {renderChildren(node.children ?? [])}
+        {renderChildren(node.children ?? []) as React.ReactNode}
       </p>
     );
   }
@@ -46,7 +46,7 @@ export function renderAdmonitionContainerWeb({
           <strong>{title}</strong>
         </p>
       ) : null}
-      <div>{renderChildren(node.children ?? [])}</div>
+      <div>{renderChildren(node.children ?? []) as React.ReactNode}</div>
     </div>
   );
 }

--- a/packages/features/containers/html-page/src/feature.ts
+++ b/packages/features/containers/html-page/src/feature.ts
@@ -1,6 +1,7 @@
 import type {
   SupramarkContainerNode,
   SupramarkNode,
+  SupramarkRootNode,
   FeatureConfigWithOptions,
   SupramarkConfig,
   SupramarkFeature,
@@ -144,7 +145,9 @@ export const htmlPageFeature: SupramarkFeature<SupramarkHtmlPageContainerNode> =
         {
           name: 'HTML Page 集成测试',
           input: ':::html\ncontent\n:::',
-          validate: (result: any) => result.children?.[0]?.name === 'html',
+          validate: (result: unknown) =>
+            ((result as SupramarkRootNode).children?.[0] as SupramarkContainerNode | undefined)
+              ?.name === 'html',
           platforms: ['web', 'rn'],
         },
       ],

--- a/packages/features/containers/map/src/feature.ts
+++ b/packages/features/containers/map/src/feature.ts
@@ -1,6 +1,7 @@
 import type {
   SupramarkContainerNode,
   SupramarkNode,
+  SupramarkRootNode,
   FeatureConfigWithOptions,
   SupramarkConfig,
   SupramarkFeature,
@@ -152,7 +153,9 @@ export const mapFeature: SupramarkFeature<SupramarkMapContainerNode> = {
         {
           name: 'Map 集成测试',
           input: ':::map\ncenter: [0, 0]\n:::',
-          validate: (result: any) => result.children?.[0]?.name === 'map',
+          validate: (result: unknown) =>
+            ((result as SupramarkRootNode).children?.[0] as SupramarkContainerNode | undefined)
+              ?.name === 'map',
           platforms: ['web', 'rn'],
         },
       ],

--- a/packages/features/containers/map/src/runtime.ts
+++ b/packages/features/containers/map/src/runtime.ts
@@ -91,7 +91,7 @@ function parseMapConfig(raw: string): ParsedMapConfig {
 
       if (!result.marker) result.marker = {};
       if (key === 'lat' || key === 'lng') {
-        (result.marker as any)[key] = num;
+        result.marker[key] = num;
       } else {
         if (!result.meta) result.meta = {};
         result.meta[`marker.${key}`] = num;

--- a/packages/features/containers/weather/src/feature.ts
+++ b/packages/features/containers/weather/src/feature.ts
@@ -32,6 +32,7 @@ import {
   type ContainerFeature,
   type ContainerHook,
   type ContainerHookContext,
+  type SupramarkContainerNode,
 } from '@supramark/core';
 
 // ============================================================================
@@ -289,20 +290,20 @@ function createWeatherContainerHook(name: string): ContainerHook {
         rawConfig: parsed.parseError ? innerText : undefined,
       };
 
-      const node = {
+      const node: SupramarkContainerNode = {
         type: 'container' as const,
         name: 'weather',
         params: token.info ? String(token.info) : undefined,
-        data,
+        data: { ...data },
         children: [],
       };
 
       const parent = stack[stack.length - 1];
-      parent.children.push(node as any);
-      stack.push(node as any);
+      parent.children.push(node);
+      stack.push(node);
     },
     onClose(ctx: ContainerHookContext) {
-      const top = ctx.stack[ctx.stack.length - 1] as any;
+      const top = ctx.stack[ctx.stack.length - 1] as SupramarkContainerNode;
       if (top && top.type === 'container' && top.name === 'weather') {
         ctx.stack.pop();
       }

--- a/packages/features/containers/weather/src/runtime.rn.tsx
+++ b/packages/features/containers/weather/src/runtime.rn.tsx
@@ -117,7 +117,7 @@ export function renderWeatherContainerRN({
   node,
   key,
 }: ContainerRNRenderArgs): React.ReactNode {
-  const data = (node?.data ?? {}) as WeatherData;
+  const data = (node?.data ?? {}) as unknown as WeatherData;
   const { format, location, units = 'metric', parseError, rawConfig } = data;
 
   // 解析错误时显示错误信息

--- a/packages/features/containers/weather/src/runtime.web.tsx
+++ b/packages/features/containers/weather/src/runtime.web.tsx
@@ -145,7 +145,7 @@ export function renderWeatherContainerWeb({
   node,
   key,
 }: ContainerWebRenderArgs): React.ReactNode {
-  const data = (node?.data ?? {}) as WeatherData;
+  const data = (node?.data ?? {}) as unknown as WeatherData;
   const { format, location, units = 'metric', parseError, rawConfig } = data;
 
   // 解析错误时显示错误信息

--- a/packages/features/core-markdown/src/feature.ts
+++ b/packages/features/core-markdown/src/feature.ts
@@ -1,6 +1,7 @@
 import type {
   SupramarkFeature,
   SupramarkNode,
+  SupramarkRootNode,
   FeatureConfigWithOptions,
   SupramarkConfig,
 } from '@supramark/core';
@@ -271,9 +272,9 @@ export const coreMarkdownFeature: SupramarkFeature<SupramarkNode> = {
           input: '# 标题\n\n这是段落',
           validate: result => {
             if (!result || typeof result !== 'object') return false;
-            const nodes = (result as any).children || [];
-            const hasHeading = nodes.some((n: any) => n.type === 'heading');
-            const hasParagraph = nodes.some((n: any) => n.type === 'paragraph');
+            const nodes = (result as SupramarkRootNode).children || [];
+            const hasHeading = nodes.some((n: SupramarkNode) => n.type === 'heading');
+            const hasParagraph = nodes.some((n: SupramarkNode) => n.type === 'paragraph');
             return hasHeading && hasParagraph;
           },
           platforms: ['web', 'rn'],
@@ -283,9 +284,9 @@ export const coreMarkdownFeature: SupramarkFeature<SupramarkNode> = {
           input: '- 列表\n\n```js\ncode\n```',
           validate: result => {
             if (!result || typeof result !== 'object') return false;
-            const nodes = (result as any).children || [];
-            const hasList = nodes.some((n: any) => n.type === 'list');
-            const hasCode = nodes.some((n: any) => n.type === 'code');
+            const nodes = (result as SupramarkRootNode).children || [];
+            const hasList = nodes.some((n: SupramarkNode) => n.type === 'list');
+            const hasCode = nodes.some((n: SupramarkNode) => n.type === 'code');
             return hasList && hasCode;
           },
           platforms: ['web', 'rn'],
@@ -295,14 +296,14 @@ export const coreMarkdownFeature: SupramarkFeature<SupramarkNode> = {
           input: '**粗体** 和 *斜体* 和 `代码`',
           validate: result => {
             if (!result || typeof result !== 'object') return false;
-            const nodes = (result as any).children || [];
+            const nodes = (result as SupramarkRootNode).children || [];
             return nodes.some(
-              (n: any) =>
+              (n: SupramarkNode) =>
                 n.type === 'paragraph' &&
                 Array.isArray(n.children) &&
-                n.children.some((c: any) => c.type === 'strong') &&
-                n.children.some((c: any) => c.type === 'emphasis') &&
-                n.children.some((c: any) => c.type === 'inline_code')
+                n.children.some((c: SupramarkNode) => c.type === 'strong') &&
+                n.children.some((c: SupramarkNode) => c.type === 'emphasis') &&
+                n.children.some((c: SupramarkNode) => c.type === 'inline_code')
             );
           },
           platforms: ['web', 'rn'],

--- a/packages/features/main/definition-list/src/feature.ts
+++ b/packages/features/main/definition-list/src/feature.ts
@@ -1,6 +1,9 @@
 import type {
   SupramarkFeature,
+  SupramarkNode,
+  SupramarkRootNode,
   SupramarkDefinitionListNode,
+  SupramarkDefinitionItemNode,
   FeatureConfigWithOptions,
   SupramarkConfig,
 } from '@supramark/core';
@@ -233,8 +236,8 @@ export const definitionListFeature: SupramarkFeature<SupramarkDefinitionListNode
           input: 'Markdown\n:   轻量级标记语言',
           validate: result => {
             if (!result || typeof result !== 'object') return false;
-            const nodes = (result as any).children || [];
-            return nodes.some((n: any) => n.type === 'definition_list');
+            const nodes = (result as SupramarkRootNode).children || [];
+            return nodes.some((n: SupramarkNode) => n.type === 'definition_list');
           },
           platforms: ['web', 'rn'],
         },
@@ -243,15 +246,15 @@ export const definitionListFeature: SupramarkFeature<SupramarkDefinitionListNode
           input: 'TypeScript\n:   强类型 JavaScript\n:   微软开发',
           validate: result => {
             if (!result || typeof result !== 'object') return false;
-            const nodes = (result as any).children || [];
-            const defList = nodes.find((n: any) => n.type === 'definition_list');
+            const nodes = (result as SupramarkRootNode).children || [];
+            const defList = nodes.find((n: SupramarkNode) => n.type === 'definition_list');
             if (!defList) return false;
-            const items = defList.children || [];
+            const items = (defList as SupramarkDefinitionListNode).children || [];
             return items.some(
-              (item: any) =>
+              (item: SupramarkDefinitionItemNode) =>
                 item.type === 'definition_item' &&
                 Array.isArray(item.children) &&
-                item.children.some((child: any) => child.type === 'definition_description')
+                item.children.some((child: SupramarkNode) => child.type === 'definition_description')
             );
           },
           platforms: ['web', 'rn'],

--- a/packages/features/main/emoji/src/feature.ts
+++ b/packages/features/main/emoji/src/feature.ts
@@ -1,5 +1,7 @@
 import type {
   SupramarkFeature,
+  SupramarkNode,
+  SupramarkRootNode,
   SupramarkTextNode,
   FeatureConfigWithOptions,
   SupramarkConfig,
@@ -210,12 +212,12 @@ export const emojiFeature: SupramarkFeature<SupramarkTextNode> = {
           input: '测试 :smile: 和 :rocket:',
           validate: result => {
             if (!result || typeof result !== 'object') return false;
-            const nodes = (result as any).children || [];
+            const nodes = (result as SupramarkRootNode).children || [];
             return nodes.some(
-              (n: any) =>
+              (n: SupramarkNode) =>
                 n.type === 'paragraph' &&
                 n.children?.some(
-                  (c: any) =>
+                  (c: SupramarkNode) =>
                     c.type === 'text' && (c.value.includes('😄') || c.value.includes('🚀'))
                 )
             );
@@ -227,11 +229,11 @@ export const emojiFeature: SupramarkFeature<SupramarkTextNode> = {
           input: '直接使用 😄🚀',
           validate: result => {
             if (!result || typeof result !== 'object') return false;
-            const nodes = (result as any).children || [];
+            const nodes = (result as SupramarkRootNode).children || [];
             return nodes.some(
-              (n: any) =>
+              (n: SupramarkNode) =>
                 n.type === 'paragraph' &&
-                n.children?.some((c: any) => c.type === 'text' && c.value.includes('😄'))
+                n.children?.some((c: SupramarkNode) => c.type === 'text' && c.value.includes('😄'))
             );
           },
           platforms: ['web', 'rn'],

--- a/packages/features/main/footnote/__tests__/feature.test.ts
+++ b/packages/features/main/footnote/__tests__/feature.test.ts
@@ -1,5 +1,6 @@
 import { footnoteFeature } from '../src/feature';
 import { validateFeature } from '@supramark/core';
+import type { SupramarkNode } from '@supramark/core';
 
 describe('Footnote Feature', () => {
   describe('Metadata', () => {
@@ -31,13 +32,13 @@ describe('Footnote Feature', () => {
       const refMatch = selector!({
         type: 'footnote_reference',
         index: 1,
-      } as any);
+      } as unknown as SupramarkNode);
 
       const defMatch = selector!({
         type: 'footnote_definition',
         index: 1,
         children: [],
-      } as any);
+      } as unknown as SupramarkNode);
 
       expect(refMatch).toBe(true);
       expect(defMatch).toBe(true);

--- a/packages/features/main/footnote/src/feature.ts
+++ b/packages/features/main/footnote/src/feature.ts
@@ -1,6 +1,7 @@
 import type {
   SupramarkFeature,
   SupramarkNode,
+  SupramarkRootNode,
   SupramarkFootnoteReferenceNode,
   SupramarkFootnoteDefinitionNode,
   FeatureConfigWithOptions,
@@ -243,13 +244,15 @@ export const footnoteFeature: SupramarkFeature<
           input: '正文[^1]\n\n[^1]: 脚注内容',
           validate: result => {
             if (!result || typeof result !== 'object') return false;
-            const nodes = (result as any).children || [];
+            const nodes = (result as SupramarkRootNode).children || [];
             const hasReference = nodes.some(
-              (n: any) =>
+              (n: SupramarkNode) =>
                 n.type === 'paragraph' &&
-                n.children?.some((c: any) => c.type === 'footnote_reference')
+                n.children?.some((c: SupramarkNode) => c.type === 'footnote_reference')
             );
-            const hasDefinition = nodes.some((n: any) => n.type === 'footnote_definition');
+            const hasDefinition = nodes.some(
+              (n: SupramarkNode) => n.type === 'footnote_definition'
+            );
             return hasReference && hasDefinition;
           },
           platforms: ['web', 'rn'],
@@ -259,16 +262,19 @@ export const footnoteFeature: SupramarkFeature<
           input: '文本[^1]和[^2]\n\n[^1]: 第一个\n[^2]: 第二个',
           validate: result => {
             if (!result || typeof result !== 'object') return false;
-            const nodes = (result as any).children || [];
-            const references = nodes.reduce((count: number, n: any) => {
+            const nodes = (result as SupramarkRootNode).children || [];
+            const references = nodes.reduce((count: number, n: SupramarkNode) => {
               if (n.type === 'paragraph' && Array.isArray(n.children)) {
                 return (
-                  count + n.children.filter((c: any) => c.type === 'footnote_reference').length
+                  count +
+                  n.children.filter((c: SupramarkNode) => c.type === 'footnote_reference').length
                 );
               }
               return count;
             }, 0);
-            const definitions = nodes.filter((n: any) => n.type === 'footnote_definition').length;
+            const definitions = nodes.filter(
+              (n: SupramarkNode) => n.type === 'footnote_definition'
+            ).length;
             return references >= 2 && definitions >= 2;
           },
           platforms: ['web', 'rn'],

--- a/packages/features/main/gfm/src/feature.ts
+++ b/packages/features/main/gfm/src/feature.ts
@@ -1,6 +1,8 @@
 import type {
   SupramarkFeature,
   SupramarkNode,
+  SupramarkRootNode,
+  SupramarkListItemNode,
   FeatureConfigWithOptions,
   SupramarkConfig,
 } from '@supramark/core';
@@ -262,14 +264,19 @@ export const gfmFeature: SupramarkFeature<SupramarkNode> = {
           input: '~~删除~~ 文本\n\n- [x] 任务1\n- [ ] 任务2',
           validate: result => {
             if (!result || typeof result !== 'object') return false;
-            const nodes = (result as any).children || [];
+            const nodes = (result as SupramarkRootNode).children || [];
             const hasDelete = nodes.some(
-              (n: any) =>
-                n.type === 'paragraph' && n.children?.some((c: any) => c.type === 'delete')
+              (n: SupramarkNode) =>
+                n.type === 'paragraph' &&
+                n.children?.some((c: SupramarkNode) => c.type === 'delete')
             );
             const hasTaskList = nodes.some(
-              (n: any) =>
-                n.type === 'list' && n.children?.some((item: any) => item.checked !== undefined)
+              (n: SupramarkNode) =>
+                n.type === 'list' &&
+                n.children?.some(
+                  (item: SupramarkNode) =>
+                    (item as SupramarkListItemNode).checked !== undefined
+                )
             );
             return hasDelete && hasTaskList;
           },
@@ -280,8 +287,8 @@ export const gfmFeature: SupramarkFeature<SupramarkNode> = {
           input: '| A | B |\n|---|---|\n| 1 | 2 |\n| 3 | 4 |',
           validate: result => {
             if (!result || typeof result !== 'object') return false;
-            const nodes = (result as any).children || [];
-            const hasTable = nodes.some((n: any) => n.type === 'table');
+            const nodes = (result as SupramarkRootNode).children || [];
+            const hasTable = nodes.some((n: SupramarkNode) => n.type === 'table');
             return hasTable;
           },
           platforms: ['web', 'rn'],

--- a/packages/features/main/math/src/feature.ts
+++ b/packages/features/main/math/src/feature.ts
@@ -1,6 +1,7 @@
 import type {
   SupramarkFeature,
   SupramarkNode,
+  SupramarkRootNode,
   SupramarkMathInlineNode,
   SupramarkMathBlockNode,
   FeatureConfigWithOptions,
@@ -262,12 +263,13 @@ export const mathFeature: SupramarkFeature<SupramarkMathInlineNode | SupramarkMa
           input: '测试 $x^2$ 和\n\n$$\\int_0^1$$',
           validate: result => {
             if (!result || typeof result !== 'object') return false;
-            const nodes = (result as any).children || [];
+            const nodes = (result as SupramarkRootNode).children || [];
             const hasMathInline = nodes.some(
-              (n: any) =>
-                n.type === 'paragraph' && n.children?.some((c: any) => c.type === 'math_inline')
+              (n: SupramarkNode) =>
+                n.type === 'paragraph' &&
+                n.children?.some((c: SupramarkNode) => c.type === 'math_inline')
             );
-            const hasMathBlock = nodes.some((n: any) => n.type === 'math_block');
+            const hasMathBlock = nodes.some((n: SupramarkNode) => n.type === 'math_block');
             return hasMathInline && hasMathBlock;
           },
           platforms: ['web', 'rn'],
@@ -277,12 +279,12 @@ export const mathFeature: SupramarkFeature<SupramarkMathInlineNode | SupramarkMa
           input: '公式 $a^2$ 和 $b^2$ 以及 $c^2$',
           validate: result => {
             if (!result || typeof result !== 'object') return false;
-            const nodes = (result as any).children || [];
+            const nodes = (result as SupramarkRootNode).children || [];
             return nodes.some(
-              (n: any) =>
+              (n: SupramarkNode) =>
                 n.type === 'paragraph' &&
                 Array.isArray(n.children) &&
-                n.children.filter((c: any) => c.type === 'math_inline').length >= 3
+                n.children.filter((c: SupramarkNode) => c.type === 'math_inline').length >= 3
             );
           },
           platforms: ['web', 'rn'],

--- a/packages/renderers/rn/src/Supramark.tsx
+++ b/packages/renderers/rn/src/Supramark.tsx
@@ -53,7 +53,7 @@ import {
 } from './styles';
 import { ErrorBoundary, ErrorInfo, ErrorDisplay } from './ErrorBoundary';
 
-type RenderedNode = any;
+type RenderedNode = React.ComponentProps<typeof Text>['children'];
 
 function getDefinitionTerms(item: SupramarkDefinitionItemNode): SupramarkDefinitionTermNode[] {
   return item.children.filter(
@@ -72,7 +72,7 @@ function getDefinitionDescriptions(
 
 export interface ContainerRendererRN {
   (args: {
-    node: any;
+    node: SupramarkContainerNode;
     key: number;
     styles: ReturnType<typeof mergeStyles>;
     config?: SupramarkConfig;
@@ -373,7 +373,11 @@ function renderNode(
       // opaque container 的 children 已在主组件 useEffect 里通过 expandOpaqueContainers
       // 预解析填充（parse(value) → children）。这里直接渲染 children。
       // Column 布局：title 一行，正文一行。
-      if (SUPRAMARK_ADMONITION_KINDS.includes(containerName as any)) {
+      if (
+        SUPRAMARK_ADMONITION_KINDS.includes(
+          containerName as (typeof SUPRAMARK_ADMONITION_KINDS)[number]
+        )
+      ) {
         const title = container.params || (container.data?.title as string | undefined);
         const kind = containerName;
         const admonitionContainerStyle = { flexDirection: 'column' as const, marginBottom: 4 };

--- a/packages/renderers/rn/src/styles.ts
+++ b/packages/renderers/rn/src/styles.ts
@@ -319,7 +319,7 @@ export function mergeStyles(customStyles?: SupramarkStyles): typeof defaultStyle
   }
 
   // 创建一个新对象,避免修改defaultStyles
-  const merged: Record<string, any> = {};
+  const merged: Record<string, TextStyle | ViewStyle> = {};
 
   // 先复制所有默认样式
   Object.keys(defaultStyles).forEach(key => {

--- a/packages/renderers/web/src/Supramark.tsx
+++ b/packages/renderers/web/src/Supramark.tsx
@@ -56,7 +56,7 @@ import { MathBlockWeb, MathInlineWeb } from './MathBlockWeb.js';
 
 export interface ContainerRendererWeb {
   (args: {
-    node: any;
+    node: SupramarkContainerNode;
     key: number;
     classNames: SupramarkClassNames;
     config?: SupramarkConfig;
@@ -510,10 +510,14 @@ function renderNode(
       //   2. 来自 @supramark/feature-admonition（feature 注册的 hook）→ name='admonition', data.kind=实际种类
       const kindFromData = container.data?.kind as string | undefined;
       const isAdmonition =
-        SUPRAMARK_ADMONITION_KINDS.includes(containerName as any) ||
+        SUPRAMARK_ADMONITION_KINDS.includes(
+          containerName as (typeof SUPRAMARK_ADMONITION_KINDS)[number]
+        ) ||
         (containerName === 'admonition' &&
           kindFromData !== undefined &&
-          SUPRAMARK_ADMONITION_KINDS.includes(kindFromData as any));
+          SUPRAMARK_ADMONITION_KINDS.includes(
+            kindFromData as (typeof SUPRAMARK_ADMONITION_KINDS)[number]
+          ));
       if (isAdmonition) {
         const kind = (kindFromData as string) || containerName;
         // title 优先使用 data.title（已剥离 kind 名），否则退回 params（可能含 kind 前缀）


### PR DESCRIPTION
## Summary

Eliminates **all explicit `any`** from the TypeScript source under `packages/**` and `crates/**` and promotes the lint rule `@typescript-eslint/no-explicit-any` from `warn` to **`error`**. This is a **types-only** change — no runtime behavior, control flow, values, or public API shapes were altered.

- **Before:** ~143 in-scope `any` occurrences across ~37 files (`.ts`/`.tsx`, excluding `node_modules`/`dist`/`lib`/`build` and `*.d.ts`). After rebasing onto the latest `main` (which merged #6), 8 additional `any` appeared in a newly-added test file and were eliminated too.
- **After:** `0` in-scope `any`. `0` `no-explicit-any` violations repo-wide (including `*.d.ts`).

## Areas touched

- `packages/core`: AST-typed renderer-arg interfaces, `FeatureRegistry`, presets, container-extension tokenizer, and the four test suites.
- `packages/features`: `core-markdown`, `main/*` (footnote, math, gfm, emoji, definition-list), `containers/*` (admonition, weather, map, html-page), `cards/vison`.
- `packages/engines`: web/rn entrypoints, mermaid/mathjax/graphviz adapters, host-bridge, and the ambient `optional-deps.d.ts`.
- `packages/renderers`: web + rn `Supramark.tsx`, rn `styles.ts`.
- `crates`: `vison` web/rn renderers + shared types, `graphviz-anywhere` tests and the RN example.

## Approach

Most sites were replaced with precise types: concrete AST node interfaces (`SupramarkContainerNode`, `SupramarkRootNode`, `SupramarkHeadingNode`, …), `FeatureConfig`, generics, or literal unions. The core renderer-arg interfaces (`ContainerWebRenderArgs`/`ContainerRNRenderArgs`) are now AST-typed; because `@supramark/core` is intentionally framework-agnostic, their `renderChildren`/`styles` use `unknown`, and the few React/RN consumers narrow at the JSX boundary.

`FeatureRegistry.register` is now generic over `TNode` so node-specific features (e.g. `SupramarkFeature<SupramarkMapContainerNode>`) register without `any`; the value is widened with a single documented `as unknown as` to the stored `SupramarkNode` contract (sound: the registry never invokes node-specific callbacks with a wider node).

## `unknown` / escape hatches used (with justification)

- **`RenderOutput<TPlatform>` (non-cli)** and **container renderer-arg `renderChildren`/`styles`**: `unknown` — core cannot depend on React/React Native, so the render-output and style-bag types are genuinely opaque at the core boundary; consumers narrow.
- **Untyped third-party module shapes** (mathjax `liteAdaptor`/`document`, wasm dynamic imports in engines, `globalThis` bridges, dynamically-imported vison modules): minimal local English-named interfaces capturing only the members actually used, with `unknown` for opaque node handles.
- **Deliberately-invalid test inputs** (`validateFeature.test.ts`, partial fixtures): `as unknown as <ProperType>` — the invalidity is what the tests assert, so a precise type would defeat the test.
- **No `// eslint-disable` was added.** Four stale `eslint-disable no-explicit-any` directives in `engines/src/web.ts` were removed since the `any` they covered is gone.

## Verification

- `bunx tsc -p tsconfig.json --noEmit`: clean in every touched package.
- Tests: `@supramark/core` 83 pass / 0 fail (wasm parser built with `RUSTFLAGS=" "`); all touched feature packages pass; `graphviz-anywhere` web 81 pass.
- `bunx eslint .` with the rule set to `error`: **0 `no-explicit-any` errors**. (Two unrelated pre-existing `no-useless-escape` errors remain in `crates/supramark-markdown/packages/react-native/src/index.ts`, a file not touched here.)
- Final in-scope `any` grep: **0**.

## Note on in-flight work

The renderer/core PR `fix/markdown-render-ts` was already **merged into `main` (#6)** by the time this branch was rebased, so its changes to `packages/core/src/plugin.ts` and the renderers are already incorporated. One trivial conflict in `packages/renderers/rn/src/Supramark.tsx` (an admonition `includes(... as any)`) was resolved by keeping the upstream comments and applying the precise literal-union cast.
