### PR TITLE
fix(graphviz-web): sync committed dist to the @actrium scope (fixes docs deploy)

### DIFF
--- a/crates/graphviz-anywhere/packages/web/dist/graphviz.d.ts
+++ b/crates/graphviz-anywhere/packages/web/dist/graphviz.d.ts
@@ -40,7 +40,7 @@ export interface GraphvizLoadOptions {
  *
  * @example
  * ```ts
- * import { Graphviz } from '@kookyleo/graphviz-anywhere-web';
+ * import { Graphviz } from '@actrium/graphviz-anywhere-web';
  *
  * const gv = await Graphviz.load();
  * const svg = gv.dot('digraph { a -> b; b -> c; }');

--- a/crates/graphviz-anywhere/packages/web/dist/graphviz.js
+++ b/crates/graphviz-anywhere/packages/web/dist/graphviz.js
@@ -21,7 +21,7 @@ var _Graphviz_module;
 import { DEFAULT_ENGINE, DEFAULT_FORMAT, GraphvizWebError, } from './shared.js';
 async function loadDefaultFactory() {
     try {
-        const mod = (await import('@kookyleo/graphviz-anywhere-web/wasm'));
+        const mod = (await import('@actrium/graphviz-anywhere-web/wasm'));
         return mod.default;
     }
     catch {
@@ -42,7 +42,7 @@ async function loadDefaultFactory() {
  *
  * @example
  * ```ts
- * import { Graphviz } from '@kookyleo/graphviz-anywhere-web';
+ * import { Graphviz } from '@actrium/graphviz-anywhere-web';
  *
  * const gv = await Graphviz.load();
  * const svg = gv.dot('digraph { a -> b; b -> c; }');

--- a/crates/graphviz-anywhere/packages/web/dist/shared.js
+++ b/crates/graphviz-anywhere/packages/web/dist/shared.js
@@ -56,7 +56,7 @@ export async function loadDefaultVizWasmModule() {
     let vizModuleFactory;
     try {
         // Published-package case: resolved via the `./wasm` export.
-        vizModuleFactory = (await import('@kookyleo/graphviz-anywhere-web/wasm'));
+        vizModuleFactory = (await import('@actrium/graphviz-anywhere-web/wasm'));
     }
     catch {
         try {


### PR DESCRIPTION
The committed `dist/` of `@actrium/graphviz-anywhere-web` still referenced the pre-rename `@kookyleo/graphviz-anywhere-web` (src moved to `@actrium/` but dist was never regenerated). The docs vitepress build resolves that committed `dist/shared.js`, so Rollup failed: `failed to resolve import "@kookyleo/graphviz-anywhere-web/wasm"` — breaking the docs-deploy workflow on every push to main since the rename (#17 onward).

Fix: point the three dist files at `@actrium/graphviz-anywhere-web` (its real name, with a `./wasm` export), matching src. Targeted scope sync, not a full `tsc` rebuild, to keep the diff minimal.

Verified the remaining repo-wide `@kookyleo/` references are non-module and don't affect the build: the plantuml reference-test fixture is intentionally pinned to the published `@kookyleo/graphviz-anywhere-web@0.1.8` (documented; the `@actrium` build isn't published), plus some lockfiles and a runtime unpkg CDN URL string.

Note: the docs-deploy workflow runs on push to main, not on PRs, so this can't be gated by PR CI — it validates on merge.