### PR TITLE
fix(plantuml): enum/annotation box height too short — members spill out (#37)

### DIFF
--- a/crates/plantuml-little/src/layout/mod.rs
+++ b/crates/plantuml-little/src/layout/mod.rs
@@ -103,8 +103,12 @@ const CLASS_FONT_SIZE: f64 = 14.0;
 /// FontParam.CLASS_ATTRIBUTE = 10pt.
 #[allow(dead_code)] // Java-ported constant for class attribute sizing
 const CLASS_ATTR_FONT_SIZE: f64 = 10.0;
-/// MethodsOrFieldsArea: empty compartment = margin_top(4) + margin_bottom(4).
-const LINE_HEIGHT_PT: f64 = 8.0;
+/// MethodsOrFieldsArea member row height.  Must match the renderer's member
+/// advance (MEMBER_ROW_HEIGHT = SansSerif 14pt ascent+descent) — previously
+/// 8.0 (just the empty-compartment margin), which made legacy-sized entities
+/// (enum/annotation) far too short: members spilled past the box bottom
+/// (issue #37).
+const LINE_HEIGHT_PT: f64 = MEMBER_ROW_HEIGHT;
 /// EntityImageClassHeader.java:150 — withMargin(circledChar, left=4, ...).
 const CIRCLE_LEFT_PAD: f64 = 4.0;
 /// SkinParam.circledCharacterRadius = 17/3+6 = 11. Diameter = 2 * 11 = 22.


### PR DESCRIPTION
## Problem

`enum` / `annotation` entity boxes were too short, so members spilled past the bottom border (issue #37).

For a 3-member enum:

```
enum OrderStatus {
  NEW
  PAID
  SHIPPED
}
```

the box was **72px** tall, but the renderer drew members ~16.3px apart, so `SHIPPED` overflowed the box bottom.

## Root cause

`estimate_entity_size_legacy` (used by `Enum` / `Annotation`) sized each member row at `LINE_HEIGHT_PT = 8.0`. That value is the **empty-compartment margin** (`margin_top 4 + margin_bottom 4`), not a row height:

```rust
let methods_height = members.len() as f64 * LINE_HEIGHT_PT + EMPTY_COMPARTMENT;
// 3 members → 3*8 + 8 = 32  (renderer needs ~48)
```

So the legacy compartment height was ~half what the renderer actually consumed.

## Fix

Set `LINE_HEIGHT_PT = MEMBER_ROW_HEIGHT` (16.296875 — SansSerif 14pt ascent+descent), matching the renderer's member advance:

```rust
const LINE_HEIGHT_PT: f64 = MEMBER_ROW_HEIGHT;
```

## Verification

Rendered via the wasm package and compared against the official PlantUML server output:

| | Before | After | Official |
|---|---|---|---|
| enum box height | 72px | **96.89px** | 96.891px |
| SHIPPED overflow | ❌ spills past bottom | ✅ inside box | ✅ |

No reference-SVG fixture exercises an enum/annotation, so the golden suite is unaffected. Class/object/interface entities use the standard (non-legacy) estimator and are untouched.

### Out of scope

Issue #37's screenshot also shows font-metrics drift (text widths ~10-15% wider than Java AWT) and the enum header using a `«enumeration»` text label instead of the `E` circled glyph. Those are separate, deeper issues (metrics backend + header rendering) not addressed here — this PR fixes the concrete overflow bug.

Fixes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)
