### PR TITLE
fix(rn): d2 图表 SVG 根属性精确清理，修复内层 viewport 被破坏

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,8 +85,11 @@ jobs:
       - name: Build in-tree wasm packages
         run: bun run build:wasm
 
-      - name: Run tests
+      - name: Run core tests (coverage)
         run: bun run test:core -- --coverage
+
+      - name: Run workspace tests (features / renderers / engines)
+        run: bun run --filter '@supramark/feature-*' --filter '@supramark/rn' --filter '@supramark/engines' --if-present test
 
       - name: Upload coverage to Codecov
         if: matrix.node-version == '20.x'

--- a/packages/renderers/rn/__tests__/svgUtils.test.ts
+++ b/packages/renderers/rn/__tests__/svgUtils.test.ts
@@ -1,0 +1,44 @@
+import { describe, test, expect } from 'bun:test';
+import { stripRootSvgSize } from '../src/svgUtils';
+
+describe('stripRootSvgSize', () => {
+  test('d2 双层嵌套：外层无 width/height 时原样返回，内层 viewport 保留', () => {
+    const svg =
+      '<svg xmlns="http://www.w3.org/2000/svg">' +
+      '<svg class="d2-svg" width="350" height="400" viewBox="-1 -1 350 400">' +
+      '<g/></svg></svg>';
+    expect(stripRootSvgSize(svg)).toBe(svg);
+  });
+
+  test('d2 + scale：外层 width/height 被删，内层 d2-svg 完整保留', () => {
+    const svg =
+      '<svg xmlns="http://www.w3.org/2000/svg" width="700" height="800">' +
+      '<svg class="d2-svg" width="350" height="400" viewBox="-1 -1 350 400">' +
+      '<g/></svg></svg>';
+    const result = stripRootSvgSize(svg);
+    expect(result).not.toContain('width="700"');
+    expect(result).not.toContain('height="800"');
+    expect(result).toContain(
+      '<svg class="d2-svg" width="350" height="400" viewBox="-1 -1 350 400">'
+    );
+  });
+
+  test('mermaid：根 width="100%" 被删且不留双空格，viewBox 与 id 保留', () => {
+    const svg =
+      '<svg id="mermaid-abc123" width="100%" viewBox="0 0 100 50" xmlns="http://www.w3.org/2000/svg">' +
+      '<g/></svg>';
+    const result = stripRootSvgSize(svg);
+    expect(result).not.toContain('width=');
+    expect(result).toContain('viewBox="0 0 100 50"');
+    expect(result).toContain('id="mermaid-abc123"');
+    expect(result).not.toContain('"  ');
+  });
+
+  test('根属性含 $ 模式字符：函数式 replacement 不被替换模式吃掉', () => {
+    const svg = '<svg width="100%" height="50" data-token="$&amp;bar"><g/></svg>';
+    const result = stripRootSvgSize(svg);
+    expect(result).toContain('data-token="$&amp;bar"');
+    expect(result).not.toContain('width=');
+    expect(result).not.toContain('height=');
+  });
+});

--- a/packages/renderers/rn/package.json
+++ b/packages/renderers/rn/package.json
@@ -6,7 +6,8 @@
   "types": "src/index.ts",
   "license": "Apache-2.0",
   "scripts": {
-    "build": "tsc -p tsconfig.json"
+    "build": "tsc -p tsconfig.json",
+    "test": "bun test"
   },
   "peerDependencies": {
     "react": ">=18.0.0",

--- a/packages/renderers/rn/src/DiagramNode.tsx
+++ b/packages/renderers/rn/src/DiagramNode.tsx
@@ -142,9 +142,18 @@ export const DiagramNode: React.FC<DiagramNodeProps> = ({ node, diagramConfig })
       );
     }
 
-    scalableSvg = scalableSvg
-      .replace(/(<svg[^>]*)\bwidth="[^"]*"/, '$1')
-      .replace(/(<svg[^>]*)\bheight="[^"]*"/, '$1');
+    // 只删除根 <svg> 的 width/height，让 SvgXml 的 width="100%" + 算好的 height 接管。
+    // 必须只精确匹配第一个 <svg>：d2 输出的是两层嵌套 svg——外层无 width/height，
+    // 内层 d2-svg 带 width/height 且 viewBox="left top W H"（left/top 是 padding 偏移，常非零）。
+    // 若用全局正则误删内层 width/height，Android 上 react-native-svg 会用 viewBox 维度
+    // 当固有尺寸并叠加 left/top 偏移，内容被放大裁切，只剩左上角可见。
+    const rootSvgMatch = scalableSvg.match(/<svg\b([^>]*)>/);
+    if (rootSvgMatch) {
+      const cleanedAttrs = rootSvgMatch[1]
+        .replace(/\s+width="[^"]*"/, '')
+        .replace(/\s+height="[^"]*"/, '');
+      scalableSvg = scalableSvg.replace(rootSvgMatch[0], `<svg${cleanedAttrs}>`);
+    }
 
     return (
       <View style={[styles.diagram, { width: containerWidth, height }]} onLayout={handleLayout}>

--- a/packages/renderers/rn/src/DiagramNode.tsx
+++ b/packages/renderers/rn/src/DiagramNode.tsx
@@ -11,7 +11,7 @@ import { SvgXml } from 'react-native-svg';
 import type { SupramarkDiagramNode, SupramarkDiagramConfig } from '@supramark/core';
 import { type DiagramRenderResult } from '@supramark/engines';
 import { createReactNativeDiagramEngine } from '@supramark/engines/rn';
-import { normalizeSvg, normalizeSvgLight } from './svgUtils';
+import { normalizeSvg, normalizeSvgLight, stripRootSvgSize } from './svgUtils';
 
 export interface DiagramNodeProps {
   node: SupramarkDiagramNode;
@@ -142,18 +142,7 @@ export const DiagramNode: React.FC<DiagramNodeProps> = ({ node, diagramConfig })
       );
     }
 
-    // 只删除根 <svg> 的 width/height，让 SvgXml 的 width="100%" + 算好的 height 接管。
-    // 必须只精确匹配第一个 <svg>：d2 输出的是两层嵌套 svg——外层无 width/height，
-    // 内层 d2-svg 带 width/height 且 viewBox="left top W H"（left/top 是 padding 偏移，常非零）。
-    // 若用全局正则误删内层 width/height，Android 上 react-native-svg 会用 viewBox 维度
-    // 当固有尺寸并叠加 left/top 偏移，内容被放大裁切，只剩左上角可见。
-    const rootSvgMatch = scalableSvg.match(/<svg\b([^>]*)>/);
-    if (rootSvgMatch) {
-      const cleanedAttrs = rootSvgMatch[1]
-        .replace(/\s+width="[^"]*"/, '')
-        .replace(/\s+height="[^"]*"/, '');
-      scalableSvg = scalableSvg.replace(rootSvgMatch[0], `<svg${cleanedAttrs}>`);
-    }
+    scalableSvg = stripRootSvgSize(scalableSvg);
 
     return (
       <View style={[styles.diagram, { width: containerWidth, height }]} onLayout={handleLayout}>

--- a/packages/renderers/rn/src/svgUtils.ts
+++ b/packages/renderers/rn/src/svgUtils.ts
@@ -140,3 +140,21 @@ export function normalizeSvg(xml: string): string {
 
   return normalized;
 }
+
+/**
+ * 精确删除根 <svg> 的 width/height，让外层容器的尺寸接管渲染。
+ *
+ * 只匹配第一个 <svg>：d2 输出两层嵌套 svg，内层 d2-svg 自带 width/height 且
+ * viewBox 带非零 left/top 偏移；若用全局正则误删内层 width/height，Android 上
+ * react-native-svg 会用 viewBox 维度当固有尺寸并叠加偏移，内容放大裁切只剩左上角。
+ *
+ * replacement 用函数式：避免根属性值里的 $ 被当作替换模式（$& / $` / $'）解释。
+ */
+export function stripRootSvgSize(xml: string): string {
+  const rootSvgMatch = xml.match(/<svg\b([^>]*)>/);
+  if (!rootSvgMatch) return xml;
+  const cleanedAttrs = rootSvgMatch[1]
+    .replace(/\s+width="[^"]*"/, '')
+    .replace(/\s+height="[^"]*"/, '');
+  return xml.replace(rootSvgMatch[0], () => `<svg${cleanedAttrs}>`);
+}


### PR DESCRIPTION
DiagramNode 原用全局正则删除 <svg> 的 width/height，d2 输出是两层嵌套 svg——外层无 width/height，正则误删内层 d2-svg 的 width/height 及 viewBox 偏移，Android 上 react-native-svg 用 viewBox 维度当固有尺寸并叠加 left/top 偏移，内容放大裁切只剩左上角。
    
改为只精确匹配根 <svg> 删 width/height，内层 viewport 原样保留。