### PR TITLE
fix: Windows path portability (drive-letter URL bug + tests hardcoding /tmp)

### DIFF
--- a/crates/mermaid-little/tests/gen_svg.rs
+++ b/crates/mermaid-little/tests/gen_svg.rs
@@ -25,9 +25,9 @@ fn gen_fixture_svg() {
         }
         match mermaid_little::convert_with_id(&source, &id) {
             Ok(svg) => {
-                let out = format!("/tmp/our_{}.svg", num);
+                let out = std::env::temp_dir().join(format!("our_{}.svg", num));
                 std::fs::write(&out, &svg).unwrap();
-                eprintln!("{}: {} bytes -> {}", num, svg.len(), out);
+                eprintln!("{}: {} bytes -> {}", num, svg.len(), out.display());
             }
             Err(e) => eprintln!("ERR {}: {}", num, e),
         }

--- a/crates/plantuml-little/src/dot/graphviz.rs
+++ b/crates/plantuml-little/src/dot/graphviz.rs
@@ -290,8 +290,10 @@ mod tests {
 
     #[test]
     fn exe_state_check_directory() {
-        let p = Path::new("/tmp");
-        assert_eq!(ExeState::check_file(Some(p)), ExeState::IsADirectory);
+        // Use the platform temp dir rather than a hard-coded "/tmp", which does
+        // not exist on Windows (there it would resolve to DoesNotExist).
+        let p = std::env::temp_dir();
+        assert_eq!(ExeState::check_file(Some(&p)), ExeState::IsADirectory);
     }
 
     #[test]

--- a/crates/plantuml-little/src/preproc/mod.rs
+++ b/crates/plantuml-little/src/preproc/mod.rs
@@ -2196,11 +2196,25 @@ impl Context {
         parse_int_like(&expanded)
     }
 
+    /// Parse a source key as a URL, but reject Windows drive-letter paths.
+    /// A bare path like `c:\dir\file.puml` parses as a URL whose scheme is the
+    /// single-letter drive (`c`), which would otherwise hijack the path-based
+    /// `%filename()` / `%dirpath()` logic. Real URLs we handle (http/https/file)
+    /// always have multi-character schemes, so a one-character scheme means we
+    /// are looking at a filesystem path and should fall through to `Path`.
+    fn parse_source_url(source_key: &str) -> Option<Url> {
+        let url = Url::parse(source_key).ok()?;
+        if url.scheme().len() == 1 {
+            return None;
+        }
+        Some(url)
+    }
+
     fn current_filename_text(&self) -> String {
         let Some(source_key) = self.current_source_key() else {
             return String::new();
         };
-        if let Ok(url) = Url::parse(source_key) {
+        if let Some(url) = Self::parse_source_url(source_key) {
             return url
                 .path_segments()
                 .and_then(|mut segments| segments.next_back())
@@ -2217,7 +2231,7 @@ impl Context {
 
     fn current_dirpath_text(&self) -> String {
         if let Some(source_key) = self.current_source_key() {
-            if let Ok(url) = Url::parse(source_key) {
+            if let Some(url) = Self::parse_source_url(source_key) {
                 return parent_url(&url).to_string();
             }
             if let Some(parent) = Path::new(source_key).parent() {

--- a/crates/plantuml-little/tests/port_dot.rs
+++ b/crates/plantuml-little/tests/port_dot.rs
@@ -156,8 +156,10 @@ mod exe_state_tests {
     #[test]
     fn check_file_directory_returns_is_a_directory() {
         // Java: assertEquals(ExeState.IS_A_DIRECTORY, ExeState.checkFile(dir))
-        let p = Path::new("/tmp");
-        assert_eq!(ExeState::check_file(Some(p)), ExeState::IsADirectory);
+        // Use the platform temp dir rather than a hard-coded "/tmp", which does
+        // not exist on Windows (there it would resolve to DoesNotExist).
+        let p = std::env::temp_dir();
+        assert_eq!(ExeState::check_file(Some(&p)), ExeState::IsADirectory);
     }
 
     #[test]


### PR DESCRIPTION
Fixes the non-graphviz Windows test failures surfaced by a full `--no-fail-fast` run on s69.

## Real bug — `%filename()` / `%dirpath()` on Windows
`current_filename_text` / `current_dirpath_text` ran `Url::parse(source_key)` first. On Windows the source key is a drive-letter path like `c:\…\sample.puml`, which parses as a URL whose **scheme is the single-letter drive** (`c`). The code then took the URL branch: `path_segments()` returns `None` for such cannot-be-a-base URLs, so `%filename()` returned **empty** and `%dirpath()` returned the **whole path**. Fix: reject one-character schemes (`Self::parse_source_url`) so drive-letter paths fall through to `Path::file_name()` / `Path::parent()`.

Observed on s69 before the fix: `file=` (empty), `dir=c:\…\sample.puml`.

## Test portability — hardcoded `/tmp`
Three tests assumed `/tmp` exists. On Windows it does not, so `ExeState::check_file` correctly returned `DoesNotExist` (not `IsADirectory`) and the mermaid writer hit `ERROR_PATH_NOT_FOUND`. Switched to `std::env::temp_dir()`:
- `graphviz.rs::exe_state_check_directory`
- `port_dot.rs::check_file_directory_returns_is_a_directory`
- `mermaid-little/tests/gen_svg.rs` (fixture writer)

`ExeState::check_file` itself was already cross-platform (`path.exists()` / `is_dir()`); only the test inputs were Unix-specific.

## Verification
All four tests pass on **Linux** and on **Windows s69** (real machine, branch checked out and recompiled). No behavior change on Unix: a non-drive path never parsed as a URL there, so the guard is a no-op.

## Not included (separate)
The 42 graphviz-laid-out plantuml fixtures still drift on the Windows **native** backend because `build-windows.sh` omits `gvplugin_pango`, so Graphviz uses estimated text metrics instead of real font metrics (same family as macOS-before-DejaVu). That is a build/backend concern tracked separately.