### PR TITLE
fix: review follow-ups — host-bridge indent + foreignObject label color

### DIFF
--- a/packages/engines/src/host-bridge.ts
+++ b/packages/engines/src/host-bridge.ts
@@ -76,17 +76,19 @@ export function installHostMetricsBridge(): void {
     return;
   }
 
-const measureText: MeasureFn = (family, text, size, bold) => {
-  try {
-    ctx.font = `${bold ? 'bold ' : ''}${size}px ${family}`;
-    const m = ctx.measureText(text);
-    const ascent = typeof m.actualBoundingBoxAscent === 'number' ? m.actualBoundingBoxAscent : size * 0.8;
-    const descent = typeof m.actualBoundingBoxDescent === 'number' ? m.actualBoundingBoxDescent : size * 0.2;
-    return { width: m.width, ascent, descent };
-  } catch {
-    return fallbackBox(text, size);
-  }
-};
+  const measureText: MeasureFn = (family, text, size, bold) => {
+    try {
+      ctx.font = `${bold ? 'bold ' : ''}${size}px ${family}`;
+      const m = ctx.measureText(text);
+      const ascent =
+        typeof m.actualBoundingBoxAscent === 'number' ? m.actualBoundingBoxAscent : size * 0.8;
+      const descent =
+        typeof m.actualBoundingBoxDescent === 'number' ? m.actualBoundingBoxDescent : size * 0.2;
+      return { width: m.width, ascent, descent };
+    } catch {
+      return fallbackBox(text, size);
+    }
+  };
 
   g.supramark = { ...(existing ?? {}), measureText };
   installed = true;

--- a/packages/renderers/rn/__tests__/svgUtils.test.ts
+++ b/packages/renderers/rn/__tests__/svgUtils.test.ts
@@ -403,6 +403,37 @@ test('normalizeSvg foreignObject falls back to #333 and ignores background-color
   expect(text).not.toMatch(/#fff/);
 });
 
+test('normalizeSvg foreignObject color comes from a style attr, not visible text', () => {
+  // A label whose visible text literally contains "color: red" must not be read
+  // as a CSS declaration; the fill stays the default.
+  const input =
+    '<svg><foreignObject width="80" height="16">' +
+    '<div><span class="nodeLabel">set color: red here</span></div></foreignObject></svg>';
+  const out = normalizeSvg(input);
+  const text = out.match(/<text[^>]*>[^<]*<\/text>/)?.[0] ?? '';
+  expect(text).toMatch(/fill:\s*#333/);
+  expect(text).not.toMatch(/fill:\s*red/);
+});
+
+test('normalizeSvg foreignObject inner span color wins over the outer', () => {
+  const input =
+    '<svg><foreignObject width="40" height="16">' +
+    '<div style="color:#111111"><span style="color:#00ff00">Hi</span></div></foreignObject></svg>';
+  const out = normalizeSvg(input);
+  const text = out.match(/<text[^>]*>Hi<\/text>/)?.[0] ?? '';
+  expect(text).toMatch(/fill:\s*#00ff00/);
+});
+
+test('normalizeSvg foreignObject color drops a trailing !important', () => {
+  const input =
+    '<svg><foreignObject width="40" height="16">' +
+    '<div><span style="color:#0000ff !important">Hi</span></div></foreignObject></svg>';
+  const out = normalizeSvg(input);
+  const text = out.match(/<text[^>]*>Hi<\/text>/)?.[0] ?? '';
+  expect(text).toMatch(/fill:\s*#0000ff/);
+  expect(text).not.toMatch(/!important/);
+});
+
 // ============================================================================
 // stripRootSvgSize — 精确删除根 <svg> 的 width/height（来自 upstream/main）
 // ============================================================================

--- a/packages/renderers/rn/src/svgUtils.ts
+++ b/packages/renderers/rn/src/svgUtils.ts
@@ -253,11 +253,15 @@ export function normalizeSvg(xml: string): string {
     if (!text) return '';
     const x = w / 2;
     const y = h * 0.7;
-    // Prefer the label's own inline text color (span/div style="color:..."). The delimiter
-    // class [;"'\s] before "color:" avoids matching background-color, so we only override
-    // when a text color is clearly present; otherwise fall back to the default.
-    const colorMatch = fo.match(/[;"'\s]color\s*:\s*([^;"']+)/i);
-    const labelFill = colorMatch ? sanitizeCssValue(colorMatch[1].trim()) : defaultTextFill;
+    // Prefer the label's own text color, read only from a style="..." attribute (never the
+    // visible label text) and only a real `color` property — the (?:^|;) boundary keeps
+    // `background-color` from matching. Last match wins, i.e. the innermost span's color.
+    // Strip a trailing !important: it's a cascade directive, not a valid SVG fill value.
+    let labelFill = defaultTextFill;
+    for (const sm of fo.matchAll(/style\s*=\s*"([^"]*)"/gi)) {
+      const decl = sm[1].match(/(?:^|;)\s*color\s*:\s*([^;]+)/i);
+      if (decl) labelFill = sanitizeCssValue(decl[1].replace(/\s*!important\s*$/i, '').trim());
+    }
     return `<text x="${x}" y="${y}" text-anchor="middle" style="fill: ${labelFill}; font-family: ${defaultFontFamily}; font-size: 16px">${text}</text>`;
   });
 


### PR DESCRIPTION
Two non-blocking follow-ups surfaced by the #32 / #41 reviews.

**1. `packages/engines/src/host-bridge.ts`** — restore `measureText`'s indentation. #32 accidentally de-indented it to column 0 (it stayed lexically inside the function, so logic was unchanged). Pure whitespace; `git diff -w` is empty.

**2. `packages/renderers/rn/src/svgUtils.ts`** — the `foreignObject` → `<text>` label color extraction now:
- reads the color only from a `style="..."` attribute, never the visible label text (a label literally containing `color: red` no longer poisons the fill);
- matches a real `color` property via a `(?:^|;)` boundary, so `background-color` doesn't match;
- takes the **innermost** style's color (the span wrapping the text), matching the CSS cascade, instead of the first match anywhere;
- strips a trailing `!important` so the emitted `fill` is a clean color, not a cascade directive.

+3 regression tests (41 pass total). Verified on the mermaid/d2 reference corpus: 0 exceptions, 0 residual `<style>`/`<foreignObject>`; rendered label colors unchanged (the 47 affected files switch to the innermost inline color — same color, now without `!important`).

**Third nit intentionally left:** the `@kookyleo` unpkg URL in `examples/react-web-csr/vite.config.ts` is a runtime CDN string and must stay on `@kookyleo` — `@actrium/graphviz-anywhere-web` is not published to npm, so an `@actrium` URL would 404 (documented at that call site, same deliberate exception as the plantuml test fixture).