### PR TITLE
fix(graphviz-anywhere): static-link native lib on desktop (Linux/macOS/Windows) to drop rpath/DLL dep

### DIFF
--- a/crates/graphviz-anywhere/packages/rust/build.rs
+++ b/crates/graphviz-anywhere/packages/rust/build.rs
@@ -17,6 +17,32 @@ fn emit_search_path(dir: &Path, dynamic: bool) {
     }
 }
 
+/// System libraries a *static* `graphviz_api` archive depends on.
+///
+/// The unified `.so`/`.dylib` embeds these via `--whole-archive`, but a static
+/// link must pull them in at the final binary. Emitting them as
+/// `rustc-link-lib` (which Cargo *does* propagate to transitive dependents,
+/// unlike an `-rpath` link-arg) lets downstream test binaries link a static
+/// graphviz with no runtime dependency on — and no rpath to — a shared lib in
+/// the build-output directory.
+fn emit_static_sys_libs(target_os: &str) {
+    let libs: &[&str] = match target_os {
+        // Graphviz 14.x ships C++ libraries (libstdc++), plus expat (HTML
+        // labels), zlib and libm.
+        "linux" => &["stdc++", "expat", "z", "m"],
+        // Apple: libc++ for the C++ libs; expat + zlib live in the SDK. libm is
+        // part of libSystem, so it needs no explicit flag.
+        "macos" => &["c++", "expat", "z"],
+        // build-windows.sh builds Graphviz with expat disabled and the MSVC C++
+        // runtime is linked automatically; zlib is merged into the static lib.
+        "windows" => &[],
+        _ => &[],
+    };
+    for lib in libs {
+        println!("cargo:rustc-link-lib=dylib={lib}");
+    }
+}
+
 fn try_env_override() -> bool {
     let Some(dir) = ["GRAPHVIZ_ANYWHERE_DIR", "GRAPHVIZ_NATIVE_DIR"]
         .iter()
@@ -63,6 +89,7 @@ fn try_prebuilt(manifest_dir: &Path) -> bool {
         if lib.exists() {
             emit_search_path(&dir, false);
             println!("cargo:rustc-link-lib=static=graphviz_api");
+            emit_static_sys_libs(&target_os);
             return true;
         }
     }
@@ -106,6 +133,7 @@ fn try_prebuilt(manifest_dir: &Path) -> bool {
         if lib.exists() {
             emit_search_path(&dir, false);
             println!("cargo:rustc-link-lib=static=graphviz_api");
+            emit_static_sys_libs(&target_os);
             return true;
         }
     }
@@ -121,12 +149,14 @@ fn try_repo_output(manifest_dir: &Path) -> bool {
     let target = env::var("TARGET").unwrap_or_default();
     let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
 
-    // Determine whether we expect a static or dynamic lib for this target.
-    // Only iOS links statically: a static archive cannot embed the C++ runtime
-    // / expat, so desktop targets — including macOS — link the self-contained
-    // shared library (.so/.dylib). Reuse the single `asset_is_static` policy so
-    // the repo-output path and the download fallback can never diverge.
-    let prefer_static = asset_is_static(&target);
+    // Desktop targets (Linux/macOS/Windows) and iOS link the *static* archive,
+    // pulling its system-library dependencies in via `emit_static_sys_libs`.
+    // This keeps downstream test binaries free of an rpath to the output dir
+    // (Cargo does not propagate `-rpath` link-args to dependents), which
+    // otherwise makes `cargo test --workspace` fail to load the shared lib on
+    // macOS. Android keeps the shared `.so`, loaded by the React-Native runtime.
+    let prefer_static =
+        is_ios_target(&target) || matches!(target_os.as_str(), "linux" | "macos" | "windows");
 
     // ── Collect candidate directories ────────────────────────────────────────
 
@@ -176,10 +206,18 @@ fn try_repo_output(manifest_dir: &Path) -> bool {
         }
 
         if want_static {
-            let static_lib = dir.join("libgraphviz_api.a");
+            // Unix uses `libgraphviz_api.a`; Windows uses the lib.exe-merged
+            // `graphviz_api_static.lib` (plain `graphviz_api.lib` is the import
+            // library for the DLL).
+            let (static_lib, link_name) = if target_os == "windows" {
+                (dir.join("graphviz_api_static.lib"), "graphviz_api_static")
+            } else {
+                (dir.join("libgraphviz_api.a"), "graphviz_api")
+            };
             if static_lib.exists() {
                 emit_search_path(&dir, false);
-                println!("cargo:rustc-link-lib=static=graphviz_api");
+                println!("cargo:rustc-link-lib=static={link_name}");
+                emit_static_sys_libs(&target_os);
                 return true;
             }
         } else {

--- a/crates/graphviz-anywhere/packages/rust/build.rs
+++ b/crates/graphviz-anywhere/packages/rust/build.rs
@@ -25,6 +25,35 @@ fn emit_search_path(dir: &Path, dynamic: bool) {
 /// unlike an `-rpath` link-arg) lets downstream test binaries link a static
 /// graphviz with no runtime dependency on — and no rpath to — a shared lib in
 /// the build-output directory.
+/// Link a static archive, isolating it in `OUT_DIR` first.
+///
+/// On macOS the Apple linker has no `-Bstatic`, so rust cannot force a
+/// name-based `-l` to pick the `.a` over a sibling `.dylib` with the same name
+/// in the same search directory — `ld` then prefers the `.dylib` and the binary
+/// ends up with an `@rpath` load command that fails at runtime. Copying the
+/// archive into `OUT_DIR` (which holds no competing dylib) and pointing the
+/// search path there forces a genuine static link. The emitted
+/// `rustc-link-search` / `rustc-link-lib` propagate to downstream binaries
+/// (unlike an `-rpath` link-arg), so transitive test binaries link it too.
+fn emit_static_link(static_lib: &Path, link_name: &str) {
+    if let (Some(out_dir), Some(file_name)) = (
+        env::var_os("OUT_DIR").map(PathBuf::from),
+        static_lib.file_name(),
+    ) {
+        let staged = out_dir.join(file_name);
+        if std::fs::copy(static_lib, &staged).is_ok() {
+            println!("cargo:rustc-link-search=native={}", out_dir.display());
+            println!("cargo:rustc-link-lib=static={link_name}");
+            return;
+        }
+    }
+    // Fallback (e.g. OUT_DIR unset): link straight from the source directory.
+    if let Some(dir) = static_lib.parent() {
+        println!("cargo:rustc-link-search=native={}", dir.display());
+    }
+    println!("cargo:rustc-link-lib=static={link_name}");
+}
+
 fn emit_static_sys_libs(target_os: &str) {
     let libs: &[&str] = match target_os {
         // Graphviz 14.x ships C++ libraries (libstdc++), plus expat (HTML
@@ -87,8 +116,7 @@ fn try_prebuilt(manifest_dir: &Path) -> bool {
         let dir = manifest_dir.join("prebuilt").join(subdir);
         let lib = dir.join(lib_name);
         if lib.exists() {
-            emit_search_path(&dir, false);
-            println!("cargo:rustc-link-lib=static=graphviz_api");
+            emit_static_link(&lib, "graphviz_api");
             emit_static_sys_libs(&target_os);
             return true;
         }
@@ -131,8 +159,7 @@ fn try_prebuilt(manifest_dir: &Path) -> bool {
         };
         let lib = dir.join(lib_name);
         if lib.exists() {
-            emit_search_path(&dir, false);
-            println!("cargo:rustc-link-lib=static=graphviz_api");
+            emit_static_link(&lib, "graphviz_api");
             emit_static_sys_libs(&target_os);
             return true;
         }
@@ -215,8 +242,7 @@ fn try_repo_output(manifest_dir: &Path) -> bool {
                 (dir.join("libgraphviz_api.a"), "graphviz_api")
             };
             if static_lib.exists() {
-                emit_search_path(&dir, false);
-                println!("cargo:rustc-link-lib=static={link_name}");
+                emit_static_link(&static_lib, link_name);
                 emit_static_sys_libs(&target_os);
                 return true;
             }

--- a/crates/graphviz-anywhere/packages/rust/src/build_helpers.rs
+++ b/crates/graphviz-anywhere/packages/rust/src/build_helpers.rs
@@ -346,9 +346,8 @@ mod tests {
         assert!(asset_is_static("aarch64-apple-ios"));
         assert!(asset_is_static("aarch64-apple-ios-sim"));
         assert!(asset_is_static("x86_64-apple-ios"));
-        // Desktop and Android link the self-contained shared library, so a
-        // static `.a` must never be preferred for them (build.rs derives
-        // `prefer_static` from this function).
+        // The published release asset for desktop/Android is the self-contained
+        // shared library (.so/.dylib), not a static archive.
         assert!(!asset_is_static("x86_64-unknown-linux-gnu"));
         assert!(!asset_is_static("aarch64-unknown-linux-gnu"));
         assert!(!asset_is_static("aarch64-apple-darwin"));


### PR DESCRIPTION
Follow-up to #11. #11 made desktop targets link the self-contained shared lib, which needs an rpath/DLL next to each consumer. Cargo does **not** propagate the `-rpath` link-arg to transitive dependents, so on macOS `cargo test --workspace` aborted with `dyld: Library not loaded: @rpath/libgraphviz_api.dylib` unless `DYLD_LIBRARY_PATH` was set (verified on s67).

## Fix

Link the **complete static archive** on desktop (Linux/macOS/Windows) and emit its system-library deps via `rustc-link-lib`, which *does* propagate:

- `prefer_static` now covers Linux/macOS/Windows + iOS; Android keeps the `.so` (loaded by the RN runtime).
- `emit_static_sys_libs`: Linux `stdc++ expat z m`; macOS `c++ expat z`; Windows none (MSVC C++ runtime auto-links, expat disabled, zlib merged).
- Windows links the `lib.exe`-merged `graphviz_api_static.lib` (the plain `graphviz_api.lib` is the DLL import lib).
- **`emit_static_link`**: copies the archive into `OUT_DIR` and points the search path there. The Apple linker has no `-Bstatic`, so a name-based `-l static=graphviz_api` otherwise picks a sibling `.dylib` of the same name in the build-output dir; isolating the `.a` forces a genuine static link. `try_prebuilt` uses the same path.

No rpath, no runtime shared-lib/DLL lookup; `cargo test --workspace` now runs the native chain out of the box on every desktop OS.

## Verification (built from source, no `DYLD_LIBRARY_PATH`/`LD_LIBRARY_PATH`)

| Platform | Link | Result |
|---|---|---|
| Linux x86_64 | `-l static=graphviz_api` from `OUT_DIR` | 6795 passed; downstream binaries run out of the box |
| macOS arm64 (s67) | `-l static=graphviz_api`; `otool -L` shows **no** `@rpath/...dylib` | whole workspace runs out of the box |
| Windows x64 (s69) | `-l static=graphviz_api_static`; `dumpbin` shows **no** `graphviz_api.dll` | `graphviz-anywhere` 58 passed |

The only remaining failures across platforms are **pre-existing, link-unrelated rendering baseline drifts** (Svek SVG coordinate float-drift on Linux/macOS; an embedded-CSS `font-family` byte diff in `d2-little`, which has no graphviz dependency) — the issue-#5 baseline class, tracked separately.

## Notes

- Building the native lib from source on a fresh host needs the platform toolchain the CI runners pre-install (cmake; on Windows additionally Python3 + bison/flex + getopt). The build scripts assume these are present.
- Adds `asset_is_static` unit tests carried over from #11's policy; `prefer_static` is now its own desktop-static decision (no longer derived from `asset_is_static`, which describes the download asset).