### PR TITLE
ci: run plantuml-little Rust unit tests (build graphviz native lib)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,3 +179,43 @@ jobs:
             echo "::endgroup::"
           done
 
+  # plantuml-little's Rust tests (parser / layout / render unit tests) do not
+  # run in the "Test & Build" job — that job only exercises the RN JS wrappers,
+  # and `cargo test -p plantuml-little` needs the graphviz-anywhere native lib,
+  # which isn't on a clean runner. Build that lib once (cached), then run the
+  # library unit tests. `--lib` skips the byte-exact reference suite, which
+  # additionally needs a local Java PlantUML jar; that heavier suite can be a
+  # follow-up job. See the CI-coverage tracking issue.
+  plantuml-rust-tests:
+    name: plantuml-little Rust tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install Graphviz build tools
+        run: sudo apt-get update && sudo apt-get install -y cmake bison flex pkg-config
+
+      - name: Graphviz submodule revision
+        id: gv
+        run: echo "sha=$(git rev-parse HEAD:crates/graphviz-anywhere/graphviz)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Graphviz native lib
+        id: gv-cache
+        uses: actions/cache@v4
+        with:
+          path: crates/graphviz-anywhere/output
+          key: graphviz-api-linux-x86_64-${{ steps.gv.outputs.sha }}-${{ hashFiles('crates/graphviz-anywhere/scripts/**') }}
+
+      - name: Build Graphviz native lib
+        if: steps.gv-cache.outputs.cache-hit != 'true'
+        run: (cd crates/graphviz-anywhere && ./scripts/build-linux.sh)
+
+      - name: cargo test -p plantuml-little (lib unit tests)
+        run: cargo test -p plantuml-little --lib
+

--- a/crates/plantuml-little/src/parser/common.rs
+++ b/crates/plantuml-little/src/parser/common.rs
@@ -1367,6 +1367,20 @@ mod tests {
     }
 
     #[test]
+    fn detect_sequence_with_bracketed_message() {
+        // A sequence message may contain brackets (e.g. an array index or an
+        // `[optional]` note). The `[...]` + arrow heuristic that sets
+        // `has_class_relation` is ambiguous and must NOT, on its own, flip such
+        // a diagram to Class — only a class-exclusive relation (`*--`, `o--`,
+        // `<|`, `|>`, ...) may do that.
+        let content = "Alice -> Bob : items[0]\nBob --> Alice : ok\n";
+        assert!(matches!(
+            detect_diagram_type(content),
+            DiagramHint::Sequence
+        ));
+    }
+
+    #[test]
     fn detect_sequence_by_arrow() {
         let content = "Alice -> Bob : Hello\n";
         assert!(matches!(


### PR DESCRIPTION
Addresses #46: `plantuml-little`'s Rust tests (parser / layout / render) don't run in **any** CI job, so PlantUML Rust changes merge with green CI and zero Rust-side coverage — e.g. the `detect_diagram_type` regression surfaced reviewing #44.

**Why they don't run today:** the `Test & Build` job only runs the RN JS wrapper's `bun test` for plantuml; `cargo test -p plantuml-little` needs the `graphviz-anywhere` native lib (its `build.rs` requires `libgraphviz_api`, absent on a clean runner) — the same reason the JNI job excludes plantuml.

**This PR** adds a `plantuml-rust-tests` job that:
1. builds the graphviz native lib once via `crates/graphviz-anywhere/scripts/build-linux.sh` (cached on the graphviz submodule revision + scripts hash), then
2. runs `cargo test -p plantuml-little --lib`.

`--lib` covers the parser/layout/render unit tests **without** the byte-exact reference suite (that one is `#![cfg(feature = "metrics-ttf-parser")]` and additionally spawns a local Java PlantUML jar — a heavier follow-up job, noted in #46).

Also adds a `detect_diagram_type` regression test pinning that a sequence message containing brackets (`Alice -> Bob : items[0]`) stays **Sequence**, not Class — the exact case that had no coverage and that #44's #29 change regressed.

**Validated locally** (ubuntu, x86_64): `build-linux.sh` produces `output/linux-x86_64/lib/libgraphviz_api.a`; `build.rs` auto-discovers it; `cargo test -p plantuml-little --lib` passes **2691 tests in ~15s, no Java**.

Refs #46.