### PR TITLE
docs(plantuml-little): DejaVu font prerequisite for native reference tests

### DIFF
--- a/crates/plantuml-little/README.md
+++ b/crates/plantuml-little/README.md
@@ -30,6 +30,16 @@ Two Graphviz execution modes are supported:
 - `native` (default): links against [`graphviz-anywhere`](https://github.com/Actrium/graphviz-anywhere)'s prebuilt `libgraphviz_api` — fast, no Node required; recommended for `cargo test --lib` / day-to-day development.
 - `wasm` (opt-in via `PLANTUML_LITTLE_TEST_BACKEND=wasm`): spawns the same Node/wasm runner the Java reference pipeline uses; this is what CI runs for `test-reference` to guarantee cross-platform determinism.
 
+> **Font prerequisite for the `native` backend on non-Linux hosts.** The native Graphviz build measures real text through pango/fontconfig, so the reference baselines only reproduce byte-exact on a machine where fontconfig resolves `DejaVu Sans` to the same font the baselines were generated with. A fresh macOS has no DejaVu installed, so fontconfig silently falls back to a system face (e.g. Hiragino Sans) — that shifts `textLength` and layout coordinates by a pixel or two and the reference tests fail even though nothing is wrong with the code. Install DejaVu before running the native reference suite:
+>
+> ```sh
+> brew install --cask font-dejavu   # macOS; Linux: apt install fonts-dejavu-core
+> fc-cache -f
+> fc-match "DejaVu Sans"            # must report DejaVuSans.ttf, not a system fallback
+> ```
+>
+> CI sidesteps this entirely by running the `wasm` backend, whose font metrics are baked into `src/font_data.rs` and host-independent.
+
 See `tests/reference/VERSION` for the exact jar / JDK / Graphviz / font-stack snapshot the current baseline was produced against.
 
 ## Supported Diagram Types (29)

--- a/crates/plantuml-little/README.zh.md
+++ b/crates/plantuml-little/README.zh.md
@@ -30,6 +30,16 @@ Graphviz 有两种执行模式：
 - `native`（默认）：链接 [`graphviz-anywhere`](https://github.com/Actrium/graphviz-anywhere) 的预编译 `libgraphviz_api`，速度快、无需 Node；日常 `cargo test --lib` / 开发调试推荐此模式。
 - `wasm`（通过 `PLANTUML_LITTLE_TEST_BACKEND=wasm` 开启）：启动与 Java reference 管线相同的 Node/wasm runner；CI 的 `test-reference` 任务采用这种模式以保证跨平台可重放。
 
+> **非 Linux 主机上跑 `native` 后端的字体前置条件。** native 的 Graphviz 构建会经 pango/fontconfig 真实测量文本，因此只有当 fontconfig 把 `DejaVu Sans` 解析到与基线生成时相同的字体，reference 基线才能逐字复现。全新的 macOS 没装 DejaVu，fontconfig 会静默回落到系统字体（例如 Hiragino Sans）——这会让 `textLength` 与布局坐标偏移一两个像素，于是代码明明没问题、reference 测试却挂掉。跑 native reference 套件前先装 DejaVu：
+>
+> ```sh
+> brew install --cask font-dejavu   # macOS；Linux：apt install fonts-dejavu-core
+> fc-cache -f
+> fc-match "DejaVu Sans"            # 必须报告 DejaVuSans.ttf，而不是系统回落字体
+> ```
+>
+> CI 直接走 `wasm` 后端绕开了这个问题：wasm 的字体度量已固化进 `src/font_data.rs`，与主机无关。
+
 当前基线对应的完整环境快照见 `tests/reference/VERSION`（jar 版本、JDK、Graphviz、字体栈）。
 
 ## 支持的图表类型（29 种完整实现）


### PR DESCRIPTION
Documents that the `native` Graphviz reference suite needs DejaVu Sans installed on non-Linux hosts.

## Why
The native backend measures text via pango/fontconfig. A fresh macOS has no DejaVu, so fontconfig falls back to a system face (e.g. Hiragino Sans), shifting `textLength`/layout coordinates by a pixel or two and failing the reference suite even though the code is correct. Verified on s67 (Apple Silicon): installing `font-dejavu` + `fc-cache -f` turns the native plantuml reference suite from coordinate-drift failures into **262 passed / 0 failed**, byte-exact with the Linux baseline.

## Change
Doc-only. Both `README.md` and `README.zh.md` gain a short note with the install/verify steps (`brew install --cask font-dejavu` / `apt install fonts-dejavu-core`, `fc-cache -f`, `fc-match "DejaVu Sans"`). No code or baselines touched; CI runs the host-independent wasm backend and is unaffected.