### PR TITLE
chore: make diagram facade publishable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -288,13 +288,12 @@ dependencies = [
 
 [[package]]
 name = "d2-little"
-version = "0.7.2"
+version = "0.7.1-1"
 dependencies = [
  "base32",
  "base64",
  "fancy-regex",
  "flate2",
- "font-metrics",
  "log",
  "markdown",
  "regex",
@@ -303,6 +302,7 @@ dependencies = [
  "serde",
  "serde_json",
  "supramark-diagram-core",
+ "supramark-font-metrics",
  "ttf-parser",
  "unicode-segmentation",
  "unicode-width",
@@ -310,7 +310,7 @@ dependencies = [
 
 [[package]]
 name = "d2-little-web"
-version = "0.7.2"
+version = "0.7.1-1"
 dependencies = [
  "d2-little",
  "wasm-bindgen",
@@ -319,6 +319,17 @@ dependencies = [
 [[package]]
 name = "dagre"
 version = "0.1.1"
+dependencies = [
+ "log",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "dagre"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9468ae6a4b98e7102e0e59ba8f9aacd2266cec71817c19b62b2d61ee260524c1"
 dependencies = [
  "log",
  "serde",
@@ -466,15 +477,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
-name = "font-metrics"
-version = "0.1.0"
-dependencies = [
- "js-sys",
- "ttf-parser",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -530,7 +532,7 @@ dependencies = [
 
 [[package]]
 name = "graphviz-anywhere"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "supramark-diagram-core",
  "thiserror 1.0.69",
@@ -868,9 +870,8 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 name = "mermaid-little"
 version = "11.14.0-1"
 dependencies = [
- "dagre",
+ "dagre 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger",
- "font-metrics",
  "json5",
  "libm",
  "log",
@@ -882,6 +883,7 @@ dependencies = [
  "serde_json",
  "serde_yml",
  "supramark-diagram-core",
+ "supramark-font-metrics",
  "thiserror 1.0.69",
 ]
 
@@ -1015,12 +1017,11 @@ checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "plantuml-little"
-version = "1.2026.2-3"
+version = "1.2026.2-4"
 dependencies = [
  "base64",
  "env_logger",
  "flate2",
- "font-metrics",
  "graphviz-anywhere",
  "libc",
  "log",
@@ -1029,6 +1030,7 @@ dependencies = [
  "serde",
  "serde_json",
  "supramark-diagram-core",
+ "supramark-font-metrics",
  "thiserror 1.0.69",
  "ureq",
  "url",
@@ -1037,7 +1039,7 @@ dependencies = [
 
 [[package]]
 name = "plantuml-little-web"
-version = "1.2026.2-3"
+version = "1.2026.2-4"
 dependencies = [
  "plantuml-little",
  "wasm-bindgen",
@@ -1467,15 +1469,15 @@ dependencies = [
 
 [[package]]
 name = "supramark-d2-native"
-version = "0.7.2"
+version = "0.7.1-1"
 dependencies = [
  "d2-little",
- "font-metrics",
+ "supramark-font-metrics",
 ]
 
 [[package]]
 name = "supramark-diagram"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "d2-little",
  "graphviz-anywhere",
@@ -1492,6 +1494,15 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "supramark-font-metrics"
+version = "0.1.0"
+dependencies = [
+ "js-sys",
+ "ttf-parser",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1538,16 +1549,16 @@ dependencies = [
 name = "supramark-mermaid-native"
 version = "11.14.0-1"
 dependencies = [
- "font-metrics",
  "mermaid-little",
+ "supramark-font-metrics",
 ]
 
 [[package]]
 name = "supramark-plantuml-native"
-version = "1.2026.2-3"
+version = "1.2026.2-4"
 dependencies = [
- "font-metrics",
  "plantuml-little",
+ "supramark-font-metrics",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,11 +64,3 @@ panic = "abort"
 # crates would both claim the same `links` key.
 [patch.crates-io]
 graphviz-anywhere = { path = "crates/graphviz-anywhere/packages/rust" }
-
-# mermaid-little declares `dagre` against its upstream git repo
-# (https://github.com/Actrium/dagre-rs.git, branch = main). Inside the
-# super-monorepo we want it resolved to the in-tree subtree at
-# crates/dagre instead — a single dagre crate compiles into the workspace,
-# and cargo-deny does not flag a git source we never end up fetching.
-[patch."https://github.com/Actrium/dagre-rs.git"]
-dagre = { path = "crates/dagre" }

--- a/crates/d2-little/Cargo.toml
+++ b/crates/d2-little/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "d2-little"
-version = "0.7.2"
+version = "0.7.1-1"
 edition = "2024"
 license = "MPL-2.0"
 authors = ["kookyleo <kookyleo@gmail.com>"]
@@ -56,7 +56,7 @@ log = "0.4"
 # convention set by plantuml-little / mermaid-little; the rename leaves
 # the `font_metrics` namespace free for any future d2-little wrapper
 # module without crate-root shadowing.
-font_metrics_core = { package = "font-metrics", path = "../font-metrics", version = "0.1" }
+font_metrics_core = { package = "supramark-font-metrics", path = "../font-metrics", version = "0.1" }
 # Unified diagram engine abstraction (DiagramEngine / EngineAst etc.).
 supramark-diagram-core = { path = "../supramark-diagram-core", version = "0.1" }
 

--- a/crates/d2-little/UPSTREAM.md
+++ b/crates/d2-little/UPSTREAM.md
@@ -3,7 +3,9 @@
 ## Source repo
 - **Upstream:** https://github.com/Actrium/d2-little
 - **Pinned commit (at merge time):** `a8db3b23f3ba2f89e031e70525ace34b1d3f0226`
-- **Pinned tag:** `v0.7.2`
+- **Port crate source tag:** `v0.7.2`
+- **Ported Terrastruct D2 version:** `v0.7.1`
+- **Crates.io version policy:** `{terrastruct-d2-version}-{port-revision}`; current crate version is `0.7.1-1`.
 - **Merged into supramark on:** 2026-05-09 (step 3 of the super-monorepo plan)
 
 ## License relationship
@@ -52,7 +54,7 @@
 
 ## Sync cadence
 - **Upstream activity:** Active, kookyleo's project. Tagged releases.
-- **Sync strategy:** subtree pull on each tagged release.
+- **Sync strategy:** subtree pull on each tagged release. Crates.io releases use the ported Terrastruct D2 version plus a port revision (for example `0.7.1-1`), matching mermaid-little / plantuml-little style.
   ```
   git fetch subtree-d2
   git subtree pull --prefix=crates/d2-little subtree-d2 main

--- a/crates/d2-little/packages/native/Cargo.toml
+++ b/crates/d2-little/packages/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "supramark-d2-native"
-version = "0.7.2"
+version = "0.7.1-1"
 edition = "2024"
 license = "MPL-2.0"
 authors = ["kookyleo <kookyleo@gmail.com>"]
@@ -30,4 +30,4 @@ d2-little = { path = "../.." }
 # convention set by plantuml-little / mermaid-little. d2-little's main
 # crate uses the same rename, leaving `font_metrics` namespace free for
 # any future wrapper module without crate-root shadowing.
-font_metrics_core = { package = "font-metrics", path = "../../../font-metrics", version = "0.1", features = ["metrics-ffi-callback"] }
+font_metrics_core = { package = "supramark-font-metrics", path = "../../../font-metrics", version = "0.1", features = ["metrics-ffi-callback"] }

--- a/crates/d2-little/packages/web/Cargo.toml
+++ b/crates/d2-little/packages/web/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "d2-little-web"
-version = "0.7.2"
+version = "0.7.1-1"
 edition = "2024"
 license = "MPL-2.0"
 authors = ["kookyleo <kookyleo@gmail.com>"]

--- a/crates/d2-little/packages/web/package.json
+++ b/crates/d2-little/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@actrium/d2-little-web",
-  "version": "0.7.2",
+  "version": "0.7.1-1",
   "description": "wasm-bindgen wrapper for d2-little — run D2 diagrams → SVG in the browser",
   "type": "module",
   "license": "MPL-2.0",

--- a/crates/font-metrics/Cargo.toml
+++ b/crates/font-metrics/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "font-metrics"
+name = "supramark-font-metrics"
 version = "0.1.0"
 edition = "2021"
 rust-version = "1.82"

--- a/crates/graphviz-anywhere/packages/rust/Cargo.toml
+++ b/crates/graphviz-anywhere/packages/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graphviz-anywhere"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 rust-version = "1.64"
 description = "Safe Rust wrapper for the graphviz-anywhere C library with bundled prebuilt binaries (and a wasm32 JS bridge)"

--- a/crates/mermaid-little/Cargo.toml
+++ b/crates/mermaid-little/Cargo.toml
@@ -33,7 +33,7 @@ path = "src/main.rs"
 required-features = ["cli", "metrics-ttf-parser"]
 
 [features]
-default = ["cli"]
+default = ["cli", "metrics-ttf-parser"]
 cli = ["dep:env_logger"]
 # Embed QuickJS + KaTeX for byte-exact LaTeX math rendering. Required for
 # CLI / test parity with mermaid's `forceLegacyMathML: true` reference
@@ -51,13 +51,11 @@ cose_bilkent = ["dep:rquickjs"]
 
 # Metrics-impl selection. The metrics-* family is mutually exclusive —
 # exactly one impl must be active per build. The default feature set
-# above deliberately selects NONE: production consumers MUST set
-# `default-features = false` and explicitly pick one of the platform
-# impls below, so the choice is visible in the consumer's Cargo.toml
-# rather than implicit. `cargo test` here is unblocked by a dev-dep on
-# `mermaid-little` itself (see [dev-dependencies]) that flips on
-# `metrics-ttf-parser` so the existing *_byte_exact.rs reference
-# suites keep running unchanged.
+# selects `metrics-ttf-parser` so crates.io verification and normal native
+# consumers compile out of the box with byte-exact metrics. Web/RN hosts
+# still set `default-features = false` and explicitly pick their platform
+# bridge (`metrics-host-callback` or `metrics-ffi-callback`) so that choice
+# remains visible in the consumer's Cargo.toml.
 #
 # Historical note: prior to 2026-05-10 this slot was `metrics-static-
 # dejavu`, gated by ~22K LOC of offline-baked Java-FontMetrics-equivalent
@@ -112,7 +110,7 @@ supramark-diagram-core = { path = "../supramark-diagram-core", version = "0.1" }
 # Imported as `font_metrics_core` (via `package =`) because
 # mermaid-little's own `crate::font_metrics` wrapper module would
 # otherwise shadow the dep in the crate-root namespace.
-font_metrics_core = { package = "font-metrics", path = "../font-metrics", version = "0.1" }
+font_metrics_core = { package = "supramark-font-metrics", path = "../font-metrics", version = "0.1" }
 thiserror = "1"
 log = "0.4"
 env_logger = { version = "0.11", optional = true }
@@ -137,7 +135,7 @@ regex = "1"
 # constraint is added so cargo-deny does not flag a wildcard public
 # dependency. Tracked for upstream contribution in
 # crates/mermaid-little/UPSTREAM.md.
-dagre = { version = "0.1", git = "https://github.com/Actrium/dagre-rs.git", branch = "main" }
+dagre = "0.1.1"
 # Pure-Rust port of fdlibm. Used by the venn layout to match V8's
 # Math.* (acos/atan2/sqrt/sin/cos) byte-for-byte — V8 ships fdlibm too,
 # so routing all venn FP through libm eliminates ULP-level drift in the

--- a/crates/mermaid-little/packages/native/Cargo.toml
+++ b/crates/mermaid-little/packages/native/Cargo.toml
@@ -46,4 +46,4 @@ mermaid-little = { path = "../..", default-features = false, features = ["metric
 # `Metrics` impl chosen by `font_metrics_core` (mermaid-little's
 # rename of this crate) would not agree with what the native lib
 # advertises to the host.
-font-metrics = { path = "../../../font-metrics", features = ["metrics-ffi-callback"], package = "font-metrics" }
+font-metrics = { path = "../../../font-metrics", features = ["metrics-ffi-callback"], package = "supramark-font-metrics" }

--- a/crates/plantuml-little/Cargo.toml
+++ b/crates/plantuml-little/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "plantuml-little"
-version = "1.2026.2-3"
+version = "1.2026.2-4"
 edition = "2021"
 rust-version = "1.82"
 license = "GPL-3.0-or-later OR LGPL-3.0-or-later OR Apache-2.0 OR EPL-2.0 OR MIT"
@@ -49,7 +49,7 @@ path = "src/main.rs"
 required-features = ["cli", "metrics-ttf-parser"]
 
 [features]
-default = ["cli", "remote"]
+default = ["cli", "remote", "metrics-ttf-parser"]
 # Semantic AST: when on, derives serde::Serialize for model types and enables PlantumlEngine::semantic.
 semantic-serde = ["dep:serde"]
 # CLI front-end (env_logger + main.rs). Disabled automatically on wasm32.
@@ -60,13 +60,11 @@ remote = ["dep:ureq"]
 
 # Metrics-impl selection. The metrics-* family is mutually exclusive —
 # exactly one impl must be active per build. The default feature set
-# above deliberately selects NONE: production consumers MUST set
-# `default-features = false` and explicitly pick one of the platform
-# impls below, so the choice is visible in the consumer's Cargo.toml
-# rather than implicit. `cargo test` here is unblocked by a dev-dep on
-# `plantuml-little` itself (see [dev-dependencies]) that flips on
-# `metrics-ttf-parser` so the existing 268+ byte-equal-with-Java
-# reference SVG suite keeps running unchanged.
+# selects `metrics-ttf-parser` so crates.io verification and normal native
+# consumers compile out of the box with byte-exact metrics. Web/RN hosts
+# still set `default-features = false` and explicitly pick their platform
+# bridge (`metrics-host-callback` or `metrics-ffi-callback`) so that choice
+# remains visible in the consumer's Cargo.toml.
 #
 # Historical note: prior to 2026-05-10 this slot was `metrics-static-
 # dejavu`, gated by ~22K LOC of offline-baked Java-FontMetrics-equivalent
@@ -115,7 +113,7 @@ metrics-ffi-callback = []
 # Imported as `font_metrics_core` (via `package =`) because plantuml-
 # little's own `crate::font_metrics` wrapper module would otherwise
 # shadow the dep in the crate-root namespace.
-font_metrics_core = { package = "font-metrics", path = "../font-metrics", version = "0.1" }
+font_metrics_core = { package = "supramark-font-metrics", path = "../font-metrics", version = "0.1" }
 thiserror = "1"
 log = "0.4"
 env_logger = { version = "0.11", optional = true }

--- a/crates/plantuml-little/packages/native/Cargo.toml
+++ b/crates/plantuml-little/packages/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "supramark-plantuml-native"
-version = "1.2026.2-3"
+version = "1.2026.2-4"
 edition = "2024"
 rust-version = "1.85"
 # Inherit the upstream multi-licence disjunction. Downstream consumers
@@ -36,4 +36,4 @@ plantuml-little = { path = "../..", default-features = false, features = ["metri
 # Re-export `supramark_install_metrics_callback` and `MeasureTextFfi`
 # from the same `cdylib` so a single `dlopen` / static-link surface
 # satisfies the host's "install metrics, then render" sequence.
-font-metrics = { path = "../../../font-metrics", default-features = false, features = ["metrics-ffi-callback"] }
+font-metrics = { package = "supramark-font-metrics", path = "../../../font-metrics", default-features = false, features = ["metrics-ffi-callback"] }

--- a/crates/plantuml-little/packages/web/Cargo.toml
+++ b/crates/plantuml-little/packages/web/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plantuml-little-web"
-version = "1.2026.2-3"
+version = "1.2026.2-4"
 edition = "2021"
 rust-version = "1.82"
 license = "GPL-3.0-or-later OR LGPL-3.0-or-later OR Apache-2.0 OR EPL-2.0 OR MIT"

--- a/crates/supramark-diagram/Cargo.toml
+++ b/crates/supramark-diagram/Cargo.toml
@@ -1,21 +1,23 @@
 [package]
 name = "supramark-diagram"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 rust-version = "1.82"
 license = "Apache-2.0"
-publish = false
+homepage = "https://github.com/Actrium/supramark"
+repository = "https://github.com/Actrium/supramark"
+documentation = "https://docs.rs/supramark-diagram"
 description = "Facade assembling the four engines: default_registry() yields a unified DiagramRegistry for CLI / FFI / downstream consumers."
 
 [dependencies]
 supramark-diagram-core = { path = "../supramark-diagram-core", version = "0.1" }
-d2-little = { path = "../d2-little" }
-mermaid-little = { path = "../mermaid-little", features = ["metrics-ttf-parser", "semantic-serde"] }
-plantuml-little = { path = "../plantuml-little", default-features = false, features = ["metrics-ttf-parser", "semantic-serde"] }
+d2-little = { path = "../d2-little", version = "=0.7.1-1" }
+mermaid-little = { path = "../mermaid-little", version = "11.14.0-1", features = ["metrics-ttf-parser", "semantic-serde"] }
+plantuml-little = { path = "../plantuml-little", version = "1.2026.2-4", default-features = false, features = ["metrics-ttf-parser", "semantic-serde"] }
 
 # The graphviz Rust adapter is exported only on native targets (wasm goes through the JS bridge, not wired up at this stage).
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-graphviz-anywhere = { path = "../graphviz-anywhere/packages/rust" }
+graphviz-anywhere = { path = "../graphviz-anywhere/packages/rust", version = "0.2.2" }
 
 [dev-dependencies]
 serde_json = "1"


### PR DESCRIPTION
Prepare supramark-diagram for crates.io publishing by making its dependency graph registry-resolvable.