### PR TITLE
fix(graphviz-rn): stage the Windows runtime DLL into the npm tarball

### DIFF
--- a/crates/graphviz-anywhere/packages/react-native/scripts/prepare-native.js
+++ b/crates/graphviz-anywhere/packages/react-native/scripts/prepare-native.js
@@ -12,7 +12,7 @@
  *   ./scripts/build-ios.sh                       -> output/ios/Graphviz.xcframework
  *   ./scripts/build-android.sh                   -> output/android/<abi>/lib/libgraphviz_api.so
  *   ./scripts/build-macos.sh                     -> output/macos-universal/lib/libgraphviz_api.dylib
- *   ./scripts/build-windows.sh                   -> output/windows-x86_64/lib/graphviz_api.{lib,dll}
+ *   ./scripts/build-windows.sh                   -> output/windows-x86_64/{lib/graphviz_api.lib, bin/graphviz_api.dll}
  *
  * Then run `npm run prepare-native` (or `node scripts/prepare-native.js`).
  * Idempotent — re-running just refreshes. Missing platforms are skipped with a
@@ -47,8 +47,9 @@ const IOS_FRAMEWORKS_DEST = path.join(PKG_DIR, 'ios', 'Frameworks');
 const MACOS_LIB_SRC = path.join(OUTPUT_DIR, 'macos-universal', 'lib');
 const MACOS_FRAMEWORKS_DEST = path.join(PKG_DIR, 'macos', 'Frameworks');
 
-// ── Windows: the import lib / DLL + header. ──────────────────────────────────
+// ── Windows: the import lib (lib/) + runtime DLL (bin/) + header. ─────────────
 const WINDOWS_LIB_SRC = path.join(OUTPUT_DIR, 'windows-x86_64', 'lib');
+const WINDOWS_BIN_SRC = path.join(OUTPUT_DIR, 'windows-x86_64', 'bin');
 const WINDOWS_INCLUDE_SRC = path.join(OUTPUT_DIR, 'windows-x86_64', 'include');
 const WINDOWS_FRAMEWORKS_DEST = path.join(PKG_DIR, 'windows', 'Frameworks');
 
@@ -142,13 +143,19 @@ function prepareWindows() {
   const libDest = path.join(WINDOWS_FRAMEWORKS_DEST, 'lib');
   const incDest = path.join(WINDOWS_FRAMEWORKS_DEST, 'include');
   copyDirRecursive(WINDOWS_LIB_SRC, libDest);
+  // build-windows.sh installs the runtime graphviz_api.dll under bin/ (CMake
+  // RUNTIME DESTINATION), separate from the import lib in lib/. Stage it too —
+  // otherwise a dynamic-link consumer ships the import lib without its DLL.
+  if (fileExists(WINDOWS_BIN_SRC)) {
+    copyDirRecursive(WINDOWS_BIN_SRC, path.join(WINDOWS_FRAMEWORKS_DEST, 'bin'));
+  }
   if (fileExists(WINDOWS_INCLUDE_SRC)) {
     copyDirRecursive(WINDOWS_INCLUDE_SRC, incDest);
   } else if (fileExists(CAPI_HEADER)) {
     fs.mkdirSync(incDest, { recursive: true });
     fs.copyFileSync(CAPI_HEADER, path.join(incDest, 'graphviz_api.h'));
   }
-  console.log('OK Windows: graphviz_api libs + headers -> windows/Frameworks/');
+  console.log('OK Windows: graphviz_api lib + dll + headers -> windows/Frameworks/');
   return true;
 }
 


### PR DESCRIPTION
Follow-up to PR #20, found by validating the Windows distribution path on a
real Windows host (s69).

## Defect

`build-windows.sh` installs the runtime `graphviz_api.dll` under
`output/windows-x86_64/bin/` (CMake `RUNTIME DESTINATION`), while the import
lib `graphviz_api.lib` lands in `lib/`. `prepare-native.js` staged only `lib/`
and `include/` into `windows/Frameworks/`, so the npm package shipped the
**import lib without its runtime DLL** — a dynamic-link consumer would fail to
load graphviz at runtime.

## Fix

Stage `output/windows-x86_64/bin/` into `windows/Frameworks/bin/` as well
(the dir is already gitignored and shipped via `files[]`). Also corrects the
script header comment, which wrongly placed the DLL under `lib/`.

## Verification (on Windows / s69)

- Re-ran staging → `windows/Frameworks/bin/graphviz_api.dll` present.
- `npm pack --dry-run` now lists `windows/Frameworks/bin/graphviz_api.dll`
  (1.3 MB) alongside the lib and headers; lib/include unchanged.

## Out of scope (noted, pre-existing)

- The `prepack` script uses POSIX-sh `if command -v bob ...` syntax which
  fails under Windows `cmd.exe`, blocking `npm pack` there (portability bug,
  not the native model).
- `windows/GraphvizNative/` has no MSBuild project wiring
  (`.vcxproj`/`.props`/`.targets`) and no declared lib linkage; whether the
  DLL vs the static lib is the right consumption form depends on adding that
  wiring — a separate, larger task.