### PR TITLE
docs(plantuml-little): Windows native backend lacks pango — use wasm for reference

### DIFF
--- a/crates/plantuml-little/README.md
+++ b/crates/plantuml-little/README.md
@@ -39,6 +39,18 @@ Two Graphviz execution modes are supported:
 > ```
 >
 > CI sidesteps this entirely by running the `wasm` backend, whose font metrics are baked into `src/font_data.rs` and host-independent.
+>
+> **Windows has no usable `native` reference path.** `scripts/build-windows.sh`
+> builds Graphviz without the `gvplugin_pango` plugin (there is no fontconfig
+> stack on the MSVC runner), so native Graphviz falls back to its built-in
+> *estimated* text metrics instead of real font measurements. Graph-laid-out
+> diagram types (class, component, object, state, ER, etc.) then drift in layout
+> coordinates versus the baselines — e.g. a CLASS diagram comes out `143px` tall
+> instead of `220px`. Diagram types that plantuml-little lays out itself
+> (sequence, usecase, activity, wire, …) still pass. Run the reference suite with
+> the `wasm` backend on Windows: `PLANTUML_LITTLE_TEST_BACKEND=wasm` (the same
+> backend CI uses), which needs the `@actrium/graphviz-anywhere-web` package
+> available to the Node runner under `tests/support`.
 
 See `tests/reference/VERSION` for the exact jar / JDK / Graphviz / font-stack snapshot the current baseline was produced against.
 

--- a/crates/plantuml-little/README.zh.md
+++ b/crates/plantuml-little/README.zh.md
@@ -39,6 +39,16 @@ Graphviz 有两种执行模式：
 > ```
 >
 > CI 直接走 `wasm` 后端绕开了这个问题：wasm 的字体度量已固化进 `src/font_data.rs`，与主机无关。
+>
+> **Windows 上没有可用的 `native` reference 路径。** `scripts/build-windows.sh`
+> 构建 Graphviz 时不带 `gvplugin_pango` 插件（MSVC 上没有 fontconfig 体系），
+> native Graphviz 因此退回内置的*估算*文字度量、而非真实字体测量。于是由
+> graphviz 排版的图种（class、component、object、state、ER 等）布局坐标会偏离
+> 基线——例如一个 CLASS 图算出来高 `143px` 而非 `220px`。由 plantuml-little
+> 自己排版的图种（sequence、usecase、activity、wire……）仍然通过。Windows 上请
+> 用 `wasm` 后端跑 reference 套件：`PLANTUML_LITTLE_TEST_BACKEND=wasm`（与 CI
+> 同一后端），它需要 `tests/support` 下的 Node runner 能拿到
+> `@actrium/graphviz-anywhere-web` 包。
 
 当前基线对应的完整环境快照见 `tests/reference/VERSION`（jar 版本、JDK、Graphviz、字体栈）。
 


### PR DESCRIPTION
Extends the existing font-prerequisite note to cover Windows.

`scripts/build-windows.sh` builds Graphviz without `gvplugin_pango` (no fontconfig stack on the MSVC runner), so the native backend uses estimated text metrics. Graph-laid-out plantuml diagram types (class/component/object/state/ER) then drift in layout coordinates versus the baselines (e.g. a CLASS diagram 143px vs 220px tall); self-laid-out types (sequence/usecase/wire/…) still pass. Documents running the reference suite with `PLANTUML_LITTLE_TEST_BACKEND=wasm` on Windows, the same backend CI uses. Doc-only; English + Chinese READMEs kept in sync.