### PR TITLE
fix(plantuml): add missing then-branch merge edge for if/else (#30)

### DIFF
--- a/crates/plantuml-little/src/layout/activity.rs
+++ b/crates/plantuml-little/src/layout/activity.rs
@@ -2598,6 +2598,35 @@ pub fn layout_activity(diagram: &ActivityDiagram) -> Result<ActivityLayout> {
                         kind: ActivityEdgeKindLayout::Normal,
                     });
                 }
+            } else if !die.then_branch.has_break {
+                // 1b. Then-branch merge (normal end): last then node → next flow
+                // node.  Symmetric to the else merge below (step 4) — without
+                // this, a `then` branch that ends normally never connects back
+                // to the merge point, so the diagram is missing the then-side
+                // merge leg (issue #30: 8 lines instead of the official 10).
+                if let (Some(last_idx), Some(next)) =
+                    (die.then_branch.nodes.last(), next_flow_idx)
+                {
+                    let last = &nodes[*last_idx];
+                    let last_cx = last.x + last.width / 2.0;
+                    let last_bottom = last.y + last.height;
+                    let merge_mid_y = die.merge_y + 5.0;
+                    let next_node = &nodes[next];
+                    let next_top = next_node.y;
+                    let next_cx = next_node.x + next_node.width / 2.0;
+                    edges.push(ActivityEdgeLayout {
+                        from_index: *last_idx,
+                        to_index: next,
+                        label: String::new(),
+                        points: vec![
+                            (last_cx, last_bottom),
+                            (last_cx, merge_mid_y),
+                            (next_cx, merge_mid_y),
+                            (next_cx, next_top),
+                        ],
+                        kind: ActivityEdgeKindLayout::IfMerge,
+                    });
+                }
             }
 
             // 2. Then branch connection (diamond left → first node)


### PR DESCRIPTION
## Problem

In an if/else activity diagram, the **then branch had no merge edge** back to the merge point when it ended normally. Only the `then has_goto` exit was handled; the else branch had its merge edge, but the then branch had no symmetric counterpart.

```
start
if (Graphviz installed?) then (yes)
  :process all\ndiagrams;
else (no)
  :process only __sequence__ and __activity__ diagrams;
endif
stop
```

Rendered with **8 connecting lines** instead of the official **10** — the then branch (left side) had no line from its bottom back to the merge point, so the diagram was visually incomplete.

## Root cause

`layout/activity.rs`, in the `has_else` branch of the if/else edge builder (Pass 3a):

- ✅ then-branch connection (diamond → first then node)
- ✅ then-branch internal edges
- ✅ else-branch connection (diamond → first else node)
- ✅ else-branch internal edges
- ✅ else-branch merge (last else node → next flow node)
- ❌ **then-branch merge (last then node → next flow node) — MISSING**

Only `then has_goto` produced a then-exit edge; a normally-ending then branch was dropped.

## Fix

Add a then-branch merge edge — a 4-point snake (`last → down → horizontal → next`) symmetric to the else merge — gated on `!has_goto && !has_break`.

## Verification

Rendered via the wasm package and compared against the official PlantUML server output:

| | Before | After | Official |
|---|---|---|---|
| Connecting lines | 8 | 11 | 10 |
| Then merge leg | ❌ missing | ✅ present | ✅ |

The after-render has 11 lines vs official 10: the then/else merge legs share the final vertical segment into the next node (one overlapping line, visually imperceptible). The official 10 avoids the overlap by routing the merge legs to the node's left/right shoulders (±12px) rather than its center — a geometry refinement that can be layered on top of this fix. The core bug (then branch disconnected) is resolved.

No regression on the other activity diagrams (#33 partition+fork, #38 while, etc.).

Fixes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)
