### PR TITLE
feat(rn-example): wire native markdown parser for iOS

### DIFF
--- a/examples/react-native/App.tsx
+++ b/examples/react-native/App.tsx
@@ -49,6 +49,10 @@ import { diagramDotFeature } from '@supramark/feature-diagram-dot';
 import '@actrium/supramark-d2-native-rn';
 import '@actrium/supramark-mermaid-native-rn';
 import '@actrium/supramark-plantuml-native-rn';
+// Side-effect: registers the native Markdown parser adapter against
+// @supramark/core's native registry so parse() routes source through the
+// linked libsupramark_markdown_native static lib (no wasm on RN).
+import '@supramark/markdown-native-rn';
 
 import { DEMOS } from '../demos';
 

--- a/examples/react-native/metro.config.js
+++ b/examples/react-native/metro.config.js
@@ -21,6 +21,20 @@ const defaultResolver = config.resolver.resolveRequest;
 
 // 配置模块解析,处理 package.json exports 和 imports 字段
 config.resolver.resolveRequest = (context, moduleName, platform) => {
+  // RN must not load the wasm web parser. plugin-loader.ts re-exports the web
+  // loader whose `await import(specifier)` wasm fallback Metro cannot bundle;
+  // route every plugin-loader / plugin-loader-web request to the native-adapter
+  // loader so parse() goes through the linked libsupramark_markdown_native.
+  if (
+    platform !== 'web' &&
+    /(^|\/)plugin-loader(-web)?(\.(js|ts))?$/.test(moduleName)
+  ) {
+    return {
+      filePath: path.resolve(workspaceRoot, 'packages/core/src/plugin-loader-rn.ts'),
+      type: 'sourceFile',
+    };
+  }
+
   // workspace 内多个 TS 源文件用 Node-ESM 风格的 `./foo.js` 导入兄弟 `.ts`。
   // Metro 默认不会把 `.js` 重映射到 `.ts` —— 我们对仅相对路径 + .js 后缀的
   // 失败 case 退一步尝试同名 .ts / .tsx，保持源码端的 ESM 风格不变。
@@ -40,7 +54,7 @@ config.resolver.resolveRequest = (context, moduleName, platform) => {
   // ECharts / Vega-Lite 走纯 JS SVG-string engine。@supramark/engines/src/*
   // 仍静态引用了部分 *-web 包名，Metro 不会跳过未调用的 `await import(...)`，
   // 所以仅把这些 wasm/web 入口短路到空 stub。
-  if (/^@kookyleo\/(d2|mermaid|plantuml)-little-web$|^@kookyleo\/graphviz-anywhere-web$/.test(moduleName)) {
+  if (/^@(kookyleo|actrium)\/(d2|mermaid|plantuml)-little-web$|^@(kookyleo|actrium)\/graphviz-anywhere-web$/.test(moduleName)) {
     return {
       filePath: path.resolve(projectRoot, 'stubs/empty.js'),
       type: 'sourceFile',
@@ -60,6 +74,16 @@ config.resolver.resolveRequest = (context, moduleName, platform) => {
 
   // @supramark/engines 的 ./rn subpath — Metro 同样不支持 package.json exports
   // 的 subpath；手动映射到 source 文件。
+  // @supramark/core/rn subpath — Metro ignores package.json exports, so map it
+  // to the same RN entry as the bare specifier (index.rn.ts re-exports the
+  // native parser registry @supramark/markdown-native-rn registers into).
+  if (moduleName === '@supramark/core/rn') {
+    return {
+      filePath: path.resolve(workspaceRoot, 'packages/core/src/index.rn.ts'),
+      type: 'sourceFile',
+    };
+  }
+
   if (moduleName === '@supramark/engines/rn') {
     return {
       filePath: path.resolve(workspaceRoot, 'packages/engines/src/rn.ts'),

--- a/examples/react-native/package.json
+++ b/examples/react-native/package.json
@@ -33,6 +33,7 @@
     "@actrium/supramark-d2-native-rn": "workspace:*",
     "@actrium/supramark-mermaid-native-rn": "workspace:*",
     "@actrium/supramark-plantuml-native-rn": "workspace:*",
+    "@supramark/markdown-native-rn": "workspace:*",
     "echarts": "^5.5.0",
     "react": "19.1.0",
     "react-native": "0.81.5",


### PR DESCRIPTION
## Summary

Make the RN example parse Markdown through the native Rust
`libsupramark_markdown_native` static lib (TurboModule `SupramarkMarkdownNative`)
on iOS, instead of the wasm `@supramark/markdown-web` bundle. This is the missing
parser counterpart to the d2 / mermaid / plantuml native engine wiring: the engines
were registered, but `<Supramark markdown=...>` internally calls `parse()`, which
had no native parser adapter — so on iOS the example could not render any Markdown
(`RN runtime requires native markdown parser adapter`).

## Changes (3 files)

- **`package.json`** — add `@supramark/markdown-native-rn` workspace dependency.
- **`App.tsx`** — side-effect import that registers the native parser adapter
  against `@supramark/core`'s native registry.
- **`metro.config.js`** — three resolver changes:
  - **plugin-loader → RN remap**: route `plugin-loader` / `plugin-loader-web` to
    `packages/core/src/plugin-loader-rn.ts`; the default loader's
    `await import(specifier)` wasm fallback cannot be bundled by Metro and never
    runs on RN.
  - **`@supramark/core/rn` subpath mapping**: Metro ignores package.json `exports`,
    so map it to `packages/core/src/index.rn.ts` (mirrors the existing
    `@supramark/engines/rn` mapping).
  - **stub-scope fix (pre-existing bug, independent of this work)**: the
    web-package stub regex matched the stale `@kookyleo/*` scope, but the packages
    are now `@actrium/*`. With the stale regex the wasm web subtree was pulled into
    the bundle and a clean (`--reset-cache`) build failed. The regex now matches
    both scopes.

## Build prerequisite

The pod consumes `ios/Frameworks/SupramarkMarkdown.xcframework`, which is
git-ignored and generated from the crate (mirrors d2/mermaid/plantuml):
cross-compile the three iOS targets → lipo the simulator slices →
`scripts/build-ios-xcframework.sh` → `prepare-native.js`. Then `bun install`,
`pod install` (autolinks `SupramarkMarkdownNative`, runs codegen for
`SupramarkMarkdownNativeSpec`), rebuild.

## Verification

Built and run on an iPhone 17 Pro simulator (iOS 26.5): the example boots, the
three native engine smoke tests pass (d2 0.7.2 / mermaid 11.14 / plantuml
1.2026.2), and Markdown demos render — headings, paragraph, an 8-column GFM table,
and a vega-lite chart all parse natively and display.
