### PR TITLE
fix: enable Windows graphviz release fallback

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -532,7 +532,7 @@ dependencies = [
 
 [[package]]
 name = "graphviz-anywhere"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "supramark-diagram-core",
  "thiserror 1.0.69",

--- a/crates/graphviz-anywhere/docs/cross-compile.md
+++ b/crates/graphviz-anywhere/docs/cross-compile.md
@@ -117,11 +117,11 @@ CI or airgapped environments). Override the release tag with
 
 - **Toolchain**: MSVC 2022, CMake, `bison`/`flex` (winflexbison)
 - **Build**: `./scripts/build-windows.sh`
-- **Output**: `output/windows-x86_64/`; ships as `.zip` (not `.tar.gz`)
-- **Release asset**: `graphviz-native-windows-x86_64.zip`
+- **Output**: `output/windows-x86_64/`; release ships as `.tar.gz`
+- **Release asset**: `graphviz-native-windows-x86_64.tar.gz`
 - **Override**: `$env:GRAPHVIZ_ANYWHERE_DIR = "output\windows-x86_64"; cargo build`
-- **build.rs**: env override works; auto-download is not supported (zip layout differs)
-- **Common errors**: `.zip` extraction must be done manually before building the Rust crate; place `graphviz_api.lib` under the dir pointed to by `GRAPHVIZ_ANYWHERE_DIR`
+- **build.rs**: env override works; auto-download extracts the `.tar.gz` release asset
+- **Common errors**: MSVC tools not on PATH when building from source; use a Developer Command Prompt/Git Bash or set `GRAPHVIZ_ANYWHERE_DIR` to a prebuilt directory containing `graphviz_api.lib`
 
 ## aarch64-pc-windows-msvc
 

--- a/crates/graphviz-anywhere/packages/rust/Cargo.toml
+++ b/crates/graphviz-anywhere/packages/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graphviz-anywhere"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2021"
 rust-version = "1.64"
 description = "Safe Rust wrapper for the graphviz-anywhere C library with bundled prebuilt binaries (and a wasm32 JS bridge)"

--- a/crates/graphviz-anywhere/packages/rust/build.rs
+++ b/crates/graphviz-anywhere/packages/rust/build.rs
@@ -325,19 +325,6 @@ fn try_github_release() -> bool {
         return false;
     };
 
-    // Windows .zip assets are not auto-extracted yet.
-    // TODO: windows zip extraction — implement curl+unzip (or PowerShell
-    // Expand-Archive) to handle .zip assets for Windows targets.
-    if asset.ends_with(".zip") {
-        eprintln!(
-            "graphviz-anywhere: automatic download of Windows .zip assets is not yet \
-             implemented.  Set GRAPHVIZ_ANYWHERE_DIR to point at the directory \
-             containing graphviz_api.lib, or drop the prebuilt lib under \
-             packages/rust/prebuilt/{target}/"
-        );
-        return false;
-    }
-
     let release_version = env::var("GRAPHVIZ_ANYWHERE_RELEASE_VERSION")
         .ok()
         .filter(|s| !s.is_empty())
@@ -389,8 +376,9 @@ fn try_github_release() -> bool {
             return false;
         }
 
+        let tar_flag = if asset.ends_with(".zip") { "-xf" } else { "-xzf" };
         let untar = Command::new("tar")
-            .args(["-xzf"])
+            .arg(tar_flag)
             .arg(&archive)
             .arg("-C")
             .arg(&staging)

--- a/crates/graphviz-anywhere/packages/rust/src/build_helpers.rs
+++ b/crates/graphviz-anywhere/packages/rust/src/build_helpers.rs
@@ -35,11 +35,9 @@ pub fn target_triple_to_asset_name(target: &str) -> Option<&'static str> {
         "x86_64-apple-ios" => Some("graphviz-native-ios-sim-x86_64.tar.gz"),
 
         // ── Windows ────────────────────────────────────────────────────────────
-        // Windows ships a .zip with a different layout; not auto-extracted here yet.
-        // TODO: windows zip extraction — implement curl+unzip logic for these.
         "x86_64-pc-windows-msvc"
-        | "x86_64-pc-windows-gnu" => Some("graphviz-native-windows-x86_64.zip"),
-        "aarch64-pc-windows-msvc" => Some("graphviz-native-windows-arm64.zip"),
+        | "x86_64-pc-windows-gnu" => Some("graphviz-native-windows-x86_64.tar.gz"),
+        "aarch64-pc-windows-msvc" => Some("graphviz-native-windows-arm64.tar.gz"),
 
         _ => None,
     }
@@ -129,7 +127,7 @@ pub fn is_ios_target(target: &str) -> bool {
 /// Returns `true` for targets where the release asset uses `.a` (static archive)
 /// rather than `.so` / `.dylib`.
 pub fn asset_is_static(target: &str) -> bool {
-    is_ios_target(target)
+    is_ios_target(target) || target.contains("windows")
 }
 
 /// Returns the lib filename to expect inside the extracted release archive.
@@ -139,7 +137,6 @@ pub fn asset_lib_filename(target: &str) -> &'static str {
         | "aarch64-apple-darwin"
         | "universal-apple-darwin" => "libgraphviz_api.dylib",
         t if is_ios_target(t) => "libgraphviz_api.a",
-        // Windows is not auto-extracted; this value is unused in practice.
         t if t.contains("windows") => "graphviz_api.lib",
         _ => "libgraphviz_api.so",
     }
@@ -229,7 +226,15 @@ mod tests {
     fn windows_arm64_asset() {
         assert_eq!(
             target_triple_to_asset_name("aarch64-pc-windows-msvc"),
-            Some("graphviz-native-windows-arm64.zip")
+            Some("graphviz-native-windows-arm64.tar.gz")
+        );
+    }
+
+    #[test]
+    fn windows_x86_64_asset() {
+        assert_eq!(
+            target_triple_to_asset_name("x86_64-pc-windows-msvc"),
+            Some("graphviz-native-windows-x86_64.tar.gz")
         );
     }
 
@@ -327,6 +332,11 @@ mod tests {
         assert_eq!(asset_lib_filename("x86_64-unknown-linux-gnu"), "libgraphviz_api.so");
     }
 
+    #[test]
+    fn asset_lib_filename_windows_is_static_import_name() {
+        assert_eq!(asset_lib_filename("x86_64-pc-windows-msvc"), "graphviz_api.lib");
+    }
+
     // ── is_ios_target ────────────────────────────────────────────────────────────
 
     #[test]
@@ -341,18 +351,18 @@ mod tests {
     // ── asset_is_static (static vs. dynamic link policy) ─────────────────────────
 
     #[test]
-    fn asset_is_static_only_for_ios() {
-        // iOS is the only target linked statically.
+    fn asset_is_static_for_ios_and_windows() {
+        // iOS and Windows release assets are linked statically.
         assert!(asset_is_static("aarch64-apple-ios"));
         assert!(asset_is_static("aarch64-apple-ios-sim"));
         assert!(asset_is_static("x86_64-apple-ios"));
-        // The published release asset for desktop/Android is the self-contained
-        // shared library (.so/.dylib), not a static archive.
+        assert!(asset_is_static("x86_64-pc-windows-msvc"));
+        // The published release asset for Linux/macOS/Android is the
+        // self-contained shared library (.so/.dylib), not a static archive.
         assert!(!asset_is_static("x86_64-unknown-linux-gnu"));
         assert!(!asset_is_static("aarch64-unknown-linux-gnu"));
         assert!(!asset_is_static("aarch64-apple-darwin"));
         assert!(!asset_is_static("x86_64-apple-darwin"));
-        assert!(!asset_is_static("x86_64-pc-windows-msvc"));
         assert!(!asset_is_static("aarch64-linux-android"));
     }
 
@@ -365,8 +375,10 @@ mod tests {
             "x86_64-unknown-linux-gnu",
             "aarch64-apple-darwin",
             "aarch64-linux-android",
+            "x86_64-pc-windows-msvc",
         ] {
-            let ships_archive = asset_lib_filename(target).ends_with(".a");
+            let lib_name = asset_lib_filename(target);
+            let ships_archive = lib_name.ends_with(".a") || lib_name.ends_with(".lib");
             assert_eq!(
                 asset_is_static(target),
                 ships_archive,


### PR DESCRIPTION
## Summary

- Enables the Windows graphviz release fallback for `graphviz-anywhere`.
- Keeps this release fix visible in the review flow instead of leaving it as an orphan `codex/*` branch.

## Validation

- Existing branch commit is tagged `v0.2.3`.
- This PR is stacked on `codex/publish-diagram-facade` because the branch includes that publishability commit.
