### PR TITLE
chore(deny): ignore quick-xml DoS advisories (unreachable via syntect themes)

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -127,4 +127,19 @@ ignore = [
     # impl and is a larger tracking task; allow it here for now so
     # cargo-deny stops blocking CI.
     "RUSTSEC-2026-0192",
+
+    # quick-xml < 0.41 carries two DoS advisories on crafted XML input:
+    #   RUSTSEC-2026-0194 — quadratic time checking a start tag for duplicate
+    #                       attribute names
+    #   RUSTSEC-2026-0195 — unbounded namespace-declaration allocation in
+    #                       NsReader (memory-exhaustion DoS)
+    # Reached only transitively (syntect -> plist -> quick-xml) and only to
+    # parse the bundled, trusted .tmTheme / .tmLanguage theme assets — never
+    # attacker-controlled XML (users supply code to highlight, not theme
+    # files), so neither DoS is reachable here. The real fix is quick-xml
+    # >= 0.41, but plist 1.9.0 (the latest release) pins `quick-xml = "^0.39.2"`
+    # and no newer plist / syntect release uses 0.41 yet; revisit once the
+    # upstream chain bumps quick-xml.
+    "RUSTSEC-2026-0194",
+    "RUSTSEC-2026-0195",
 ]


### PR DESCRIPTION
Two new advisories on `quick-xml 0.39.4` are failing **License Compliance** (cargo-deny) on every PR and on `main` re-runs:
- `RUSTSEC-2026-0194` — quadratic time checking a start tag for duplicate attribute names
- `RUSTSEC-2026-0195` — unbounded namespace-declaration allocation in `NsReader` (memory-exhaustion DoS)

**Neither is reachable here.** `quick-xml` is a purely transitive dep — `syntect -> plist -> quick-xml` — used only to parse the bundled, trusted `.tmTheme` / `.tmLanguage` theme assets. Users supply *code to highlight*, never theme XML, so the crafted-XML DoS path is unreachable.

**Upgrade is blocked upstream.** The real fix is `quick-xml >= 0.41`, but `plist 1.9.0` (the latest release) pins `quick-xml = "^0.39.2"`, and no newer `plist` / `syntect` release uses 0.41 — `cargo update -p quick-xml --precise 0.41.0` fails to resolve. So ignore the two advisories with that rationale (same pattern as the ttf-parser `RUSTSEC-2026-0192` entry), and revisit when the upstream chain bumps quick-xml.

Verified locally: `cargo deny check` → `advisories ok, bans ok, licenses ok, sources ok`.

Unblocks #48 (and every other PR) whose License Compliance is currently red on these two advisories.