### PR TITLE
fix(graphviz-anywhere): link self-contained shared lib on desktop (fixes cargo test native chain)

### DIFF
--- a/crates/graphviz-anywhere/packages/rust/build.rs
+++ b/crates/graphviz-anywhere/packages/rust/build.rs
@@ -122,10 +122,11 @@ fn try_repo_output(manifest_dir: &Path) -> bool {
     let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
 
     // Determine whether we expect a static or dynamic lib for this target.
-    // Only iOS links statically (matching `asset_is_static`): a static archive
-    // cannot embed the C++ runtime / expat, so desktop targets — including
-    // macOS — link the self-contained shared library (.so/.dylib) instead.
-    let prefer_static = is_ios_target(&target);
+    // Only iOS links statically: a static archive cannot embed the C++ runtime
+    // / expat, so desktop targets — including macOS — link the self-contained
+    // shared library (.so/.dylib). Reuse the single `asset_is_static` policy so
+    // the repo-output path and the download fallback can never diverge.
+    let prefer_static = asset_is_static(&target);
 
     // ── Collect candidate directories ────────────────────────────────────────
 

--- a/crates/graphviz-anywhere/packages/rust/build.rs
+++ b/crates/graphviz-anywhere/packages/rust/build.rs
@@ -122,7 +122,10 @@ fn try_repo_output(manifest_dir: &Path) -> bool {
     let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
 
     // Determine whether we expect a static or dynamic lib for this target.
-    let prefer_static = is_ios_target(&target) || target_os == "macos";
+    // Only iOS links statically (matching `asset_is_static`): a static archive
+    // cannot embed the C++ runtime / expat, so desktop targets — including
+    // macOS — link the self-contained shared library (.so/.dylib) instead.
+    let prefer_static = is_ios_target(&target);
 
     // ── Collect candidate directories ────────────────────────────────────────
 
@@ -179,14 +182,12 @@ fn try_repo_output(manifest_dir: &Path) -> bool {
                 return true;
             }
         } else {
-            // Dynamic: prefer .a on macOS/Linux desktop for cleaner downstream
-            // linking; fall back to .so / .dylib.
-            let static_lib = dir.join("libgraphviz_api.a");
-            if static_lib.exists() && (target_os == "macos" || target_os == "linux") {
-                emit_search_path(&dir, false);
-                println!("cargo:rustc-link-lib=static=graphviz_api");
-                return true;
-            }
+            // Dynamic desktop/mobile targets: link the self-contained shared
+            // library. A static `.a` is intentionally NOT preferred here — it
+            // cannot embed the C++ runtime (libstdc++) or expat, which the
+            // unified .so already pulls in via --whole-archive; linking the .a
+            // statically would leave those symbols undefined. (Static linking
+            // is only used for iOS, handled by the want_static branch above.)
             let dylib = if target_os == "macos" {
                 dir.join("libgraphviz_api.dylib")
             } else {

--- a/crates/graphviz-anywhere/packages/rust/src/build_helpers.rs
+++ b/crates/graphviz-anywhere/packages/rust/src/build_helpers.rs
@@ -337,4 +337,42 @@ mod tests {
         assert!(!is_ios_target("aarch64-apple-darwin"));
         assert!(!is_ios_target("aarch64-linux-android"));
     }
+
+    // ── asset_is_static (static vs. dynamic link policy) ─────────────────────────
+
+    #[test]
+    fn asset_is_static_only_for_ios() {
+        // iOS is the only target linked statically.
+        assert!(asset_is_static("aarch64-apple-ios"));
+        assert!(asset_is_static("aarch64-apple-ios-sim"));
+        assert!(asset_is_static("x86_64-apple-ios"));
+        // Desktop and Android link the self-contained shared library, so a
+        // static `.a` must never be preferred for them (build.rs derives
+        // `prefer_static` from this function).
+        assert!(!asset_is_static("x86_64-unknown-linux-gnu"));
+        assert!(!asset_is_static("aarch64-unknown-linux-gnu"));
+        assert!(!asset_is_static("aarch64-apple-darwin"));
+        assert!(!asset_is_static("x86_64-apple-darwin"));
+        assert!(!asset_is_static("x86_64-pc-windows-msvc"));
+        assert!(!asset_is_static("aarch64-linux-android"));
+    }
+
+    #[test]
+    fn asset_is_static_agrees_with_lib_filename() {
+        // The link policy must match the expected library file: static targets
+        // ship a `.a`, dynamic targets a `.so` / `.dylib`.
+        for target in [
+            "aarch64-apple-ios",
+            "x86_64-unknown-linux-gnu",
+            "aarch64-apple-darwin",
+            "aarch64-linux-android",
+        ] {
+            let ships_archive = asset_lib_filename(target).ends_with(".a");
+            assert_eq!(
+                asset_is_static(target),
+                ships_archive,
+                "asset_is_static and asset_lib_filename disagree for {target}"
+            );
+        }
+    }
 }

--- a/crates/graphviz-anywhere/scripts/build-linux.sh
+++ b/crates/graphviz-anywhere/scripts/build-linux.sh
@@ -170,10 +170,25 @@ cp "${WRAPPER_SRC}/graphviz_api.h" "${INSTALL_DIR}/include/"
 # The shared .so is kept for consumers that prefer dynamic linking.
 log_info "Building static archive libgraphviz_api.a..."
 AR="${AR:-ar}"
-# Respect cross-compilation AR (e.g. AR=aarch64-linux-gnu-ar)
-"${AR}" rcs "${INSTALL_DIR}/lib/libgraphviz_api.a" \
-    "${BUILD_DIR}/graphviz_api.o" \
-    "${GV_STATIC_LIBS[@]}"
+# Respect cross-compilation AR (e.g. AR=aarch64-linux-gnu-ar).
+#
+# `ar rcs out.a wrapper.o libfoo.a` stores each libfoo.a as an opaque archive
+# *member* rather than merging its objects, so the Graphviz symbols never end
+# up in the final archive (the linker then reports them undefined). Use an MRI
+# script: ADDLIB pulls every object out of each component static library, so
+# the result is a single self-contained archive — mirroring what the .so gets
+# via --whole-archive.
+ar_mri="${BUILD_DIR}/libgraphviz_api.mri"
+{
+    echo "CREATE ${INSTALL_DIR}/lib/libgraphviz_api.a"
+    echo "ADDMOD ${BUILD_DIR}/graphviz_api.o"
+    for _lib in "${GV_STATIC_LIBS[@]}"; do
+        echo "ADDLIB ${_lib}"
+    done
+    echo "SAVE"
+    echo "END"
+} > "${ar_mri}"
+"${AR}" -M < "${ar_mri}"
 
 # Step 5: Verify
 log_info "Verifying outputs..."


### PR DESCRIPTION
## Problem

`cargo test --workspace` fails to compile the graphviz/plantuml native chain. The crate's `build.rs` falls back to downloading a prebuilt lib from `github.com/Actrium/graphviz-anywhere/releases/.../graphviz-native-<platform>.tar.gz`, which currently **404s** (the org-migrated release assets were never uploaded). Building the lib from source (`scripts/build-linux.sh`) didn't help either, because of two bugs below.

## Root causes

1. **`build.rs` preferred a static `.a` on Linux/macOS.** A static archive can't embed the C++ runtime (`libstdc++`) or `expat`, so linking it left `std::basic_streambuf` vtable / `XML_Parse` / … undefined. This contradicted `asset_is_static`, which marks only iOS as static — desktop is meant to link the self-contained shared lib.
2. **`build-linux.sh` produced a broken `.a`.** `ar rcs out.a wrapper.o libfoo.a …` stores each component `libfoo.a` as an opaque archive *member* rather than merging its objects, so the Graphviz symbols (`gvContextPlugins`, `agmemread`, …) were absent from the final archive.

## Fix

- `build.rs`: `prefer_static = is_ios_target(target)` only; desktop targets (Linux **and** macOS) link the self-contained `.so`/`.dylib` (built with `--whole-archive`). iOS still links the static `.a`. Now consistent with `asset_is_static` and the download path.
- `build-linux.sh`: build the unified `.a` with an `ar` MRI script (`ADDLIB` merges every component object) instead of nesting archives.

## Verification (Linux x86_64, built from source)

- `scripts/build-linux.sh` → `output/linux-x86_64/lib/libgraphviz_api.{so,a}` (the `.a` now defines `gvContextPlugins`/`agmemread` as `T`).
- `cargo test -p graphviz-anywhere` → 22 passed + doc-test.
- **`cargo test --workspace` → 2476 passed, 0 failed** (previously failed to compile).

## Notes

- "Normal generation" workflow: pull the `graphviz` submodule, run `scripts/build-<platform>.sh`; `build.rs`'s `try_repo_output` then picks up `output/<platform>/lib/`. The build outputs stay git-ignored.
- The macOS branch is the analogous, principled change (its `build-macos.sh` already merges the `.a` correctly via `libtool -static`, and the `.dylib` is self-contained); it's covered by the same `prefer_static` alignment but was validated here on Linux only — s67 (macOS) can confirm via `scripts/build-macos.sh`.
- Uploading the release assets to `Actrium/graphviz-anywhere` remains a separate follow-up for the zero-setup `cargo add` download path.