### PR TITLE
fix(rn): mermaid 图表颜色丢失与文字不显示

### DIFF
--- a/packages/renderers/rn/__tests__/svgUtils.test.ts
+++ b/packages/renderers/rn/__tests__/svgUtils.test.ts
@@ -105,13 +105,24 @@ test('normalizeSvg foreignObject 多个 <p> 文本拼接为单个 text', () => {
 // ============================================================================
 
 test('normalizeSvg 给无 fill 的 <text style> 补默认色', () => {
-  // d2 text 真实结构：style 含 text-anchor/font-size 但无 fill
+  // d2 text 真实结构：style 含 text-anchor/font-size 但无 fill，也无 fill 属性
   const input =
-    '<svg><text x="1" y="2" fill="blue" class="text-bold" style="text-anchor:middle;font-size:16px">a</text></svg>';
+    '<svg><text x="1" y="2" class="text-bold" style="text-anchor:middle;font-size:16px">a</text></svg>';
   const out = normalizeSvg(input);
   const text = out.match(/<text[^>]*>/)?.[0] ?? '';
   expect(text).toMatch(/fill: #333/);
   expect(text).toMatch(/font-family:/);
+});
+
+test('normalizeSvg text 已有 fill 属性时不补默认色（不覆盖 step-2 内联）', () => {
+  // step-2 把 class 的 fill 内联成属性后，step-3 不能再往 style 补 #333——style 优先级
+  // 高于属性，会覆盖掉正确颜色。这是 review 问题 6/8 的回归防护。
+  const input =
+    '<svg><style>.title{fill:#ff0000}</style><text class="title" style="font-size:20px">Hi</text></svg>';
+  const out = normalizeSvg(input);
+  const text = out.match(/<text[^>]*>/)?.[0] ?? '';
+  expect(text).toMatch(/fill="#ff0000"/);
+  expect(text).not.toMatch(/fill:\s*#333/);
 });
 
 test('normalizeSvg inlineColors 把 CSS 值里的双引号转单引号（防属性嵌套）', () => {
@@ -146,4 +157,122 @@ test('normalizeSvg 保护 <text> 内的裸文本不被删', () => {
   const input = '<svg><text x="0" y="0">Hello World</text></svg>';
   const out = normalizeSvg(input);
   expect(out).toContain('>Hello World<');
+});
+
+// ============================================================================
+// normalizeSvg — well-formedness 与真实多规则回归（覆盖 review 阻断缺陷）
+// ============================================================================
+
+// 自闭合形状补色后必须仍以 /> 结尾——/ 落在属性中间会让 react-native-svg 解析抛错整图空白。
+test('normalizeSvg 自闭合 rect 补色后保持 /> 结尾（阻断 1 回归）', () => {
+  const input =
+    '<svg><style>.node rect{fill:#ECECFF;stroke:#9370DB}</style>' +
+    '<g class="node"><rect class="basic label-container" width="10" height="10"/></g></svg>';
+  const out = normalizeSvg(input);
+  // 任何开标签都不能出现「/ 后跟属性」的畸形（阻断 1 的特征）
+  expect(out).not.toMatch(/\/\s+\w+="[^"]*"/);
+  const rect = out.match(/<rect[^>]*>/)?.[0] ?? '';
+  expect(rect).toMatch(/fill="#ECECFF".*\/>$/);
+});
+
+// .node rect 与 .cluster rect 末段都塌缩成 rect 时不能互相覆盖——按祖先链区分。
+test('normalizeSvg .node rect 与 .cluster rect 按祖先链分别上色（阻断 2 回归）', () => {
+  const input =
+    '<svg id="m1">' +
+    '<style>' +
+    '#m1 .node rect{fill:#ECECFF;stroke:#9370DB;stroke-width:1px}' +
+    '#m1 .cluster rect{fill:#ffffde;stroke:#aaaa33}' +
+    '</style>' +
+    '<g class="cluster"><rect class="cluster" width="200" height="200"/></g>' +
+    '<g class="node"><rect class="basic label-container" width="100" height="40"/></g>' +
+    '</svg>';
+  const out = normalizeSvg(input);
+  const rects = out.match(/<rect[^>]*>/g) ?? [];
+  const nodeRect = rects.find(r => r.includes('label-container')) ?? '';
+  const clusterRect = rects.find(r => r.includes('"cluster"')) ?? '';
+  expect(nodeRect).toMatch(/fill="#ECECFF"/);
+  expect(nodeRect).not.toMatch(/fill="#ffffde"/);
+  expect(clusterRect).toMatch(/fill="#ffffde"/);
+});
+
+// !important 必须剥离——内联成属性值后是非法语法（fill="#333 !important" 会失效变黑）。
+test('normalizeSvg 剥离 CSS 值里的 !important', () => {
+  const input =
+    '<svg><style>.root .anchor path{fill:#333 !important}</style>' +
+    '<g class="root"><g class="anchor"><path class="anchor" d="M0 0"/></g></g></svg>';
+  const out = normalizeSvg(input);
+  expect(out).not.toContain('!important');
+  expect(out).toMatch(/fill="#333"/);
+});
+
+// foreignObject 内只有 <span> 无 <p>（venn 标签）也要提取文本，不能整段删除。
+test('normalizeSvg foreignObject 内 <span> 文本也被提取', () => {
+  const input =
+    '<svg><g transform="translate(10,10)">' +
+    '<foreignObject width="40" height="16"><div xmlns="x"><span class="nodeLabel">vennLabel</span></div></foreignObject>' +
+    '</g></svg>';
+  const out = normalizeSvg(input);
+  expect(out).toContain('>vennLabel<');
+});
+
+// <br/> 是行边界，剥标签前必须转空格，否则 Line1<br/>Line2 粘成 Line1Line2。
+test('normalizeSvg foreignObject 内 <br/> 转空格避免行粘连', () => {
+  const input =
+    '<svg><foreignObject width="40" height="32">' +
+    '<div xmlns="x"><span class="nodeLabel"><p>Line1<br/>Line2</p></span></div></foreignObject></svg>';
+  const out = normalizeSvg(input);
+  expect(out).toContain('>Line1 Line2<');
+  expect(out).not.toContain('>Line1Line2<');
+});
+
+// d2 裸 <text>（无 style 无 fill）也要兜底默认色，否则默认黑。
+test('normalizeSvg 无 style 的裸 <text> 补默认 fill', () => {
+  const input = '<svg><text class="text-mono" x="0" y="10">code</text></svg>';
+  const out = normalizeSvg(input);
+  const text = out.match(/<text[^>]*>/)?.[0] ?? '';
+  expect(text).toMatch(/fill:\s*#333|fill="#333"/);
+});
+
+// 复合选择器 rect.divider 必须命中（tag + class 同段），不能把整段当 key 永不匹配。
+test('normalizeSvg 复合选择器 rect.divider 命中', () => {
+  const input =
+    '<svg><style>rect.divider{stroke:#999}</style><rect class="divider" width="1" height="1"/></svg>';
+  const out = normalizeSvg(input);
+  expect(out).toMatch(/stroke="#999"/);
+});
+
+// color: 在 CSS 语义里只设置文本颜色，对 rect 的 fill 无影响。
+// .box{fill:blue;color:red} 对 rect 应产出 fill=blue，不能被 color:red 覆盖。
+test('normalizeSvg color: 不影响 rect 的 fill（仅对 text 生效）', () => {
+  const input =
+    '<svg><style>.box{fill:blue;color:red}</style><rect class="box" width="1" height="1"/></svg>';
+  const out = normalizeSvg(input);
+  expect(out).toMatch(/fill="blue"/);
+  expect(out).not.toMatch(/fill="red"/);
+});
+
+// color: 对 text 是 fill 候选（radar 标题等用 color: 上色）。
+test('normalizeSvg color: 作为 text 的 fill 候选', () => {
+  const input =
+    '<svg><style>.title{color:#ff6600}</style><text class="title" x="0" y="0">radar</text></svg>';
+  const out = normalizeSvg(input);
+  const text = out.match(/<text[^>]*>/)?.[0] ?? '';
+  expect(text).toMatch(/fill="#ff6600"/);
+});
+
+// 整体 well-formedness：所有开标签以 > 或 /> 结尾，不残留畸形 / 在属性中间。
+test('normalizeSvg 输出所有标签 well-formed', () => {
+  const input =
+    '<svg id="m1"><style>.node rect{fill:#ECECFF}.cluster rect{fill:#ffffde}</style>' +
+    '<g class="cluster"><rect class="cluster" width="10" height="10"/></g>' +
+    '<g class="node"><rect class="basic label-container" width="10" height="10"/></g>' +
+    '<g class="node"><foreignObject width="40" height="16"><div><p>label</p></div></foreignObject></g>' +
+    '<text x="0" y="0">t</text></svg>';
+  const out = normalizeSvg(input);
+  // 不允许「/ 后跟属性」的畸形标签（阻断 1 特征）
+  expect(out).not.toMatch(/\/\s+\w+="[^"]*"/);
+  // 不允许属性值里残留 !important
+  expect(out).not.toContain('!important');
+  // 不残留 <style>
+  expect(out).not.toMatch(/<style/i);
 });

--- a/packages/renderers/rn/__tests__/svgUtils.test.ts
+++ b/packages/renderers/rn/__tests__/svgUtils.test.ts
@@ -1,0 +1,149 @@
+import { test, expect } from 'bun:test';
+import { normalizeSvg, normalizeSvgLight } from '../src/svgUtils';
+
+// ============================================================================
+// normalizeSvgLight — 轻量清理（用于 MathJax 这类已内联样式的 SVG）
+// ============================================================================
+
+test('normalizeSvgLight 删除 xml 头 / 注释 / style / title / desc / metadata', () => {
+  const input =
+    '<?xml version="1.0"?><!doctype svg><!-- c -->' +
+    '<svg xmlns="x"><title>t</title><desc>d</desc><metadata>m</metadata>' +
+    '<style>.a{fill:red}</style><rect/></svg>';
+  const out = normalizeSvgLight(input);
+  // 标签内属性空格保留，标签间空白被压缩
+  expect(out).toBe('<svg xmlns="x"><rect/></svg>');
+  expect(out).not.toMatch(/<\?xml|<!--|<style|<title|<desc|<metadata|<!doctype/i);
+});
+
+test('normalizeSvgLight 压缩标签间空白', () => {
+  expect(normalizeSvgLight('<svg>\n  <rect/>\n</svg>')).toBe('<svg><rect/></svg>');
+});
+
+// ============================================================================
+// normalizeSvg — mermaid 颜色内联
+// ============================================================================
+
+test('normalizeSvg 把 scoped CSS class 选择器的颜色内联到 rect 属性', () => {
+  // 模拟 mermaid 真实结构：rect 无 fill（靠 #id .node rect { fill:..; stroke:.. }）
+  const input =
+    '<svg id="m1" viewBox="0 0 100 100">' +
+    '<style>#m1 .node rect{fill:#ECECFF;stroke:#9370DB;stroke-width:1px}</style>' +
+    '<g class="node"><rect class="basic label-container" style="" x="0" y="0" width="10" height="10"/></g>' +
+    '</svg>';
+  const out = normalizeSvg(input);
+  const rect = out.match(/<rect[^>]*>/)?.[0] ?? '';
+  expect(rect).toMatch(/fill="#ECECFF"/);
+  expect(rect).toMatch(/stroke="#9370DB"/);
+  expect(rect).toMatch(/stroke-width="1px"/);
+  expect(out).not.toContain('<style');
+});
+
+test('normalizeSvg 元素已有 fill 属性时不覆盖', () => {
+  const input =
+    '<svg><style>.node rect{fill:#ECECFF}</style>' +
+    '<rect class="node" fill="#FF0000" width="1" height="1"/></svg>';
+  const out = normalizeSvg(input);
+  const rect = out.match(/<rect[^>]*>/)?.[0] ?? '';
+  expect(rect).toMatch(/fill="#FF0000"/);
+  expect(rect).not.toMatch(/fill="#ECECFF"/);
+});
+
+test('normalizeSvg 没有 <style> 的 SVG 不补默认色到 rect（保持原样）', () => {
+  // 无 CSS 时 inlineColors 找不到匹配的规则，rect 维持输入形态（不强行补色）
+  const input = '<svg><rect class="x" width="1" height="1"/></svg>';
+  const out = normalizeSvg(input);
+  const rect = out.match(/<rect[^>]*>/)?.[0] ?? '';
+  expect(rect).not.toMatch(/fill=/);
+});
+
+// ============================================================================
+// normalizeSvg — foreignObject → text 转换（mermaid 文字）
+// ============================================================================
+
+test('normalizeSvg 把含文本的 foreignObject 转成 <text>', () => {
+  // 模拟 mermaid 节点标签结构：foreignObject 内 div/span/p 文本
+  const input =
+    '<svg viewBox="0 0 100 100">' +
+    '<g transform="translate(50,50)">' +
+    '<foreignObject width="40" height="16">' +
+    '<div xmlns="x"><span class="nodeLabel"><p>Start</p></span></div>' +
+    '</foreignObject>' +
+    '</g></svg>';
+  const out = normalizeSvg(input);
+  expect(out).not.toContain('<foreignObject');
+  expect(out).toContain('>Start<');
+  // 转换出的 text 用 foreignObject width 居中（x=20）、height*0.7 近似基线（y≈11.2）
+  const text = out.match(/<text[^>]*>Start<\/text>/)?.[0] ?? '';
+  expect(text).toMatch(/x="20"/);
+  expect(text).toMatch(/text-anchor="middle"/);
+  expect(text).toMatch(/fill: #333/);
+});
+
+test('normalizeSvg 把空 foreignObject（width=0 或无文本）删除', () => {
+  const input =
+    '<svg><g>' +
+    '<foreignObject width="0" height="16"><div><span class="edgeLabel"></span></div></foreignObject>' +
+    '<foreignObject width="10" height="16"><div><span></span></div></foreignObject>' +
+    '</g></svg>';
+  const out = normalizeSvg(input);
+  expect(out).not.toContain('<foreignObject');
+  expect(out).not.toContain('<text');
+});
+
+test('normalizeSvg foreignObject 多个 <p> 文本拼接为单个 text', () => {
+  const input =
+    '<svg><foreignObject width="20" height="16">' +
+    '<div><p>line1</p><p>line2</p></div>' +
+    '</foreignObject></svg>';
+  const out = normalizeSvg(input);
+  expect(out).toContain('>line1 line2<');
+});
+
+// ============================================================================
+// normalizeSvg — d2 text 补色 + font-family 引号转义
+// ============================================================================
+
+test('normalizeSvg 给无 fill 的 <text style> 补默认色', () => {
+  // d2 text 真实结构：style 含 text-anchor/font-size 但无 fill
+  const input =
+    '<svg><text x="1" y="2" fill="blue" class="text-bold" style="text-anchor:middle;font-size:16px">a</text></svg>';
+  const out = normalizeSvg(input);
+  const text = out.match(/<text[^>]*>/)?.[0] ?? '';
+  expect(text).toMatch(/fill: #333/);
+  expect(text).toMatch(/font-family:/);
+});
+
+test('normalizeSvg inlineColors 把 CSS 值里的双引号转单引号（防属性嵌套）', () => {
+  // 若 CSS 的 fill/stroke 值带双引号（少见但可能），拼进 <rect fill="..."> 会嵌套。
+  // sanitizeCssValue 把双引号转单引号，保证属性合法、SvgXml 能解析。
+  const input =
+    '<svg><style>.x{fill:"weird value"}</style><rect class="x" width="1" height="1"/></svg>';
+  const out = normalizeSvg(input);
+  const rect = out.match(/<rect[^>]*>/)?.[0] ?? '';
+  expect(rect).toMatch(/fill="'weird value'"/);
+  // 整个 rect 标签不出现 "..." 内嵌 "..."（嵌套双引号会让属性提前关闭）
+  expect(rect).not.toMatch(/fill="[^"]*"[^"]+"/);
+});
+
+// ============================================================================
+// normalizeSvg — 不破坏既有结构
+// ============================================================================
+
+test('normalizeSvg 不误删 rect 的 class/style 属性（安全正则回归）', () => {
+  // 原版 />[^<]+</ 会把 rect 的 class 属性串当裸文本破坏，导致按 class 匹配 CSS 失效。
+  const input =
+    '<svg><style>.label-container{fill:#ECECFF}</style>' +
+    '<rect class="basic label-container" style="" width="1" height="1"/></svg>';
+  const out = normalizeSvg(input);
+  const rect = out.match(/<rect[^>]*>/)?.[0] ?? '';
+  // class 被保留才能让 inlineColors 匹配上 CSS、补出 fill
+  expect(rect).toMatch(/class="basic label-container"/);
+  expect(rect).toMatch(/fill="#ECECFF"/);
+});
+
+test('normalizeSvg 保护 <text> 内的裸文本不被删', () => {
+  const input = '<svg><text x="0" y="0">Hello World</text></svg>';
+  const out = normalizeSvg(input);
+  expect(out).toContain('>Hello World<');
+});

--- a/packages/renderers/rn/__tests__/svgUtils.test.ts
+++ b/packages/renderers/rn/__tests__/svgUtils.test.ts
@@ -278,6 +278,40 @@ test('normalizeSvg 输出所有标签 well-formed', () => {
 });
 
 // ============================================================================
+// 祖先 class 按词精确匹配（防子串误命中，对抗探针）
+// ============================================================================
+
+// 祖先段必须按词精确匹配，不能用字符串子串：.node 选择器不能命中 class="nodes"
+//（复数）的祖先。mermaid 里 node/nodes、cluster/clusters 成对共存，子串匹配会染错色。
+test('normalizeSvg .node 不子串命中 class="nodes" 祖先', () => {
+  const input =
+    '<svg><style>.node rect{fill:#9370DB}</style>' +
+    '<g class="nodes"><rect class="basic" width="10" height="10"/></g></svg>';
+  const out = normalizeSvg(input);
+  expect(out).not.toMatch(/fill="#9370DB"/);
+});
+
+// .label 选择器不能命中 class="edgeLabel"/"nodeLabel" 等子串祖先。
+test('normalizeSvg .label 不子串命中 class="edgeLabel" 祖先', () => {
+  const input =
+    '<svg><style>.label rect{fill:#ffffde}</style>' +
+    '<g class="edgeLabel"><rect class="basic" width="10" height="10"/></g></svg>';
+  const out = normalizeSvg(input);
+  expect(out).not.toMatch(/fill="#ffffde"/);
+});
+
+// 自闭合 <g class="x"/> 无 </g>，其 class 不应入栈泄漏给后续兄弟元素。
+test('normalizeSvg 自闭合 <g/> 的 class 不泄漏给兄弟元素', () => {
+  // 自闭合 g 带 class="node"，紧随其后的 rect 在另一个 g 里（class 为空）。
+  // 若自闭合 g 错误入栈，rect 会被误认为有 node 祖先而染上 #9370DB。
+  const input =
+    '<svg><style>.node rect{fill:#9370DB}</style>' +
+    '<g class="node"/><g><rect class="basic" width="10" height="10"/></g></svg>';
+  const out = normalizeSvg(input);
+  expect(out).not.toMatch(/fill="#9370DB"/);
+});
+
+// ============================================================================
 // stripRootSvgSize — 精确删除根 <svg> 的 width/height（来自 upstream/main）
 // ============================================================================
 

--- a/packages/renderers/rn/package.json
+++ b/packages/renderers/rn/package.json
@@ -6,7 +6,8 @@
   "types": "src/index.ts",
   "license": "Apache-2.0",
   "scripts": {
-    "build": "tsc -p tsconfig.json"
+    "build": "tsc -p tsconfig.json",
+    "test": "bun test"
   },
   "peerDependencies": {
     "react": ">=18.0.0",

--- a/packages/renderers/rn/src/svgUtils.ts
+++ b/packages/renderers/rn/src/svgUtils.ts
@@ -17,90 +17,207 @@ export function normalizeSvgLight(xml: string): string {
     .replace(/>\s+</g, '><');
 }
 
-type ColorKey = 'fill' | 'stroke' | 'stroke-width' | 'font-family' | 'font-size';
+type ColorKey = 'fill' | 'stroke' | 'stroke-width' | 'font-family' | 'font-size' | 'color';
 type CssDecls = Partial<Record<ColorKey, string>>;
 
-const COLOR_ATTRS_RE = /^(fill|stroke|stroke-width|font-family|font-size)$/;
+// color: 在 CSS 语义里只设置文本颜色，对 rect/path 的 fill 无影响。这里单独收存，
+// inlineColors 时仅对 text 元素把 color 当 fill 候选——避免 .box{fill:blue;color:red}
+// 把 rect 染成 red（应是 blue）。
+const DECL_KEY_MAP: Record<string, ColorKey | undefined> = {
+  fill: 'fill',
+  stroke: 'stroke',
+  'stroke-width': 'stroke-width',
+  'font-family': 'font-family',
+  'font-size': 'font-size',
+  color: 'color',
+};
+
+// 选择器的一段，如 `.node rect` → { tag:'rect', classes:['node'] }，`rect.divider` → { tag:'rect', classes:['divider'] }。
+type SelectorPart = { tag: string | null; classes: string[] };
+type CssRule = { selector: SelectorPart[]; decls: CssDecls };
 
 /**
- * 解析 <style> 里的 CSS 规则，按选择器末尾的 class/标签名索引。
+ * 解析 <style> 里的 CSS 规则。选择器按「祖先→自身」存为完整链，保留源序。
  *
- * mermaid/d2 的 CSS 多为 scoped：`#id .node rect { fill:#ECECFF; stroke:#9370DB; }`。
- * react-native-svg 不支持 CSS 选择器，需要把颜色内联到元素属性。这里按末尾选择器
- *（如 `#id .node rect` 取 `rect`、`.label-container` 取 `label-container`）建索引，
- * 后续按元素 class 或标签名匹配内联。同 key 多规则后者覆盖前者。
+ * mermaid/d2 的 CSS 多为 scoped：`#id .node rect { fill:#ECECFF }`。
+ * react-native-svg 不支持 CSS 选择器，需要把颜色内联到元素属性。
+ * 旧实现按选择器末段建扁平 key，导致 `.node rect` 与 `.cluster rect` 都塌缩成 `rect`
+ * 互相覆盖。这里改为保留完整祖先链，匹配时按元素的 class + 祖先 class 链逐条比对。
+ *
+ * 同选择器后写覆盖先写（CSS 源序即优先级，mermaid 输出已按特异性排好序，无需算权重）。
+ * `!important` 在此剥离——内联成属性值后是非法语法，会失效。
  */
-function parseCssRules(cssText: string): Map<string, CssDecls> {
-  const rules = new Map<string, CssDecls>();
+function parseCssRules(cssText: string): CssRule[] {
+  const rules: CssRule[] = [];
   for (const [, selectorGroup, body] of cssText.matchAll(/([^{}]+)\{([^{}]*)\}/g)) {
     const decls: CssDecls = {};
     for (const part of body.split(';')) {
       const idx = part.indexOf(':');
       if (idx <= 0) continue;
-      const key = part.slice(0, idx).trim();
-      const value = part.slice(idx + 1).trim();
-      if (COLOR_ATTRS_RE.test(key)) decls[key as ColorKey] = value;
+      const key = part.slice(0, idx).trim().toLowerCase();
+      const rawValue = part.slice(idx + 1).trim();
+      const mapped = DECL_KEY_MAP[key];
+      if (!mapped) continue;
+      // 剥 !important：内联属性值不支持，原样拷进去会让属性值非法（fill="#333 !important"）。
+      const value = rawValue.replace(/\s*!important\s*$/i, '');
+      decls[mapped] = value;
     }
     if (Object.keys(decls).length === 0) continue;
     for (const sel of selectorGroup.split(',').map(s => s.trim()).filter(Boolean)) {
-      const parts = sel.split(/\s+/).filter(Boolean);
-      const last = parts[parts.length - 1] ?? sel;
-      const key = last.startsWith('.') ? last.slice(1) : last;
-      rules.set(key, { ...(rules.get(key) ?? {}), ...decls });
+      const selector = parseSelector(sel);
+      if (selector.length === 0) continue;
+      rules.push({ selector, decls });
     }
   }
   return rules;
 }
 
+/** 解析单条选择器为祖先→自身的段链。忽略 id 与伪类；复合选择器 `.a.b rect` 合并 classes。 */
+function parseSelector(sel: string): SelectorPart[] {
+  const parts: SelectorPart[] = [];
+  for (const chunk of sel.split(/\s+/).filter(Boolean)) {
+    // 纯 id 选择器（#m1）不产生约束段——mermaid scoped id 不参与内联匹配，跳过避免污染段链。
+    if (chunk.startsWith('#')) continue;
+    // 处理形如 rect.divider / .a.b tag —— 同一复合选择器内可能 tag 与多个 class 并存。
+    const classes: string[] = [];
+    let tag: string | null = null;
+    for (const token of chunk.split(/(?=\.)/)) {
+      const t = token.trim();
+      if (!t) continue;
+      if (t.startsWith('.')) classes.push(t.slice(1));
+      else if (t.startsWith(':')) {
+        /* 伪类忽略 */
+      } else tag = t.toLowerCase();
+    }
+    parts.push({ tag, classes });
+  }
+  return parts;
+}
+
+/**
+ * 规则是否匹配某元素：从选择器末段（自身）往前比对祖先栈顶。
+ * 末段 tag/classes 必须匹配当前元素；其余段从栈顶往下逐一匹配祖先 g 的 class。
+ */
+function ruleMatches(rule: CssRule, tag: string, classes: string[], ancestorClasses: string[]): boolean {
+  const parts = rule.selector;
+  const self = parts[parts.length - 1];
+  if (self.tag && self.tag !== tag) return false;
+  if (self.classes.length && !self.classes.every(c => classes.includes(c))) return false;
+  // 剩余段是祖先约束，从栈顶（最近祖先）往下匹配。
+  let ancIdx = ancestorClasses.length - 1;
+  for (let i = parts.length - 2; i >= 0; i--) {
+    const anc = parts[i];
+    let found = false;
+    while (ancIdx >= 0) {
+      const ancCls = ancestorClasses[ancIdx];
+      ancIdx--;
+      // 祖先段无 tag 约束（mermaid 祖先都是 .class），只要 class 全满足即可。
+      if (anc.classes.length && anc.classes.every(c => ancCls.includes(c))) {
+        found = true;
+        break;
+      }
+    }
+    if (!found) return false;
+  }
+  return true;
+}
+
 /** 双引号转单引号，避免拼进 style="..." 产生嵌套双引号（d2 font-family "d2-<hash>-font-bold"）。 */
 const sanitizeCssValue = (v: string): string => v.replace(/"/g, "'");
 
+const SHAPE_TAGS = /^(rect|path|circle|ellipse|polygon|text)$/;
+
 /**
  * 规范化 SVG（用于 mermaid / d2）：
- * 1. 解析 <style> 的 CSS 规则，把 class 选择器的 fill/stroke 内联到 rect/path 等元素属性
+ * 1. 解析 <style> 的 CSS 规则，把 class 选择器的 fill/stroke 内联到形状/text 元素属性
  *    ——否则删 <style> 后元素无颜色源，react-native-svg 默认黑色填充。
  * 2. 删除 <style>（react-native-svg 不支持 CSS 选择器）。
- * 3. 保护 <text> / <foreignObject>，再用安全正则删标签间空白——原版 />[^<]+</ 会误删
- *    rect 的 class/style 属性串和 foreignObject 的标签文字。
+ * 3. foreignObject → text（react-native-svg 不渲染其 HTML 子节点）。
+ * 4. 删 xml 头/注释 + 标签间空白，保护 text/foreignObject 内文本不被误删。
  */
 export function normalizeSvg(xml: string): string {
-  // 1. 解析 CSS 规则，提取默认色 + class → decls 映射。
-  const cssRules = new Map<string, CssDecls>();
+  // 1. 解析所有 <style> 的 CSS 规则，保留源序。
+  const cssRules: CssRule[] = [];
   for (const [, cssText] of xml.matchAll(/<style\b[^>]*>([\s\S]*?)<\/style>/gi)) {
-    for (const [key, decls] of parseCssRules(cssText)) {
-      cssRules.set(key, { ...(cssRules.get(key) ?? {}), ...decls });
-    }
+    cssRules.push(...parseCssRules(cssText));
   }
   const defaultTextFill = '#333';
   const defaultFontFamily = sanitizeCssValue('Arial, sans-serif');
 
-  // 2. 内联 class 颜色到形状元素 fill/stroke 属性（按 class + 标签名匹配）。
-  const inlineColors = (tag: string, attrs: string): string => {
-    const classes = attrs.match(/\bclass="([^"]*)"/)?.[1].split(/\s+/).filter(Boolean) ?? [];
-    const matched = [...classes, tag]
-      .map(k => cssRules.get(k))
-      .filter((d): d is CssDecls => Boolean(d));
-    const pick = (key: ColorKey) => matched.find(d => d[key])?.[key];
-    const fill = pick('fill');
-    const stroke = pick('stroke');
-    const strokeWidth = pick('stroke-width');
-    const extra =
-      (fill && !/\bfill=/.test(attrs) ? ` fill="${sanitizeCssValue(fill)}"` : '') +
-      (stroke && !/\bstroke=/.test(attrs) ? ` stroke="${sanitizeCssValue(stroke)}"` : '') +
-      (strokeWidth && !/\bstroke-width=/.test(attrs) ? ` stroke-width="${sanitizeCssValue(strokeWidth)}"` : '');
-    return `<${tag}${attrs}${extra}>`;
-  };
-  let out = xml.replace(/<(\w+)((?:[^>]*?))>/g, (full, tag: string, attrs: string) =>
-    /^(rect|path|circle|ellipse|polygon)$/.test(tag) ? inlineColors(tag, attrs) : full
+  // 2. 单次线性扫描内联颜色：维护祖先 class 栈，遇 <g class> push、</g> pop，
+  //    对形状/文本元素用祖先链匹配 CSS 规则，按源序合并 decls 后补进属性。
+  //    自闭合标签（<rect .../>）的结尾 / 不能被吞进 attrs，否则补色后变成
+  //    <rect .../ fill="..."> —— / 落在属性中间，react-native-svg 解析抛错整图空白。
+  const ancestorClasses: string[] = [];
+  let out = xml.replace(
+    /<(\/?)(\w+)([^>]*?)(\/?)>/g,
+    (full, closing: string, tag: string, attrs: string, selfClose: string) => {
+      const lower = tag.toLowerCase();
+      // 闭标签：从祖先栈弹出一个 g（仅 g 入栈，其它容器不参与选择器匹配）。
+      if (closing) {
+        if (lower === 'g' && ancestorClasses.length) ancestorClasses.pop();
+        return full;
+      }
+      // 开标签：g 先入栈再返回（自身不内联），形状/text 内联后返回。
+      if (lower === 'g') {
+        const gClasses = attrs.match(/\bclass="([^"]*)"/)?.[1].split(/\s+/).filter(Boolean) ?? [];
+        ancestorClasses.push(gClasses.join(' '));
+        return full;
+      }
+      if (!SHAPE_TAGS.test(lower)) return full;
+
+      const classes = attrs.match(/\bclass="([^"]*)"/)?.[1].split(/\s+/).filter(Boolean) ?? [];
+      // 按源序合并所有命中规则的 decls（后写覆盖先写）。
+      const merged: CssDecls = {};
+      for (const rule of cssRules) {
+        if (ruleMatches(rule, lower, classes, ancestorClasses)) {
+          Object.assign(merged, rule.decls);
+        }
+      }
+      const pick = (key: ColorKey) => merged[key];
+      // text 元素：fill 缺省时回退到 color（CSS 文本颜色语义）；形状元素忽略 color。
+      const fill = pick('fill') ?? (lower === 'text' ? pick('color') : undefined);
+      const stroke = pick('stroke');
+      const strokeWidth = pick('stroke-width');
+      const fontFamily = pick('font-family');
+      const fontSize = pick('font-size');
+      const extra =
+        (fill && !/\bfill=/.test(attrs) ? ` fill="${sanitizeCssValue(fill)}"` : '') +
+        (stroke && !/\bstroke=/.test(attrs) ? ` stroke="${sanitizeCssValue(stroke)}"` : '') +
+        (strokeWidth && !/\bstroke-width=/.test(attrs) ? ` stroke-width="${sanitizeCssValue(strokeWidth)}"` : '') +
+        (fontFamily && !/\bfont-family=/.test(attrs) ? ` font-family="${sanitizeCssValue(fontFamily)}"` : '') +
+        (fontSize && !/\bfont-size=/.test(attrs) ? ` font-size="${sanitizeCssValue(fontSize)}"` : '');
+      return `<${tag}${attrs}${extra}${selfClose}>`;
+    }
   );
 
-  // 3. 给 <text> 补 inline 默认色（d2 的 text 有 style 但无 fill，会默认黑色）。
-  out = out.replace(/<text([^>]*?)style="([^"]*)"/gi, (_m, attrs: string, style: string) => {
-    const extra =
-      (style.includes('fill:') ? '' : `; fill: ${defaultTextFill}`) +
-      (style.includes('font-family:') ? '' : `; font-family: ${defaultFontFamily}`) +
-      (style.includes('font-size:') ? '' : `; font-size: 16px`);
-    return `<text${attrs}style="${style}${extra}"`;
+  // 3. 给无 fill 的 <text> 兜底默认色（d2 的 text 有 style 但无 fill，会默认黑色）。
+  //    兜底前必须同时检查 style 和属性：step-2 可能已把 class 的 fill/font-family 内联成
+  //    属性（fill="..."），此时不能再往 style 补默认值——style 优先级高于属性，会覆盖掉
+  //    step-2 内联的正确颜色。
+  out = out.replace(/<text([^>]*?)>/gi, (_m, attrs: string) => {
+    const hasFillAttr = /\bfill=/.test(attrs);
+    const hasFontFamilyAttr = /\bfont-family=/.test(attrs);
+    const hasFontSizeAttr = /\bfont-size=/.test(attrs);
+    const styleMatch = attrs.match(/\bstyle="([^"]*)"/);
+    if (!styleMatch) {
+      // 无 style 的 text：属性已有全部三者就不补，否则补缺的到 style。
+      const needFill = !hasFillAttr;
+      const needFontFamily = !hasFontFamilyAttr;
+      const needFontSize = !hasFontSizeAttr;
+      if (!needFill && !needFontFamily && !needFontSize) return `<text${attrs}>`;
+      const decls =
+        (needFill ? `fill: ${defaultTextFill}; ` : '') +
+        (needFontFamily ? `font-family: ${defaultFontFamily}; ` : '') +
+        (needFontSize ? `font-size: 16px; ` : '');
+      return `<text${attrs} style="${decls.trim().replace(/;$/, '')}">`;
+    }
+    let style = styleMatch[1];
+    // style 里缺、且属性里也没有时才补默认值。
+    if (!/fill:/.test(style) && !hasFillAttr) style += `; fill: ${defaultTextFill}`;
+    if (!/font-family:/.test(style) && !hasFontFamilyAttr) style += `; font-family: ${defaultFontFamily}`;
+    if (!/font-size:/.test(style) && !hasFontSizeAttr) style += `; font-size: 16px`;
+    return `<text${attrs.replace(/\bstyle="[^"]*"/, `style="${style}"`)}>`;
   });
 
   // 4. 删除 <style>（颜色已内联）。
@@ -108,26 +225,26 @@ export function normalizeSvg(xml: string): string {
 
   // 5. foreignObject → text：mermaid 的节点/连线标签全在 <foreignObject> 的 HTML 里
   //    （div/span/p），react-native-svg 不渲染 foreignObject 的 HTML 子节点，文字会消失。
-  //    转换成 <text>：提取 <p> 里的纯文本，用 foreignObject 的 width/height 居中定位
-  //    （x=width/2, y=height*0.7 近似基线，text-anchor=middle）。foreignObject 无 x/y，
-  //    位置由父 <g> transform 决定，转换后的 <text> 继承同样的父 transform，位置不变。
-  //    width=0 或无文本的 foreignObject（空 edgeLabel 占位）直接删除。
+  //    转换成 <text>：提取 foreignObject 内全部文本（<br> 先转空格避免行粘连），用
+  //    foreignObject 的 width/height 居中定位（x=width/2, y=height*0.7 近似基线，
+  //    text-anchor=middle）。foreignObject 无 x/y，位置由父 <g> transform 决定，转换后的
+  //    <text> 继承同样的父 transform，位置不变。width=0 或无文本的 foreignObject 直接删除。
   out = out.replace(/<foreignObject\b[^>]*>[\s\S]*?<\/foreignObject>/gi, (fo) => {
     const w = Number(fo.match(/\bwidth="([^"]*)"/)?.[1] ?? 0);
     const h = Number(fo.match(/\bheight="([^"]*)"/)?.[1] ?? 0);
     if (!w || !h) return '';
-    // 提取所有 <p>...</p> 里的文本，拼接（mermaid 多行标签少见，多数单个 <p>）
-    const texts = [...fo.matchAll(/<p\b[^>]*>([\s\S]*?)<\/p>/gi)]
-      .map(m => m[1].replace(/<[^>]+>/g, '').trim())
-      .filter(Boolean);
-    if (texts.length === 0) return '';
-    const text = texts.join(' ');
+    // <br> 和块级闭合标签（</p>/</div>）先转空格作为行/块边界，避免行粘连；再剥其余标签，
+    // 取 foreignObject 内全部纯文本（不限 <p>，venn 标签是 <span>）。
+    const html = fo.replace(/<br\s*\/?>/gi, ' ').replace(/<\/(p|div|li|h[1-6])>/gi, ' ');
+    const text = html.replace(/<[^>]+>/g, '').replace(/\s+/g, ' ').trim();
+    if (!text) return '';
     const x = w / 2;
     const y = h * 0.7;
     return `<text x="${x}" y="${y}" text-anchor="middle" style="fill: ${defaultTextFill}; font-family: ${defaultFontFamily}; font-size: 16px">${text}</text>`;
   });
 
-  // 6. 保护 <text> / <foreignObject>，删 xml 头/注释 + 标签间空白，再恢复。
+  // 6. 保护 <text>，删 xml 头/注释 + 标签间空白，再恢复。
+  //    foreignObject 在 step-5 已全部转走，无需再 stash。
   const preserved: string[] = [];
   const stash = (m: string) => {
     const token = `<ph data-i="${preserved.length}" />`;
@@ -136,7 +253,6 @@ export function normalizeSvg(xml: string): string {
   };
   out = out
     .replace(/<text\b[\s\S]*?<\/text>/gi, stash)
-    .replace(/<foreignObject\b[\s\S]*?<\/foreignObject>/gi, stash)
     .replace(/<\?xml[\s\S]*?\?>/gi, '')
     .replace(/<\?[\s\S]*?\?>/g, '')
     .replace(/<!doctype[\s\S]*?>/gi, '')

--- a/packages/renderers/rn/src/svgUtils.ts
+++ b/packages/renderers/rn/src/svgUtils.ts
@@ -1,142 +1,151 @@
-// 统一的 SVG 预处理工具，用于将 Mermaid / MathJax 生成的 SVG
+// 统一的 SVG 预处理工具，用于将 Mermaid / d2 生成的 SVG
 // 调整为更适合 react-native-svg 渲染的形式。
 
 /**
- * 对已经完成样式内联的 SVG 做轻量清理。
+ * 轻量清理：用于已经完成样式内联、无需颜色处理的 SVG（如 MathJax）。
  */
 export function normalizeSvgLight(xml: string): string {
-  let normalized = xml;
-
-  normalized = normalized
+  return xml
     .replace(/<\?xml[\s\S]*?\?>/gi, '')
     .replace(/<\?[\s\S]*?\?>/g, '')
     .replace(/<!doctype[\s\S]*?>/gi, '')
     .replace(/<!--[\s\S]*?-->/g, '')
     .replace(/<title[\s\S]*?<\/title>/gi, '')
     .replace(/<desc[\s\S]*?<\/desc>/gi, '')
-    .replace(/<metadata[\s\S]*?<\/metadata>/gi, '');
-
-  normalized = normalized.replace(/<style[^>]*>[\s\S]*?<\/style>/gi, '');
-  normalized = normalized.replace(/>\s+</g, '><');
-
-  return normalized;
+    .replace(/<metadata[\s\S]*?<\/metadata>/gi, '')
+    .replace(/<style[^>]*>[\s\S]*?<\/style>/gi, '')
+    .replace(/>\s+</g, '><');
 }
 
+type ColorKey = 'fill' | 'stroke' | 'stroke-width' | 'font-family' | 'font-size';
+type CssDecls = Partial<Record<ColorKey, string>>;
+
+const COLOR_ATTRS_RE = /^(fill|stroke|stroke-width|font-family|font-size)$/;
+
 /**
- * 规范化 SVG：
- * - 移除 <style> 标签（react-native-svg 不支持内联 CSS）
- * - 为常见元素添加一些默认样式（主要针对 Mermaid 导出的图表）
+ * 解析 <style> 里的 CSS 规则，按选择器末尾的 class/标签名索引。
+ *
+ * mermaid/d2 的 CSS 多为 scoped：`#id .node rect { fill:#ECECFF; stroke:#9370DB; }`。
+ * react-native-svg 不支持 CSS 选择器，需要把颜色内联到元素属性。这里按末尾选择器
+ *（如 `#id .node rect` 取 `rect`、`.label-container` 取 `label-container`）建索引，
+ * 后续按元素 class 或标签名匹配内联。同 key 多规则后者覆盖前者。
+ */
+function parseCssRules(cssText: string): Map<string, CssDecls> {
+  const rules = new Map<string, CssDecls>();
+  for (const [, selectorGroup, body] of cssText.matchAll(/([^{}]+)\{([^{}]*)\}/g)) {
+    const decls: CssDecls = {};
+    for (const part of body.split(';')) {
+      const idx = part.indexOf(':');
+      if (idx <= 0) continue;
+      const key = part.slice(0, idx).trim();
+      const value = part.slice(idx + 1).trim();
+      if (COLOR_ATTRS_RE.test(key)) decls[key as ColorKey] = value;
+    }
+    if (Object.keys(decls).length === 0) continue;
+    for (const sel of selectorGroup.split(',').map(s => s.trim()).filter(Boolean)) {
+      const parts = sel.split(/\s+/).filter(Boolean);
+      const last = parts[parts.length - 1] ?? sel;
+      const key = last.startsWith('.') ? last.slice(1) : last;
+      rules.set(key, { ...(rules.get(key) ?? {}), ...decls });
+    }
+  }
+  return rules;
+}
+
+/** 双引号转单引号，避免拼进 style="..." 产生嵌套双引号（d2 font-family "d2-<hash>-font-bold"）。 */
+const sanitizeCssValue = (v: string): string => v.replace(/"/g, "'");
+
+/**
+ * 规范化 SVG（用于 mermaid / d2）：
+ * 1. 解析 <style> 的 CSS 规则，把 class 选择器的 fill/stroke 内联到 rect/path 等元素属性
+ *    ——否则删 <style> 后元素无颜色源，react-native-svg 默认黑色填充。
+ * 2. 删除 <style>（react-native-svg 不支持 CSS 选择器）。
+ * 3. 保护 <text> / <foreignObject>，再用安全正则删标签间空白——原版 />[^<]+</ 会误删
+ *    rect 的 class/style 属性串和 foreignObject 的标签文字。
  */
 export function normalizeSvg(xml: string): string {
-  let normalized = xml;
+  // 1. 解析 CSS 规则，提取默认色 + class → decls 映射。
+  const cssRules = new Map<string, CssDecls>();
+  for (const [, cssText] of xml.matchAll(/<style\b[^>]*>([\s\S]*?)<\/style>/gi)) {
+    for (const [key, decls] of parseCssRules(cssText)) {
+      cssRules.set(key, { ...(cssRules.get(key) ?? {}), ...decls });
+    }
+  }
+  const defaultTextFill = '#333';
+  const defaultFontFamily = sanitizeCssValue('Arial, sans-serif');
 
-  // 先保留语义 text 节点，避免后续移除裸文本时把标签内容也删掉。
-  const preservedTextNodes: string[] = [];
-  normalized = normalized.replace(/<text\b[\s\S]*?<\/text>/gi, match => {
-    const token = `<smtext_placeholder data-i="${preservedTextNodes.length}" />`;
-    preservedTextNodes.push(match);
-    return token;
+  // 2. 内联 class 颜色到形状元素 fill/stroke 属性（按 class + 标签名匹配）。
+  const inlineColors = (tag: string, attrs: string): string => {
+    const classes = attrs.match(/\bclass="([^"]*)"/)?.[1].split(/\s+/).filter(Boolean) ?? [];
+    const matched = [...classes, tag]
+      .map(k => cssRules.get(k))
+      .filter((d): d is CssDecls => Boolean(d));
+    const pick = (key: ColorKey) => matched.find(d => d[key])?.[key];
+    const fill = pick('fill');
+    const stroke = pick('stroke');
+    const strokeWidth = pick('stroke-width');
+    const extra =
+      (fill && !/\bfill=/.test(attrs) ? ` fill="${sanitizeCssValue(fill)}"` : '') +
+      (stroke && !/\bstroke=/.test(attrs) ? ` stroke="${sanitizeCssValue(stroke)}"` : '') +
+      (strokeWidth && !/\bstroke-width=/.test(attrs) ? ` stroke-width="${sanitizeCssValue(strokeWidth)}"` : '');
+    return `<${tag}${attrs}${extra}>`;
+  };
+  let out = xml.replace(/<(\w+)((?:[^>]*?))>/g, (full, tag: string, attrs: string) =>
+    /^(rect|path|circle|ellipse|polygon)$/.test(tag) ? inlineColors(tag, attrs) : full
+  );
+
+  // 3. 给 <text> 补 inline 默认色（d2 的 text 有 style 但无 fill，会默认黑色）。
+  out = out.replace(/<text([^>]*?)style="([^"]*)"/gi, (_m, attrs: string, style: string) => {
+    const extra =
+      (style.includes('fill:') ? '' : `; fill: ${defaultTextFill}`) +
+      (style.includes('font-family:') ? '' : `; font-family: ${defaultFontFamily}`) +
+      (style.includes('font-size:') ? '' : `; font-size: 16px`);
+    return `<text${attrs}style="${style}${extra}"`;
   });
 
-  normalized = normalized
+  // 4. 删除 <style>（颜色已内联）。
+  out = out.replace(/<style\b[^>]*>[\s\S]*?<\/style>/gi, '');
+
+  // 5. foreignObject → text：mermaid 的节点/连线标签全在 <foreignObject> 的 HTML 里
+  //    （div/span/p），react-native-svg 不渲染 foreignObject 的 HTML 子节点，文字会消失。
+  //    转换成 <text>：提取 <p> 里的纯文本，用 foreignObject 的 width/height 居中定位
+  //    （x=width/2, y=height*0.7 近似基线，text-anchor=middle）。foreignObject 无 x/y，
+  //    位置由父 <g> transform 决定，转换后的 <text> 继承同样的父 transform，位置不变。
+  //    width=0 或无文本的 foreignObject（空 edgeLabel 占位）直接删除。
+  out = out.replace(/<foreignObject\b[^>]*>[\s\S]*?<\/foreignObject>/gi, (fo) => {
+    const w = Number(fo.match(/\bwidth="([^"]*)"/)?.[1] ?? 0);
+    const h = Number(fo.match(/\bheight="([^"]*)"/)?.[1] ?? 0);
+    if (!w || !h) return '';
+    // 提取所有 <p>...</p> 里的文本，拼接（mermaid 多行标签少见，多数单个 <p>）
+    const texts = [...fo.matchAll(/<p\b[^>]*>([\s\S]*?)<\/p>/gi)]
+      .map(m => m[1].replace(/<[^>]+>/g, '').trim())
+      .filter(Boolean);
+    if (texts.length === 0) return '';
+    const text = texts.join(' ');
+    const x = w / 2;
+    const y = h * 0.7;
+    return `<text x="${x}" y="${y}" text-anchor="middle" style="fill: ${defaultTextFill}; font-family: ${defaultFontFamily}; font-size: 16px">${text}</text>`;
+  });
+
+  // 6. 保护 <text> / <foreignObject>，删 xml 头/注释 + 标签间空白，再恢复。
+  const preserved: string[] = [];
+  const stash = (m: string) => {
+    const token = `<ph data-i="${preserved.length}" />`;
+    preserved.push(m);
+    return token;
+  };
+  out = out
+    .replace(/<text\b[\s\S]*?<\/text>/gi, stash)
+    .replace(/<foreignObject\b[\s\S]*?<\/foreignObject>/gi, stash)
     .replace(/<\?xml[\s\S]*?\?>/gi, '')
     .replace(/<\?[\s\S]*?\?>/g, '')
     .replace(/<!doctype[\s\S]*?>/gi, '')
     .replace(/<!--[\s\S]*?-->/g, '')
     .replace(/<title[\s\S]*?<\/title>/gi, '')
     .replace(/<desc[\s\S]*?<\/desc>/gi, '')
-    .replace(/<metadata[\s\S]*?<\/metadata>/gi, '');
+    .replace(/<metadata[\s\S]*?<\/metadata>/gi, '')
+    .replace(/>\s+</g, '><')
+    .replace(/<ph\s+data-i="(\d+)"\s*\/>/g, (_m, i: string) => preserved[Number(i)] ?? '');
 
-  normalized = normalized.replace(/>\s+</g, '><');
-  normalized = normalized.replace(/>[^<]+</g, '><');
-
-  const styleMatch = normalized.match(/<style[^>]*>([\s\S]*?)<\/style>/i);
-  let defaultTextFill = '#333';
-  let defaultFontFamily = 'Arial, sans-serif';
-  let defaultFontSize = '16px';
-  let defaultNodeFill = '#ECECFF';
-  let defaultStroke = '#9370DB';
-  let defaultStrokeWidth = '1px';
-
-  if (styleMatch) {
-    const styleContent = styleMatch[1];
-
-    const textFillMatch = styleContent.match(/\.label[^}]*fill\s*:\s*([^;}\s]+)/);
-    if (textFillMatch) defaultTextFill = textFillMatch[1];
-
-    const fontFamilyMatch = styleContent.match(/font-family\s*:\s*([^;}\n]+)/);
-    if (fontFamilyMatch) defaultFontFamily = fontFamilyMatch[1];
-
-    const fontSizeMatch = styleContent.match(/font-size\s*:\s*([^;}\s]+)/);
-    if (fontSizeMatch) defaultFontSize = fontSizeMatch[1];
-
-    const nodeFillMatch = styleContent.match(/\.node\s+rect[^}]*fill\s*:\s*([^;}\s]+)/);
-    if (nodeFillMatch) defaultNodeFill = nodeFillMatch[1];
-
-    const strokeMatch = styleContent.match(/\.node\s+rect[^}]*stroke\s*:\s*([^;}\s]+)/);
-    if (strokeMatch) defaultStroke = strokeMatch[1];
-
-    const strokeWidthMatch = styleContent.match(/\.node\s+rect[^}]*stroke-width\s*:\s*([^;}\s]+)/);
-    if (strokeWidthMatch) defaultStrokeWidth = strokeWidthMatch[1];
-  }
-
-  normalized = normalized.replace(/<style[^>]*>[\s\S]*?<\/style>/gi, '');
-
-  normalized = normalized.replace(
-    /<text([^>]*?)style="([^"]*)"/gi,
-    (_match: string, attrs: string, existingStyle: string) => {
-      const styles: string[] = [];
-      if (existingStyle && existingStyle.trim()) styles.push(existingStyle.trim());
-
-      if (!existingStyle.includes('fill:')) styles.push(`fill: ${defaultTextFill}`);
-      if (!existingStyle.includes('font-family:')) styles.push(`font-family: ${defaultFontFamily}`);
-      if (!existingStyle.includes('font-size:')) styles.push(`font-size: ${defaultFontSize}`);
-
-      const attrsWithSpace = attrs && attrs.trim() ? attrs + ' ' : attrs;
-      return `<text${attrsWithSpace}style="${styles.join('; ')}"`;
-    }
-  );
-
-  normalized = normalized.replace(
-    /<rect([^>]*?)style="([^"]*)"/gi,
-    (_match: string, attrs: string, existingStyle: string) => {
-      const styles: string[] = [];
-      if (existingStyle && existingStyle.trim()) styles.push(existingStyle.trim());
-
-      if (!existingStyle?.includes('fill:')) styles.push(`fill: ${defaultNodeFill}`);
-      if (!existingStyle?.includes('stroke:')) styles.push(`stroke: ${defaultStroke}`);
-      if (!existingStyle?.includes('stroke-width:')) {
-        styles.push(`stroke-width: ${defaultStrokeWidth}`);
-      }
-
-      const attrsWithSpace = attrs && attrs.trim() ? attrs + ' ' : attrs;
-      return `<rect${attrsWithSpace}style="${styles.join('; ')}"`;
-    }
-  );
-
-  normalized = normalized.replace(
-    /<path\s+([^>]*?)style="([^"]*)"/gi,
-    (_match: string, attrs: string, existingStyle: string) => {
-      const styles: string[] = [];
-      if (existingStyle && existingStyle.trim()) {
-        styles.push(existingStyle.trim());
-      }
-
-      if (!existingStyle?.includes('fill:')) {
-        styles.push(`fill: ${defaultStroke}`);
-      }
-      if (!existingStyle?.includes('stroke:') && !existingStyle?.includes('stroke-width:')) {
-        styles.push(`stroke: ${defaultStroke}`);
-      }
-
-      return `<path ${attrs}style="${styles.join('; ')}"`;
-    }
-  );
-
-  normalized = normalized.replace(
-    /<smtext_placeholder\s+data-i="(\d+)"\s*\/>/g,
-    (_match, indexText) => preservedTextNodes[Number(indexText)] ?? ''
-  );
-
-  return normalized;
+  return out;
 }

--- a/packages/renderers/rn/src/svgUtils.ts
+++ b/packages/renderers/rn/src/svgUtils.ts
@@ -97,8 +97,10 @@ function parseSelector(sel: string): SelectorPart[] {
 /**
  * 规则是否匹配某元素：从选择器末段（自身）往前比对祖先栈顶。
  * 末段 tag/classes 必须匹配当前元素；其余段从栈顶往下逐一匹配祖先 g 的 class。
+ * 自身段与祖先段都用数组 Array.includes 按词精确匹配——祖先栈存数组而非 join 字符串，
+ * 避免字符串 String.includes 子串匹配把 .node 误命中 nodes / .label 误命中 edgeLabel。
  */
-function ruleMatches(rule: CssRule, tag: string, classes: string[], ancestorClasses: string[]): boolean {
+function ruleMatches(rule: CssRule, tag: string, classes: string[], ancestorClasses: string[][]): boolean {
   const parts = rule.selector;
   const self = parts[parts.length - 1];
   if (self.tag && self.tag !== tag) return false;
@@ -109,9 +111,9 @@ function ruleMatches(rule: CssRule, tag: string, classes: string[], ancestorClas
     const anc = parts[i];
     let found = false;
     while (ancIdx >= 0) {
-      const ancCls = ancestorClasses[ancIdx];
+      const ancCls: string[] = ancestorClasses[ancIdx];
       ancIdx--;
-      // 祖先段无 tag 约束（mermaid 祖先都是 .class），只要 class 全满足即可。
+      // 祖先 class 按词精确匹配（Array.includes），与自身段语义一致。
       if (anc.classes.length && anc.classes.every(c => ancCls.includes(c))) {
         found = true;
         break;
@@ -148,7 +150,7 @@ export function normalizeSvg(xml: string): string {
   //    对形状/文本元素用祖先链匹配 CSS 规则，按源序合并 decls 后补进属性。
   //    自闭合标签（<rect .../>）的结尾 / 不能被吞进 attrs，否则补色后变成
   //    <rect .../ fill="..."> —— / 落在属性中间，react-native-svg 解析抛错整图空白。
-  const ancestorClasses: string[] = [];
+  const ancestorClasses: string[][] = [];
   let out = xml.replace(
     /<(\/?)(\w+)([^>]*?)(\/?)>/g,
     (full, closing: string, tag: string, attrs: string, selfClose: string) => {
@@ -160,8 +162,10 @@ export function normalizeSvg(xml: string): string {
       }
       // 开标签：g 先入栈再返回（自身不内联），形状/text 内联后返回。
       if (lower === 'g') {
+        // 自闭合 <g .../> 无对应 </g>，不入栈——否则 class 泄漏给兄弟元素且后续 </g> 弹栈错位。
+        if (selfClose) return full;
         const gClasses = attrs.match(/\bclass="([^"]*)"/)?.[1].split(/\s+/).filter(Boolean) ?? [];
-        ancestorClasses.push(gClasses.join(' '));
+        ancestorClasses.push(gClasses);
         return full;
       }
       if (!SHAPE_TAGS.test(lower)) return full;


### PR DESCRIPTION
fix(rn): mermaid 图表颜色丢失与文字不显示
    
react-native-svg 不支持 CSS 选择器，也不渲染 foreignObject 里的
HTML 子节点，导致 mermaid（走 native FFI）输出的标准 SVG 在 RN 上
两个问题：

1. 颜色全黑：mermaid 节点 rect 的颜色靠 <style> 里的 scoped class
   选择器（#id .node rect { fill:..; stroke:.. }）。normalizeSvg 删
   <style> 后 rect 无颜色源，react-native-svg 默认黑色填充。改为删
   <style> 前先解析 class 选择器，按元素 class + 标签名把 fill/stroke
   内联到属性。原版裸文本正则 />[^<]+</ 会顺带破坏 rect 的 class
   属性串，导致按 class 匹配失效，一并改为只删空白 />\\s+</。

2. 无文字：mermaid 节点/连线标签全在 <foreignObject> 的 HTML 里
   （div/span/p），react-native-svg 不渲染 HTML 子节点。改为提取
   <p> 里的纯文本，用 foreignObject 的 width/height 生成居中的
   <text> 替换；空占位（width=0）直接删除。
       
test(rn): 补 svgUtils 单元测试
    
覆盖颜色内联、foreignObject → text 转换、引号转义、安全正则回归
等核心场景（12 例，bun test）。并给 @supramark/rn 加 test 脚本。