### PR TITLE
fix(rn): table 撑满父容器可用宽度，cell 均分

### DIFF
--- a/packages/renderers/rn/src/Supramark.tsx
+++ b/packages/renderers/rn/src/Supramark.tsx
@@ -536,8 +536,9 @@ function renderNode(
     }
     case 'table': {
       const table = node;
+      const screenWidth = Dimensions.get('window').width;
       return (
-        <View key={key} style={styles.table}>
+        <View key={key} style={[styles.table, { width: screenWidth }]}>
           {table.children.map((row, index) =>
             renderNode(row, index, styles, highlighted, config, onOpenHtmlPage, containerRenderers)
           )}

--- a/packages/renderers/rn/src/styles.ts
+++ b/packages/renderers/rn/src/styles.ts
@@ -273,6 +273,7 @@ export const defaultStyles = StyleSheet.create({
   },
   // Table styles
   table: {
+    maxWidth: '100%',
     borderWidth: 1,
     borderColor: '#ddd',
     marginBottom: 12,
@@ -284,6 +285,7 @@ export const defaultStyles = StyleSheet.create({
   },
   tableCell: {
     flex: 1,
+    flexShrink: 1,
     padding: 8,
     borderRightWidth: 1,
     borderRightColor: '#ddd',


### PR DESCRIPTION
table 在内容驱动的弹性气泡里（flexShrink + maxWidth + alignSelf: flex-start）撑不开。气泡宽度由内容决定，table 又无显式 width/flex，
cell flex:1 均分需要父宽度基准，父宽度未定时 Yoga 退化，table 塌缩。

- table 显式 width: screenWidth：撑到屏宽（= 父容器 maxWidth 上限）， 打破"气泡宽度依赖内容、内容依赖气泡宽度"的循环
- maxWidth: '100%'：不超过祖父容器，窄容器场景收缩兜底
- tableCell flex:1（原有）：cell 均分 row 宽度
- tableCell flexShrink:1：超过 maxWidth 时 cell 收缩换行，不溢出