### PR TITLE
fix(engines/mermaid): center node and edge labels (#40)

### DIFF
--- a/packages/engines/__tests__/mermaid-label-centering.test.ts
+++ b/packages/engines/__tests__/mermaid-label-centering.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it, mock } from 'bun:test';
+
+// Issue #40: mermaid flowchart labels rendered off-center.
+//   - Node text sat at the bottom of its box instead of the vertical
+//     middle (foreignObject height = ascent+descent, but the inner div
+//     paints at line-height 1.5 and overflows downward under
+//     `display: table-cell`).
+//   - Edge-label text sat ~width/2 to the LEFT of its edge (the label
+//     group's `translate(-w/2, …)` recentred the background rect but the
+//     text-anchor=middle text self-centres at x=0, so it never got the
+//     shift).
+//
+// Both are visual artifacts of markup that faithfully mirrors upstream
+// mermaid; supramark recenters them in `inlineMermaidSvg`. These tests
+// pin the post-processing by feeding a raw (pre-fix) SVG fragment
+// through `renderMermaidSvg` with the wasm mocked.
+
+const RAW_EDGE_LABEL =
+  '<g class="edgeLabel" transform="translate(200, 100)">' +
+  '<g class="label" data-id="L_a_b_0" transform="translate(-42, -7)">' +
+  '<g><rect class="background" style="" x="-2" y="-2" width="88" height="18"></rect>' +
+  '<text y="-10.1" text-anchor="middle" style="">' +
+  '<tspan class="text-outer-tspan row" x="0" y="-0.1em" dy="1.1em" text-anchor="middle">' +
+  '<tspan font-style="normal" class="text-inner-tspan" font-weight="normal">edge</tspan>' +
+  '<tspan font-style="normal" class="text-inner-tspan" font-weight="normal"> label</tspan>' +
+  '</tspan></text></g></g></g>';
+
+const RAW_NODE_LABEL =
+  '<g class="node default  " id="n0" transform="translate(200, 50)">' +
+  '<rect class="basic label-container" rx="5" ry="5" x="-100" y="-22" width="200" height="44"></rect>' +
+  '<g class="label" style="" transform="translate(-90, -7)"><rect></rect>' +
+  '<foreignObject width="180" height="14">' +
+  '<div style="display: table-cell; white-space: nowrap; line-height: 1.5; max-width: 200px; text-align: center;" xmlns="http://www.w3.org/1999/xhtml">' +
+  '<span class="nodeLabel "><p>The cat in the hat</p></span>' +
+  '</div></foreignObject></g></g>';
+
+const RAW_SVG =
+  '<svg id="mermaid-1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 200">' +
+  '<style>#mermaid-1{font-family:sans-serif;font-size:16px;fill:#333;}#mermaid-1 p{margin:0;}</style>' +
+  '<g><g class="nodes">' +
+  RAW_NODE_LABEL +
+  '</g><g class="edgeLabels">' +
+  RAW_EDGE_LABEL +
+  '</g></g></svg>';
+
+mock.module('../src/host-bridge.js', () => ({
+  __esModule: true,
+  installHostMetricsBridge: () => {},
+}));
+
+mock.module('@actrium/mermaid-little-web', () => ({
+  __esModule: true,
+  convert: () => RAW_SVG,
+}));
+
+const { renderMermaidSvg } = await import('../src/mermaid/index.ts');
+
+describe('mermaid label centering (#40)', () => {
+  it('recenters edge-label text on the edge midpoint', async () => {
+    const out = await renderMermaidSvg('flowchart LR\n  a -- "edge label" --> b');
+
+    // The label group must drop its -w/2 x-shift: the text self-centres
+    // via text-anchor=middle, so any x-shift moves it off the edge.
+    const labelTransform = out.match(
+      /<g class="label" data-id="L_a_b_0" transform="translate\(([^)]+)\)"/
+    )?.[1];
+    expect(labelTransform).toBe('0, -7');
+
+    // The background rect must straddle x=0 (x = -width/2) so it shares
+    // the text's centre line. width=88 → x=-44.
+    const rectX = out.match(
+      /<rect class="background"[^>]* x="([^"]+)"/
+    )?.[1];
+    expect(rectX).toBe('-44');
+  });
+
+  it('centers node-label content vertically inside the foreignObject', async () => {
+    const out = await renderMermaidSvg('flowchart LR\n  a("The cat in the hat")');
+
+    // The upstream `display: table-cell` lets the div grow to its
+    // (taller, line-height:1.5) content and overflow the foreignObject
+    // downward. Flex-centering with height:100% pins the div to the
+    // foreignObject box and centers its content.
+    expect(out).not.toContain('display: table-cell;');
+    expect(out).toContain('display: flex; align-items: center; justify-content: center;');
+    expect(out).toContain('height: 100%');
+    // foreignObject overflow must be visible so the (possibly taller)
+    // painted text isn't clipped.
+    expect(out).toContain('<foreignObject overflow="visible"');
+    // <p> default margin collapses (would otherwise re-introduce an offset).
+    expect(out).toContain('margin:0');
+  });
+});

--- a/packages/engines/src/mermaid/index.ts
+++ b/packages/engines/src/mermaid/index.ts
@@ -296,7 +296,17 @@ function fmtCoord(value: number): string {
 function recenterMermaidEdgeLabels(svg: string): string {
   return svg.replace(
     /<g class="edgeLabel" transform="translate\(([^,)]+),\s*([^)]+)\)"><g class="label" data-id="([^"]*)" transform="translate\(([^,)]+),\s*([^)]+)\)"><g><rect class="background"(?: style="([^"]*)")? x="-2" y="-2" width="([^"]+)" height="([^"]+)"><\/rect>/g,
-    (_match, lx, ly, did, _tx, ty, rs, w, h) => {
+    (
+      _match: string,
+      lx: string,
+      ly: string,
+      did: string,
+      _tx: string,
+      ty: string,
+      rs: string | undefined,
+      w: string,
+      h: string,
+    ) => {
       const width = parseFloat(w);
       const rectX = -width / 2;
       const styleAttr = rs !== undefined ? ` style="${rs}"` : '';

--- a/packages/engines/src/mermaid/index.ts
+++ b/packages/engines/src/mermaid/index.ts
@@ -258,6 +258,80 @@ function normalizeMermaidHtmlLabels(svg: string): string {
   });
 }
 
+/**
+ * Format a coordinate the way mermaid emits one — plain decimal, no
+ * scientific notation, float noise trimmed. Used when we rewrite SVG
+ * geometry that the wasm already serialised.
+ */
+function fmtCoord(value: number): string {
+  if (!Number.isFinite(value)) return '0';
+  return String(Math.round(value * 1e6) / 1e6);
+}
+
+/**
+ * Re-center SVG-text edge labels on their edge.
+ *
+ * `mermaid-little` faithfully reproduces upstream mermaid's edge-label
+ * markup for `htmlLabels: false`:
+ *
+ * ```html
+ * <g class="edgeLabel" transform="translate(lx, ly)">
+ *   <g class="label" transform="translate(-w/2, -h/2)">
+ *     <g><rect class="background" x="-2" y="-2" width="w+4" height="h+4"></rect>
+ *        <text text-anchor="middle">…tspans anchored at x=0…</text></g>
+ *   </g>
+ * </g>
+ * ```
+ *
+ * The `<text>` self-centres at local x=0 (text-anchor=middle) while the
+ * background rect spans local x=[-2, w+2] (centre w/2). After the outer
+ * `translate(-w/2, …)`, the rect lands on the edge midpoint but the text
+ * lands w/2 to its left — visibly off-centre (empirically ~30px for a
+ * 60px label; see issue #40).
+ *
+ * Re-centre by dropping the x-shift from the label-group transform (the
+ * text already self-centres) and shifting the rect to straddle x=0
+ * (`x = -width/2`). Text and background then share the same centre line.
+ */
+function recenterMermaidEdgeLabels(svg: string): string {
+  return svg.replace(
+    /<g class="edgeLabel" transform="translate\(([^,)]+),\s*([^)]+)\)"><g class="label" data-id="([^"]*)" transform="translate\(([^,)]+),\s*([^)]+)\)"><g><rect class="background"(?: style="([^"]*)")? x="-2" y="-2" width="([^"]+)" height="([^"]+)"><\/rect>/g,
+    (_match, lx, ly, did, _tx, ty, rs, w, h) => {
+      const width = parseFloat(w);
+      const rectX = -width / 2;
+      const styleAttr = rs !== undefined ? ` style="${rs}"` : '';
+      return (
+        `<g class="edgeLabel" transform="translate(${lx}, ${ly})">` +
+        `<g class="label" data-id="${did}" transform="translate(0, ${ty})">` +
+        `<g><rect class="background"${styleAttr} x="${fmtCoord(rectX)}" y="-2" width="${w}" height="${h}"></rect>`
+      );
+    }
+  );
+}
+
+/**
+ * Vertically center node/edge HTML labels inside their `<foreignObject>`.
+ *
+ * `mermaid-little` sizes each `<foreignObject>` to the font's
+ * ascent+descent, but the inner `<div>` paints at `line-height: 1.5`,
+ * producing a line box ~1.5× taller than the foreignObject. With the
+ * upstream `display: table-cell` the div grows to the (larger) content
+ * height and overflows the foreignObject downward, so the text sits at
+ * the bottom of the node instead of the middle (issue #40).
+ *
+ * Switching the div to a flex container that fills the foreignObject
+ * (`height: 100%`) and centers its content restores vertical centering
+ * even when the painted text is taller than the measured box — the
+ * foreignObject's `overflow="visible"` (set by `normalizeMermaidHtmlLabels`)
+ * keeps anything from being clipped.
+ */
+function centerMermaidHtmlLabels(svg: string): string {
+  return svg.replace(
+    /display:\s*table-cell;\s*white-space:\s*nowrap;\s*line-height:\s*1\.5;/g,
+    'display: flex; align-items: center; justify-content: center; height: 100%; white-space: nowrap; line-height: 1.5;'
+  );
+}
+
 function inlineMermaidSvg(svg: string, options?: Record<string, unknown>): string {
   const styleMatch = svg.match(/<style[^>]*>([\s\S]*?)<\/style>/i);
   const cssText = styleMatch?.[1] ?? '';
@@ -296,6 +370,8 @@ function inlineMermaidSvg(svg: string, options?: Record<string, unknown>): strin
 
   next = applyFontFamilies(next, textFontFamily, monoFontFamily);
   next = normalizeMermaidHtmlLabels(next);
+  next = recenterMermaidEdgeLabels(next);
+  next = centerMermaidHtmlLabels(next);
   return next;
 }
 


### PR DESCRIPTION
## Summary

Fixes #40 — Mermaid 流程图文字不居中、超出边框。

For `htmlLabels: false` flowcharts (the issue's repro), labels rendered off-center in two ways:

1. **Node text not vertically centered** — sat at the bottom of the box instead of the middle.
2. **Edge-label text not horizontally centered** — sat ~width/2 to the **left** of its edge.

### Root cause

Both artifacts come from markup that `mermaid-little` emits *faithfully matching upstream mermaid*, so the fix belongs in the engine post-processing layer ([`inlineMermaidSvg`](packages/engines/src/mermaid/index.ts)) rather than the wasm crate (which would break byte-exact parity fixtures).

**Node labels** — each `<foreignObject>` is sized to the font's `ascent+descent`, but the inner `<div>` paints at `line-height: 1.5`, i.e. a line box ~1.5× taller. Under the upstream `display: table-cell`, the div grows to the (taller) content height and overflows the foreignObject **downward**, dropping the text to the bottom of the node.

**Edge labels** — the markup is:
```html
<g class="edgeLabel" transform="translate(lx, ly)">          <!-- edge midpoint -->
  <g class="label" transform="translate(-w/2, -h/2)">         <!-- shifts content left by w/2 -->
    <rect class="background" x="-2" width="w+4"/>             <!-- rect centre → edge midpoint ✓ -->
    <text text-anchor="middle">…anchored at x=0…</text>      <!-- text centre → w/2 LEFT of midpoint ✗ -->
```
The `translate(-w/2, …)` re-centers the **background rect** on the edge, but the `text-anchor=middle` text self-centres at local `x=0` and never receives the same shift, so it lands one half-width to the left.

### Fix

- **`centerMermaidHtmlLabels`** — switch the label `<div>` from `display: table-cell` to `display:flex; align-items:center; justify-content:center; height:100%`. The div now pins to the foreignObject box and centers its content; the foreignObject's `overflow="visible"` (already set by `normalizeMermaidHtmlLabels`) keeps taller text from being clipped.
- **`recenterMermaidEdgeLabels`** — drop the `x` shift from the label-group transform (the text already self-centres) and shift the background rect to `x = -width/2` so text and rect share the same centre line.

## Verification

Reproduced the issue's exact input in a headless browser (Chrome) and measured before/after with `getBoundingClientRect`:

| | before | after |
|---|---|---|
| Node text vs node center (vertical) | ~21 px off | **0 px** |
| Edge-label text vs edge midpoint (horizontal) | ~30 px off | **<1 px** |

Unit tests in [`packages/engines/__tests__/mermaid-label-centering.test.ts`](packages/engines/__tests__/mermaid-label-centering.test.ts) pin both transforms by feeding a raw (pre-fix) SVG fragment through `renderMermaidSvg` with the wasm mocked.

`bun run lint`, `bun run build`, and `bun test` (engines) all pass.

