### PR TITLE
fix(rn/svgUtils): harden CSS inlining edge cases + cover line/polyline

### DIFF
--- a/packages/renderers/rn/__tests__/svgUtils.test.ts
+++ b/packages/renderers/rn/__tests__/svgUtils.test.ts
@@ -312,6 +312,98 @@ test('normalizeSvg 自闭合 <g/> 的 class 不泄漏给兄弟元素', () => {
 });
 
 // ============================================================================
+// Review nit hardening — one before/after regression probe per fix
+// ============================================================================
+
+// Nit 1: rewriting a <text> style must use a function replacer. A literal-string
+// replacement lets $& / $` / $' / $n inside the new style value be interpreted as
+// replacement patterns, corrupting the attribute value.
+test('normalizeSvg <text> style rewrite is not mangled by $ replacement patterns', () => {
+  const input = `<svg><text style="font-family:'a$&b';font-size:16px">x</text></svg>`;
+  const out = normalizeSvg(input);
+  // After fix: the style value survives verbatim, with the default fill appended.
+  expect(out).toContain(`<text style="font-family:'a$&b';font-size:16px; fill: #333">`);
+  // Before fix: $& expands to the whole match, producing a nested style=" ('a' then style=").
+  expect(out).not.toContain('astyle=');
+});
+
+// Nit 2: a self-closing <text .../> must stay />-terminated after default-fill. The
+// trailing slash must be captured separately and re-emitted, otherwise it lands in the
+// middle of the attrs as the malformed <text ... fill="red"/ style=...>.
+test('normalizeSvg self-closing <text/> stays />-terminated after styling', () => {
+  const input = '<svg><style>.x{fill:red}</style><text class="x"/></svg>';
+  const out = normalizeSvg(input);
+  const text = out.match(/<text[^>]*>/)?.[0] ?? '';
+  expect(text).toMatch(/fill="red"/); // fill comes from the step-2 inlining
+  expect(text).toMatch(/\/>$/); // the tag is />-terminated
+  expect(out).not.toMatch(/\/\s+\w+="[^"]*"/); // no "slash followed by attribute" malformation
+});
+
+// Nit 3: the "already has attr" guard uses (^|\s), not \b. \b also matches after the
+// hyphen in data-fill / data-stroke, so data-fill="x" would be mistaken for an existing
+// fill and skip the real CSS inlining.
+test('normalizeSvg data-fill does not block real CSS fill inlining', () => {
+  const input =
+    '<svg><style>.c{fill:red}</style><rect data-fill="x" class="c" width="1" height="1"/></svg>';
+  const out = normalizeSvg(input);
+  const rect = out.match(/<rect[^>]*>/)?.[0] ?? '';
+  expect(rect).toMatch(/fill="red"/); // data-fill is "x"; fill="red" can only be the inlined one
+  expect(rect).toContain('data-fill="x"');
+});
+
+// Nit 4: line / polyline are stroke-bearing shapes; they must receive the CSS stroke and
+// must not be given a spurious solid fill.
+test('normalizeSvg <line> receives CSS stroke without a forced fill', () => {
+  const input =
+    '<svg><style>.edge{stroke:#333}</style><line class="edge" x1="0" y1="0" x2="10" y2="10"/></svg>';
+  const out = normalizeSvg(input);
+  const line = out.match(/<line[^>]*>/)?.[0] ?? '';
+  expect(line).toMatch(/stroke="#333"/);
+  expect(line).not.toContain('fill='); // stroke-only: never invent a fill when CSS omits it
+});
+
+test('normalizeSvg <polyline> matches a class selector and gets stroke', () => {
+  const input =
+    '<svg><style>.grid{stroke:#ccc}</style><polyline class="grid" points="0,0 10,10"/></svg>';
+  const out = normalizeSvg(input);
+  const poly = out.match(/<polyline[^>]*>/)?.[0] ?? '';
+  expect(poly).toMatch(/stroke="#ccc"/);
+});
+
+// Nit 4b: a stroked shape whose CSS explicitly sets fill:none must keep fill="none"
+// (it must not be treated as "no fill" and dropped).
+test('normalizeSvg <line> keeps an explicit CSS fill:none', () => {
+  const input =
+    '<svg><style>.edge{stroke:#333;fill:none}</style><line class="edge" x1="0" y1="0" x2="1" y2="1"/></svg>';
+  const out = normalizeSvg(input);
+  const line = out.match(/<line[^>]*>/)?.[0] ?? '';
+  expect(line).toMatch(/fill="none"/);
+  expect(line).toMatch(/stroke="#333"/);
+});
+
+// Nit 5: the foreignObject -> text label color should inherit the inner span/div inline
+// color; it falls back to #333 when no color is present.
+test('normalizeSvg foreignObject label inherits the inner color', () => {
+  const input =
+    '<svg><g transform="translate(10,10)">' +
+    '<foreignObject width="40" height="16"><div xmlns="x"><span style="color:#ff0000">Hi</span></div></foreignObject>' +
+    '</g></svg>';
+  const out = normalizeSvg(input);
+  const text = out.match(/<text[^>]*>Hi<\/text>/)?.[0] ?? '';
+  expect(text).toMatch(/fill:\s*#ff0000/);
+});
+
+test('normalizeSvg foreignObject falls back to #333 and ignores background-color', () => {
+  const input =
+    '<svg><foreignObject width="40" height="16">' +
+    '<div style="background-color:#fff"><span class="nodeLabel">Plain</span></div></foreignObject></svg>';
+  const out = normalizeSvg(input);
+  const text = out.match(/<text[^>]*>Plain<\/text>/)?.[0] ?? '';
+  expect(text).toMatch(/fill:\s*#333/);
+  expect(text).not.toMatch(/#fff/);
+});
+
+// ============================================================================
 // stripRootSvgSize — 精确删除根 <svg> 的 width/height（来自 upstream/main）
 // ============================================================================
 

--- a/packages/renderers/rn/src/svgUtils.ts
+++ b/packages/renderers/rn/src/svgUtils.ts
@@ -127,7 +127,9 @@ function ruleMatches(rule: CssRule, tag: string, classes: string[], ancestorClas
 /** 双引号转单引号，避免拼进 style="..." 产生嵌套双引号（d2 font-family "d2-<hash>-font-bold"）。 */
 const sanitizeCssValue = (v: string): string => v.replace(/"/g, "'");
 
-const SHAPE_TAGS = /^(rect|path|circle|ellipse|polygon|text)$/;
+// line / polyline are stroke-only; the fill logic below stays conservative and only
+// emits a fill when the CSS supplies one (e.g. fill:none), never a spurious default.
+const SHAPE_TAGS = /^(rect|path|circle|ellipse|polygon|line|polyline|text)$/;
 
 /**
  * 规范化 SVG（用于 mermaid / d2）：
@@ -185,12 +187,14 @@ export function normalizeSvg(xml: string): string {
       const strokeWidth = pick('stroke-width');
       const fontFamily = pick('font-family');
       const fontSize = pick('font-size');
+      // "already has attr" guards use (^|\s) rather than \b: \b also matches after the
+      // hyphen in data-fill / data-stroke, which would wrongly skip real CSS inlining.
       const extra =
-        (fill && !/\bfill=/.test(attrs) ? ` fill="${sanitizeCssValue(fill)}"` : '') +
-        (stroke && !/\bstroke=/.test(attrs) ? ` stroke="${sanitizeCssValue(stroke)}"` : '') +
-        (strokeWidth && !/\bstroke-width=/.test(attrs) ? ` stroke-width="${sanitizeCssValue(strokeWidth)}"` : '') +
-        (fontFamily && !/\bfont-family=/.test(attrs) ? ` font-family="${sanitizeCssValue(fontFamily)}"` : '') +
-        (fontSize && !/\bfont-size=/.test(attrs) ? ` font-size="${sanitizeCssValue(fontSize)}"` : '');
+        (fill && !/(?:^|\s)fill=/.test(attrs) ? ` fill="${sanitizeCssValue(fill)}"` : '') +
+        (stroke && !/(?:^|\s)stroke=/.test(attrs) ? ` stroke="${sanitizeCssValue(stroke)}"` : '') +
+        (strokeWidth && !/(?:^|\s)stroke-width=/.test(attrs) ? ` stroke-width="${sanitizeCssValue(strokeWidth)}"` : '') +
+        (fontFamily && !/(?:^|\s)font-family=/.test(attrs) ? ` font-family="${sanitizeCssValue(fontFamily)}"` : '') +
+        (fontSize && !/(?:^|\s)font-size=/.test(attrs) ? ` font-size="${sanitizeCssValue(fontSize)}"` : '');
       return `<${tag}${attrs}${extra}${selfClose}>`;
     }
   );
@@ -199,29 +203,34 @@ export function normalizeSvg(xml: string): string {
   //    兜底前必须同时检查 style 和属性：step-2 可能已把 class 的 fill/font-family 内联成
   //    属性（fill="..."），此时不能再往 style 补默认值——style 优先级高于属性，会覆盖掉
   //    step-2 内联的正确颜色。
-  out = out.replace(/<text([^>]*?)>/gi, (_m, attrs: string) => {
-    const hasFillAttr = /\bfill=/.test(attrs);
-    const hasFontFamilyAttr = /\bfont-family=/.test(attrs);
-    const hasFontSizeAttr = /\bfont-size=/.test(attrs);
+  // Capture an optional trailing slash so a self-closing <text .../> stays />-terminated
+  // after we append style; otherwise the slash lands mid-attrs and breaks parsing.
+  out = out.replace(/<text([^>]*?)(\/?)>/gi, (_m, attrs: string, slash: string) => {
+    // (^|\s) guards (not \b): keep data-fill / data-font-size from masking real attributes.
+    const hasFillAttr = /(?:^|\s)fill=/.test(attrs);
+    const hasFontFamilyAttr = /(?:^|\s)font-family=/.test(attrs);
+    const hasFontSizeAttr = /(?:^|\s)font-size=/.test(attrs);
     const styleMatch = attrs.match(/\bstyle="([^"]*)"/);
     if (!styleMatch) {
       // 无 style 的 text：属性已有全部三者就不补，否则补缺的到 style。
       const needFill = !hasFillAttr;
       const needFontFamily = !hasFontFamilyAttr;
       const needFontSize = !hasFontSizeAttr;
-      if (!needFill && !needFontFamily && !needFontSize) return `<text${attrs}>`;
+      if (!needFill && !needFontFamily && !needFontSize) return `<text${attrs}${slash}>`;
       const decls =
         (needFill ? `fill: ${defaultTextFill}; ` : '') +
         (needFontFamily ? `font-family: ${defaultFontFamily}; ` : '') +
         (needFontSize ? `font-size: 16px; ` : '');
-      return `<text${attrs} style="${decls.trim().replace(/;$/, '')}">`;
+      return `<text${attrs} style="${decls.trim().replace(/;$/, '')}"${slash}>`;
     }
     let style = styleMatch[1];
     // style 里缺、且属性里也没有时才补默认值。
     if (!/fill:/.test(style) && !hasFillAttr) style += `; fill: ${defaultTextFill}`;
     if (!/font-family:/.test(style) && !hasFontFamilyAttr) style += `; font-family: ${defaultFontFamily}`;
     if (!/font-size:/.test(style) && !hasFontSizeAttr) style += `; font-size: 16px`;
-    return `<text${attrs.replace(/\bstyle="[^"]*"/, `style="${style}"`)}>`;
+    // Function replacer: a literal string would let $& / $` / $' / $n inside the new style
+    // value be interpreted as replacement patterns and corrupt it (as stripRootSvgSize does).
+    return `<text${attrs.replace(/\bstyle="[^"]*"/, () => `style="${style}"`)}${slash}>`;
   });
 
   // 4. 删除 <style>（颜色已内联）。
@@ -244,7 +253,12 @@ export function normalizeSvg(xml: string): string {
     if (!text) return '';
     const x = w / 2;
     const y = h * 0.7;
-    return `<text x="${x}" y="${y}" text-anchor="middle" style="fill: ${defaultTextFill}; font-family: ${defaultFontFamily}; font-size: 16px">${text}</text>`;
+    // Prefer the label's own inline text color (span/div style="color:..."). The delimiter
+    // class [;"'\s] before "color:" avoids matching background-color, so we only override
+    // when a text color is clearly present; otherwise fall back to the default.
+    const colorMatch = fo.match(/[;"'\s]color\s*:\s*([^;"']+)/i);
+    const labelFill = colorMatch ? sanitizeCssValue(colorMatch[1].trim()) : defaultTextFill;
+    return `<text x="${x}" y="${y}" text-anchor="middle" style="fill: ${labelFill}; font-family: ${defaultFontFamily}; font-size: 16px">${text}</text>`;
   });
 
   // 6. 保护 <text>，删 xml 头/注释 + 标签间空白，再恢复。


### PR DESCRIPTION
## Summary

Follow-up hardening for the `svgUtils` rework merged in #23, addressing the five review nits from that PR's re-review. Each fix has a regression test.

## Changes (`packages/renderers/rn/src/svgUtils.ts`)

1. **Nested `style="…"` replace** now uses a function replacer, so `$&`/`` $` ``/`$'`/`$n` inside a `<text>` style value are no longer interpreted as replacement patterns (same technique `stripRootSvgSize` already uses).
2. **Default-fill regex** preserves an optional trailing self-close slash (`/<text([^>]*?)(\/?)>/`), so a self-closing `<text/>` stays `/>`-terminated and well-formed.
3. **"Already has attr" guards** use `(?:^|\s)` instead of `\b` (fill / stroke / stroke-width / font-family / font-size), so `data-fill` / `data-stroke` no longer mask real CSS inlining.
4. **`SHAPE_TAGS`** covers `line` / `polyline`, so sequence-diagram lifelines / message-lines and grid lines receive their CSS `stroke` (stroke-only; a stroked line stays unfilled, explicit `fill:none` preserved).
5. **`foreignObject` → `<text>`** honors the label's own inline `color` when present (the delimiter class avoids matching `background-color`), else falls back to the default.

Defensive vs behavioral: 1-3 are pure hardening (no change on real mermaid/d2 output); 4 adds line/polyline coloring; 5 narrows label color to the label's own inline color when present.

## Verification

- 38 `svgUtils` tests pass (30 original + 8 new; the 7 bug-detecting tests fail before these fixes).
- Ran the patched `normalizeSvg` over 2004 real styled reference SVGs (mermaid + d2): 0 exceptions, 0 residual `<style>`/`<foreignObject>`. All 440 output changes are attributable to the intended line/polyline stroke (#4, 337 files) and fill/label-color coverage (#5); 0 unexplained diffs (no regression).
