### PR TITLE
fix(lint): treat embedded interactive runtime JS as an asset (restores plantuml reference baselines)

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -79,6 +79,10 @@ module.exports = {
     'crates/d2-little/setup.js',
     'crates/mermaid-little/src/katex/vendor/**',
     'crates/mermaid-little/src/cose_bilkent_js/**',
+    // Interactive runtime injected verbatim into rendered SVGs and compared
+    // byte-for-byte by the reference tests — linting/auto-fixing it silently
+    // changes the rendered output, so treat it as an embedded asset.
+    'crates/plantuml-little/src/render/interactive/**',
 
     // docs build outputs / caches
     'docs/public/preview/',

--- a/crates/plantuml-little/src/render/interactive/default.js
+++ b/crates/plantuml-little/src/render/interactive/default.js
@@ -39,7 +39,7 @@
 	function getEdgesAndDistance1Nodes(startingNode) {
 		const nodeName = startingNode.getAttribute("data-entity");
 		const escapedNodeName = escapeForCssAttributeSelector(nodeName);
-		const results = new Set();
+		let results = new Set();
 
         svg.querySelectorAll(`.link[data-entity-1="${escapedNodeName}"], .link[data-entity-2="${escapedNodeName}"]`).forEach(link => {
             const linkStartNodeName = link.getAttribute("data-entity-1");

--- a/crates/plantuml-little/src/render/interactive/sequencediagram.js
+++ b/crates/plantuml-little/src/render/interactive/sequencediagram.js
@@ -123,7 +123,7 @@
 	function initFloatingHeader() {
 	    try {
 	        const header = groupParticipantHeaders()
-            createFloatingHeaderToggleButton(header);
+            const toggleButton = createFloatingHeaderToggleButton(header);
             const floatingHeaderElement = createFloatingHeader(header)
 
             svgRoot.querySelectorAll("g.floating-header-toggle-button").forEach(button => {
@@ -147,6 +147,7 @@
 
             const isFloatingHeaderActive = window.localStorage?.getItem(LOCAL_STORAGE_FLOATING_HEADER_ACTIVE) === "true";
             svgRoot.classList.toggle("floating-header-active", isFloatingHeaderActive);
+            console.log("In accordance with local storage, setting floating header active = ", isFloatingHeaderActive);
 
         } catch(e) {
             console.error("Error while initialising floating header:", e, svgRoot);


### PR DESCRIPTION
## Problem

`crates/plantuml-little/src/render/interactive/{default,sequencediagram}.js` are `include_str!`'d **verbatim into rendered SVGs** and compared byte-for-byte by `plantuml-little`'s `reference_tests`. The repo-wide lint hardening (#10) auto-fixed them — `let`→`const`, dropped an unused var, removed a debug `console.log` — which silently changed the rendered SVG output and broke the reference baselines.

CI did not catch it because supramark CI does not run these Rust reference tests (only native `cargo test`, run manually / on s67·s69, surfaced it).

## Fix

- Add `crates/plantuml-little/src/render/interactive/**` to ESLint `ignorePatterns`, alongside the existing vendored runtime bundles (`mathjax.js`, `katex/vendor`, `cose_bilkent_js`). This embedded runtime is an output asset, not source to be reformatted.
- Restore the three bytes so the embedded JS matches the baselines again.

## Verification

`cargo test -p plantuml-little --test reference_tests` (native, Linux): **256 passed / 6 failed → 262 / 0**. The two changed `.js` files are now byte-identical to their pre-#10 state.

## Note

All 6 previously-failing fixtures on Linux were this embedded-JS regression. The separate ~2px Graphviz coordinate drift seen only on **macOS** (s67) is unrelated: the baselines are Linux-generated and Linux native Graphviz reproduces them exactly; macOS native renders text with macOS fonts (via pango), giving a sub-pixel text-width difference. That is a cross-platform font/text-rendering difference, not an upstream-fidelity regression, and is not addressed here.