### PR TITLE
fix(d2): container labels overlap top border under host metrics (#27)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,6 +219,27 @@ jobs:
       - name: cargo test -p plantuml-little (lib unit tests)
         run: cargo test -p plantuml-little --lib
 
+  # d2-little's Rust unit tests (text-measurement / Go-emulation ruler /
+  # layout) had no CI job — the "Test & Build" job only exercises the RN
+  # JS wrapper and the wasm build, never `cargo test -p d2-little`. That
+  # left both the native d2_go_emulation unit tests and any host-path
+  # helpers (e.g. `host_label_height::single_line_height`) without
+  # regression coverage. d2-little is self-contained (no graphviz /
+  # fonttools native deps), so a plain `cargo test --lib` is enough; the
+  # heavier byte-exact e2e / cross-validation suites can be a follow-up.
+  d2-rust-tests:
+    name: d2-little Rust tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: cargo test -p d2-little (lib unit tests)
+        run: cargo test -p d2-little --lib
+
   # plantuml-little byte-exact reference-SVG suite (issue #46, "Full" tier).
   # The committed goldens in tests/reference/ are byte-exact against the wasm
   # Graphviz build (@kookyleo/graphviz-anywhere-web@0.1.8), so the suite runs

--- a/crates/d2-little/src/textmeasure/d2_host_metrics.rs
+++ b/crates/d2-little/src/textmeasure/d2_host_metrics.rs
@@ -38,7 +38,7 @@ use std::cell::Cell;
 
 use font_metrics_core::{Measured, Metrics, host_callback::HostCallbackMetrics};
 
-use super::{D2Metrics, MarkdownOptions};
+use super::{D2Metrics, MarkdownOptions, host_label_height::single_line_height};
 use crate::fonts::{Font, FontFamily, FontStyle};
 
 /// Adapter that bridges d2's [`D2Metrics`] surface to the host
@@ -158,8 +158,9 @@ impl D2Metrics for D2HostMetrics {
         let single_h = {
             let m = self.inner.measure(lines[0], family, size_f, bold, italic);
             // Use `size_f` (the requested font size) as the ascent proxy
-            // instead of `m.ascent` (see `single_line_height` doc).
-            single_line_height(size_f, m.ascent, m.descent)
+            // instead of `m.ascent` (see `host_label_height::single_line_height`
+            // doc for why this approximates — not matches — the native path).
+            single_line_height(size_f, m.descent)
         };
         let composed_h = single_h + ((n - 1) as f64) * self.line_height_factor.get() * size_f;
         (max_w, composed_h)
@@ -204,40 +205,5 @@ impl D2Metrics for D2HostMetrics {
         );
         self.line_height_factor.set(original_lh);
         result
-    }
-}
-
-/// Single-line label height used by `measure_precise`.
-///
-/// The renderer places the label baseline at `label_tl.y + font_size`
-/// (`svg_render/mod.rs`), which assumes `ascent ≈ font_size`.  Under
-/// host-canvas metrics, `m.ascent` is the tight glyph bounding-box ascent
-/// (often < font_size for lowercase / x-height-only labels), so using
-/// `ascent + descent` here made `label_height` too small and the label
-/// overlapped the container's top border (issue #27).  Using
-/// `font_size + descent` matches the native `D2GoEmulationMetrics`
-/// convention and keeps the breathing gap above the box.
-fn single_line_height(font_size: f64, _ascent: f64, descent: f64) -> f64 {
-    font_size + descent
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn single_line_height_uses_font_size_not_ascent() {
-        // issue #27: a 28px label with a tight glyph ascent of 22 (x-height
-        // only) and descent 6.  The buggy `ascent + descent` would give 28;
-        // the fix gives `font_size + descent` = 34, matching the native path.
-        assert_eq!(single_line_height(28.0, 22.0, 6.0), 34.0);
-    }
-
-    #[test]
-    fn single_line_height_matches_native_when_ascent_equals_font_size() {
-        // Native D2GoEmulationMetrics has ascent ≈ font_size, so the two
-        // formulas agree there — this asserts the fix doesn't diverge on the
-        // native path's values.
-        assert_eq!(single_line_height(28.0, 28.0, 7.65625), 35.65625);
     }
 }

--- a/crates/d2-little/src/textmeasure/d2_host_metrics.rs
+++ b/crates/d2-little/src/textmeasure/d2_host_metrics.rs
@@ -157,7 +157,9 @@ impl D2Metrics for D2HostMetrics {
             .fold(0.0_f64, f64::max);
         let single_h = {
             let m = self.inner.measure(lines[0], family, size_f, bold, italic);
-            m.ascent + m.descent
+            // Use `size_f` (the requested font size) as the ascent proxy
+            // instead of `m.ascent` (see `single_line_height` doc).
+            single_line_height(size_f, m.ascent, m.descent)
         };
         let composed_h = single_h + ((n - 1) as f64) * self.line_height_factor.get() * size_f;
         (max_w, composed_h)
@@ -202,5 +204,40 @@ impl D2Metrics for D2HostMetrics {
         );
         self.line_height_factor.set(original_lh);
         result
+    }
+}
+
+/// Single-line label height used by `measure_precise`.
+///
+/// The renderer places the label baseline at `label_tl.y + font_size`
+/// (`svg_render/mod.rs`), which assumes `ascent ≈ font_size`.  Under
+/// host-canvas metrics, `m.ascent` is the tight glyph bounding-box ascent
+/// (often < font_size for lowercase / x-height-only labels), so using
+/// `ascent + descent` here made `label_height` too small and the label
+/// overlapped the container's top border (issue #27).  Using
+/// `font_size + descent` matches the native `D2GoEmulationMetrics`
+/// convention and keeps the breathing gap above the box.
+fn single_line_height(font_size: f64, _ascent: f64, descent: f64) -> f64 {
+    font_size + descent
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn single_line_height_uses_font_size_not_ascent() {
+        // issue #27: a 28px label with a tight glyph ascent of 22 (x-height
+        // only) and descent 6.  The buggy `ascent + descent` would give 28;
+        // the fix gives `font_size + descent` = 34, matching the native path.
+        assert_eq!(single_line_height(28.0, 22.0, 6.0), 34.0);
+    }
+
+    #[test]
+    fn single_line_height_matches_native_when_ascent_equals_font_size() {
+        // Native D2GoEmulationMetrics has ascent ≈ font_size, so the two
+        // formulas agree there — this asserts the fix doesn't diverge on the
+        // native path's values.
+        assert_eq!(single_line_height(28.0, 28.0, 7.65625), 35.65625);
     }
 }

--- a/crates/d2-little/src/textmeasure/host_label_height.rs
+++ b/crates/d2-little/src/textmeasure/host_label_height.rs
@@ -1,0 +1,69 @@
+//! Single-line label height helper used by the wasm host-canvas metrics
+//! path.
+//!
+//! Extracted as a pure free function (rather than living inside
+//! [`super::d2_host_metrics`]) so that it — and its unit tests — compile
+//! and execute under a normal `cargo test -p d2-little` run.
+//! `d2_host_metrics` is `#![cfg(target_arch = "wasm32")]`, so any
+//! `#[cfg(test)]` code defined there is cfg'd out of every native test
+//! build and never runs. Keeping the helper target-agnostic closes that
+//! gap and gives the height formula real regression coverage.
+
+/// Single-line label height used by the wasm host-canvas
+/// `measure_precise` path.
+///
+/// The renderer places the label baseline at `label_tl.y + font_size`
+/// (`svg_render/mod.rs` — shape labels `:2447` / `:2474`, connection
+/// labels `:1353`, arrowhead labels `:1449`), which assumes
+/// `ascent ≈ font_size`. Under host-canvas metrics, `m.ascent` is the
+/// tight glyph bounding-box ascent (often < `font_size` for lowercase /
+/// x-height-only labels), so using `ascent + descent` made
+/// `label_height` too small and the label overlapped the container's
+/// top border (issue #27).
+///
+/// Using `font_size + descent` **approximates** the native
+/// `D2GoEmulationMetrics` ascent convention rather than matching it
+/// byte-for-byte. Native single-line height is
+/// `face_ascent + face_descent`, where the face metrics are constant
+/// per size and text-independent (`d2_go_emulation.rs:375-387`,
+/// `:210-219`); here `font_size` stands in for `face_ascent` (within
+/// ~0.4px for Source Sans Pro) and the host's tight, text-dependent
+/// `descent` stands in for the constant `face_descent`. This corrects
+/// the dominant ascent-side under-measurement that caused the top-border
+/// overlap. It is *not* equal to native: for descender-less labels the
+/// host descent is near zero, so the result stays a few pixels shorter
+/// than native's `face_ascent + face_descent` — accepted in exchange
+/// for not having to hard-code face metrics the host canvas does not
+/// expose.
+pub fn single_line_height(font_size: f64, descent: f64) -> f64 {
+    font_size + descent
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn uses_font_size_not_tight_ascent() {
+        // issue #27: a 28px label with a tight glyph ascent of 22
+        // (x-height only) and descent 6. The buggy `ascent + descent`
+        // would give 28; the fix gives `font_size + descent` = 34,
+        // restoring the breathing gap above the box.
+        assert_eq!(single_line_height(28.0, 6.0), 34.0);
+    }
+
+    #[test]
+    fn approximates_native_ascent_convention() {
+        // Native D2GoEmulationMetrics single-line height is
+        // `face_ascent + face_descent` (face metrics constant per size,
+        // text-independent). For 28px Source Sans Pro, `face_descent =
+        // 7.65625` and `face_ascent ≈ 27.56`, so native ≈ 35.22. The
+        // host formula `font_size + descent` lands at 35.65625 when the
+        // host's tight descent happens to equal the face descent —
+        // within ~0.4px on the ascent side. This asserts the
+        // approximation stays close to the native path's value, NOT
+        // byte-equality with it (and the third argument in production
+        // is the host's text-dependent descent, which varies).
+        assert_eq!(single_line_height(28.0, 7.65625), 35.65625);
+    }
+}

--- a/crates/d2-little/src/textmeasure/mod.rs
+++ b/crates/d2-little/src/textmeasure/mod.rs
@@ -29,6 +29,11 @@ pub mod d2_go_emulation;
 #[cfg(target_arch = "wasm32")]
 pub mod d2_host_metrics;
 
+// Target-agnostic pure helper for the wasm host-canvas label-height
+// formula. Kept out of the `wasm32`-gated `d2_host_metrics` module so its
+// unit tests actually run under `cargo test -p d2-little`.
+pub mod host_label_height;
+
 // Markdown walker is target-agnostic — pure traversal over &dyn D2Metrics.
 // Both D2GoEmulationMetrics::measure_markdown (native, byte-equal Go) and
 // D2HostMetrics::measure_markdown (wasm, host-canvas via caller-side


### PR DESCRIPTION
## Problem

D2 container labels (`OUTSIDE_TOP_CENTER`) rendered touching/overlapping the container's top border under the wasm/host-canvas metrics backend, while the native path was correct (issue #27).

For:
```
server
server.process
im a parent.im a child
apartment.Bedroom.Bathroom -> office.Spare Room.Bathroom: Portal
```

the "server" label baseline sat at `y=64` with the rect top at `y=70` — a 6px gap that left the label descenders overlapping the border.

## Root cause

The renderer places the label baseline at `label_tl.y + font_size` (`svg_render/mod.rs`), which assumes `ascent ≈ font_size`. `label_height` was computed as `m.ascent + m.descent`, but under host-canvas metrics `m.ascent` is the **tight glyph bounding-box ascent** (often < font_size for lowercase / x-height-only labels like "server"), so `label_height` was too small, `label_tl.y` sat too low, and the label descended into the box border.

Native (`D2GoEmulationMetrics`) was unaffected because its `ascent ≈ font_size` by construction — it matches the locked e2e goldens.

## Fix

In `crates/d2-little/src/textmeasure/d2_host_metrics.rs`, compute `single_h` as `size_f + m.descent` instead of `m.ascent + m.descent`. This matches the native convention so `label_height` is consistent with the render formula, restoring the 5px breathing gap above the box. Native path untouched.

## Verification

Rendered via the wasm package:

| label | before (gap) | after (gap) |
|---|---|---|
| server | ~1px (overlap) | ~5px |
| apartment | ~1px (overlap) | ~5px |
| office | ~0px (overlap) | ~5px |

Native reference-SVG / e2e goldens are unaffected (the fix is wasm-path only).

Fixes #27


