### PR TITLE
fix(mermaid): align label bounds with browser rendering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -868,7 +868,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "mermaid-little"
-version = "11.14.0-2"
+version = "11.14.0-3"
 dependencies = [
  "dagre 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger",
@@ -1477,7 +1477,7 @@ dependencies = [
 
 [[package]]
 name = "supramark-diagram"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "d2-little",
  "graphviz-anywhere",

--- a/crates/mermaid-little/Cargo.toml
+++ b/crates/mermaid-little/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mermaid-little"
-version = "11.14.0-2"
+version = "11.14.0-3"
 edition = "2021"
 rust-version = "1.82"
 license = "MIT"

--- a/crates/mermaid-little/src/layout/class.rs
+++ b/crates/mermaid-little/src/layout/class.rs
@@ -51,6 +51,8 @@ pub struct ClassLayout {
 /// Default padding — matches upstream `classRenderer-v3-unified.ts`
 /// which calls `setupViewPortForSVG(svg, padding=8)`.
 const VIEWBOX_PADDING: f64 = 8.0;
+const CLASS_BOX_PADDING: f64 = 12.0;
+const CLASS_HTML_LINE_HEIGHT: f64 = 24.0;
 
 /// Public entry point.
 pub fn layout(d: &ClassDiagram, theme: &ThemeVariables) -> Result<ClassLayout> {
@@ -238,9 +240,9 @@ fn build_layout_data(d: &ClassDiagram, _theme: &ThemeVariables) -> LayoutData {
         // (`tests/support/generate_ref.mjs`) measures `el.textContent`
         // for HTML elements, and `<br/>` contributes empty textContent.
         // So a multi-line note like "Foo\nBar" is measured as a single
-        // joined string "FooBar". bbox.height collapses to a single
-        // 16.296875 line. Padding = 6 ⇒ +12 on each axis.
-        let line_h = 16.296875_f64;
+        // joined string "FooBar". In a real browser the HTML label resolves
+        // to 16 px text with line-height:1.5, i.e. a 24 px line box.
+        let line_h = CLASS_HTML_LINE_HEIGHT;
         let note_padding = 6.0_f64;
         let joined: String = n.text.split('\n').collect();
         // Upstream's note label goes through DOMPurify into a foreignObject;
@@ -287,9 +289,9 @@ fn build_layout_data(d: &ClassDiagram, _theme: &ThemeVariables) -> LayoutData {
             // even when the label text is empty — the resulting fO collapses
             // to (0, line_h) which still nudges dagre's rank packing.
             // Without this, the note→class spline collapses by one
-            // line-height (~16 px), shifting downstream y-coordinates.
+            // line-height, shifting downstream y-coordinates.
             e.extra.insert("label_width".into(), "0".into());
-            e.extra.insert("label_height".into(), "16.296875".into());
+            e.extra.insert("label_height".into(), line_h.to_string());
             // Upstream sets arrowTypeStart/End to 'none' (string), which
             // renders as no marker reference. Leave both as None here.
             data.edges.push(e);
@@ -304,7 +306,7 @@ fn build_layout_data(d: &ClassDiagram, _theme: &ThemeVariables) -> LayoutData {
     // the `opacity:0; !important` style on the basic rect container.
     let iface_family = "trebuchet ms,verdana,arial,sans-serif";
     let iface_font = 14.0_f64;
-    let iface_line_h = 16.296875_f64;
+    let iface_line_h = CLASS_HTML_LINE_HEIGHT;
     for iface in &d.interfaces {
         // Upstream's `rect` shape measures the label's foreignObject and
         // pads with `labelPaddingX/Y`. For lollipop interfaces the text
@@ -340,7 +342,7 @@ fn build_layout_data(d: &ClassDiagram, _theme: &ThemeVariables) -> LayoutData {
     // — `make_edge_label` in the dagre bridge picks these up.
     let label_family = "trebuchet ms,verdana,arial,sans-serif";
     let label_font = 14.0_f64;
-    let label_line_h = 16.296875_f64;
+    let label_line_h = CLASS_HTML_LINE_HEIGHT;
     for (i, r) in d.relations.iter().enumerate() {
         let mut e = Edge {
             id: format!("id_{}_{}_{}", r.id1, r.id2, i + 1),
@@ -502,8 +504,8 @@ fn estimate_classbox_dimensions(c: &ClassNode) -> (f64, f64) {
     // For empty members AND methods (no `hideEmptyMembersBox`): renderExtraBox=true → extraHeight=24.
     let font = 14.0;
     let family = "trebuchet ms,verdana,arial,sans-serif";
-    let line_h = 16.296875_f64; // foreignObject height for label at 14 px
-    let padding = 12.0_f64;
+    let line_h = CLASS_HTML_LINE_HEIGHT;
+    let padding = CLASS_BOX_PADDING;
 
     // Label width (bold, html-label style — measured via foreignObject).
     // The foreignObject width tracks the rendered <p>{display_label}</p>
@@ -537,20 +539,20 @@ fn estimate_classbox_dimensions(c: &ClassNode) -> (f64, f64) {
     let has_members = !c.members.is_empty();
     let has_methods = !c.methods.is_empty();
 
-    // bbox.height — `generate_ref.mjs`'s getBBox shim *ignores* transforms
-    // when computing the union, and every foreignObject (label / each
-    // member / each method) starts at intrinsic (0, 0, w, line_h). Their
-    // union therefore collapses to a single (0, 0, max_w, line_h) box.
-    // We intentionally do NOT add per-row height here.
-    let _ = (has_members, has_methods);
-
-    // h adjustments per classBox.ts:
-    let mut h = bbox_h;
-    if !has_members && !has_methods {
-        h += padding; // GAP
-    } else if has_members && !has_methods {
-        h += padding * 2.0;
-    }
+    // Real browsers include each translated classBox text row in the shape
+    // bbox. The old jsdom fixture shim collapsed every foreignObject to the
+    // same local origin, producing very short boxes whose labels were clipped
+    // when rendered in Chrome/Safari. Count the visible rows and reserve the
+    // same vertical bands Mermaid paints: label/member/method rows, 4 GAPs for
+    // populated class boxes, and the outer top/bottom padding.
+    let annotation_rows = if c.annotations.is_empty() { 0 } else { 1 };
+    let label_rows = c.display_label().split('\n').count().max(1);
+    let row_count = annotation_rows + label_rows + c.members.len() + c.methods.len();
+    let band_gap_h = if has_members || has_methods {
+        padding * 4.0
+    } else {
+        padding
+    };
 
     // extraHeight: with empty members AND methods, renderExtraBox=true →
     // extraHeight = PADDING * 2 = 24. Otherwise 0.
@@ -561,7 +563,7 @@ fn estimate_classbox_dimensions(c: &ClassNode) -> (f64, f64) {
     };
 
     let drawn_w = bbox_w + 2.0 * padding;
-    let drawn_h = h + 2.0 * padding + extra_h;
+    let drawn_h = row_count as f64 * bbox_h + band_gap_h + 2.0 * padding + extra_h;
     (drawn_w, drawn_h)
 }
 

--- a/crates/mermaid-little/src/layout/state.rs
+++ b/crates/mermaid-little/src/layout/state.rs
@@ -12,10 +12,11 @@
 //! `stateDiagram`).
 
 use crate::error::Result;
-use crate::font_metrics::{line_height as font_line_height, text_width};
+use crate::font_metrics::text_width;
 use crate::layout::unified::render as unified_render;
 use crate::layout::unified::types::{Edge as LEdge, LayoutData, LayoutResult, Node as LNode};
 use crate::model::state::{NotePosition, ParseItem, StateDiagram, StateKind};
+use crate::render::foreign_object::{html_label_line_height, HTML_LABEL_FONT_SIZE};
 use crate::theme::ThemeVariables;
 
 /// Layout result for one state diagram.
@@ -80,12 +81,10 @@ const DEFAULT_NODE_SPACING: f64 = 50.0;
 const DEFAULT_RANK_SPACING: f64 = 50.0;
 const DEFAULT_LABEL_PAD_X: f64 = 8.0;
 const DEFAULT_LABEL_PAD_Y: f64 = 8.0;
-/// Font size used for node label measurement. Upstream's `labelHelper`
-/// calls `div.getBoundingClientRect()` on the foreignObject HTML label,
-/// which inherits the default 14 px sans-serif from the SVG root — NOT
-/// the theme's `fontSize` (16 px). Using 14 px here makes dagre assign
-/// the same node dimensions as upstream.
-const DEFAULT_FONT_SIZE: f64 = 14.0;
+/// Font size used for HTML labels inside Mermaid foreignObjects. The SVG root
+/// resolves to 16 px and label divs set `line-height: 1.5`, so a one-line
+/// label consumes 24 px in browser layout.
+const DEFAULT_FONT_SIZE: f64 = HTML_LABEL_FONT_SIZE;
 
 /// Public entry.
 pub fn layout(d: &StateDiagram, theme: &ThemeVariables) -> Result<StateLayout> {
@@ -315,7 +314,7 @@ pub fn layout(d: &StateDiagram, theme: &ThemeVariables) -> Result<StateLayout> {
                     // Node size = union_w + padding × union_h + padding.
                     n.shape = Some("rectWithTitle".into());
                     let desc_lines = state.description.as_ref().unwrap();
-                    let lh = font_line_height("sans-serif", DEFAULT_FONT_SIZE, node_is_bold, false);
+                    let lh = html_label_line_height(DEFAULT_FONT_SIZE);
                     let title_w =
                         text_width(label, "sans-serif", DEFAULT_FONT_SIZE, node_is_bold, false);
                     let mut max_w = title_w;
@@ -566,11 +565,9 @@ pub fn layout(d: &StateDiagram, theme: &ThemeVariables) -> Result<StateLayout> {
                             false,
                             false,
                         );
-                        // Note height is always 46.296875 (16.296875 + 2*15):
-                        // jsdom getBoundingClientRect on the single-line foreignObject returns
-                        // exactly one line height (16.296875) regardless of multi-line content.
-                        const NOTE_HEIGHT: f64 = 46.296875;
                         const NOTE_PAD: f64 = 15.0;
+                        let note_height =
+                            html_label_line_height(DEFAULT_FONT_SIZE) + 2.0 * NOTE_PAD;
                         let note_w = note_text_w + 2.0 * NOTE_PAD;
                         let note_node = LNode {
                             id: note_id.clone(),
@@ -581,7 +578,7 @@ pub fn layout(d: &StateDiagram, theme: &ThemeVariables) -> Result<StateLayout> {
                             look: Some("classic".into()),
                             label: Some(note.text.clone()),
                             width: Some(note_w),
-                            height: Some(NOTE_HEIGHT),
+                            height: Some(note_height),
                             parent_id: Some(parent_id_str.clone()),
                             ..Default::default()
                         };
@@ -1358,10 +1355,10 @@ fn decode_label_entities(s: &str) -> String {
 /// the full joined string gives the same result as measuring the textContent.
 fn measure_edge_label(text: &str) -> (f64, f64) {
     const EDGE_LABEL_FONT: &str = "sans-serif";
-    const EDGE_LABEL_SIZE: f64 = 14.0;
-    let h = font_line_height(EDGE_LABEL_FONT, EDGE_LABEL_SIZE, false, false);
+    const EDGE_LABEL_SIZE: f64 = HTML_LABEL_FONT_SIZE;
+    let h = html_label_line_height(EDGE_LABEL_SIZE);
     if text.is_empty() {
-        return (0.0, h);
+        return (0.0, 0.0);
     }
     // Measure the full text as one string — \n chars have zero advance so the
     // sum equals the textContent width (with <br/> tags stripped).  This
@@ -1388,7 +1385,7 @@ fn measure_lines_box(lines: &[&str], font_size: f64, bold: bool) -> (f64, f64) {
         }
     }
     let lines_n = lines.len().max(1) as f64;
-    let h = lines_n * font_line_height(font_family, font_size, bold, false);
+    let h = lines_n * html_label_line_height(font_size);
     let total_w = max_w + 2.0 * DEFAULT_LABEL_PAD_X;
     let total_h = h + 2.0 * DEFAULT_LABEL_PAD_Y;
     // No minimum width: upstream's labelHelper uses actual text metrics with

--- a/crates/mermaid-little/src/render/foreign_object.rs
+++ b/crates/mermaid-little/src/render/foreign_object.rs
@@ -37,7 +37,17 @@
 //!   trailing `.0`, fractions via Rust's shortest-decimal `{}` formatter
 //!   which matches Grisu3 / Ryū ≈ JS's default).
 
-use crate::font_metrics::{line_height, text_width};
+use crate::font_metrics::text_width;
+
+/// Browser-resolved default for labels rendered inside Mermaid's HTML
+/// `<foreignObject>` labels. The generated SVG root declares
+/// `font-size:16px`, and the label `<div>` declares `line-height: 1.5`.
+pub const HTML_LABEL_FONT_SIZE: f64 = 16.0;
+pub const HTML_LABEL_LINE_HEIGHT_RATIO: f64 = 1.5;
+
+pub fn html_label_line_height(font_size_px: f64) -> f64 {
+    font_size_px * HTML_LABEL_LINE_HEIGHT_RATIO
+}
 
 /// Detect a KaTeX block — at least one paired `$$..$$` on a single line.
 /// Mirrors mermaid's `katexRegex.test(text)` (`/\$\$(.*)\$\$/g`).
@@ -764,9 +774,10 @@ fn has_paired_markdown_markers(s: &str) -> bool {
 /// The jsdom shim in `tests/support/generate_ref.mjs::resolveFont`
 /// walks up the DOM looking for explicit `font-family` / `font-size` /
 /// `font-weight` ATTRIBUTES or inline `style` values — CSS class rules
-/// are IGNORED. If none are found, it defaults to `14px` / `sans-serif`
-/// / non-bold, which is what nearly every Stratum 3 `<foreignObject>`
-/// label resolves to in practice.
+/// are IGNORED. In real browser consumers the generated SVG root declares
+/// `font-size:16px` and the HTML label div declares `line-height: 1.5`,
+/// so the fallback must match that rendered size instead of the older
+/// jsdom-reference-only 14px assumption.
 ///
 /// Call with explicit `Some(...)` fields only when the emitted SVG
 /// actually sets a matching attribute on the label `<div>`, `<span>`,
@@ -782,8 +793,9 @@ pub struct HtmlLabelFont<'a> {
 impl<'a> HtmlLabelFont<'a> {
     fn resolve(&self) -> (&'a str, f64, bool) {
         (
-            self.font_family.unwrap_or("sans-serif"),
-            self.font_size_px.unwrap_or(14.0),
+            self.font_family
+                .unwrap_or("trebuchet ms,verdana,arial,sans-serif"),
+            self.font_size_px.unwrap_or(HTML_LABEL_FONT_SIZE),
             self.bold.unwrap_or(false),
         )
     }
@@ -820,7 +832,7 @@ pub fn measure_html_label(
     let (family, size, bold) = font.resolve();
     // Fast path: empty string.
     if text.is_empty() {
-        return (0.0, line_height(family, size, bold, false));
+        return (0.0, html_label_line_height(size));
     }
     // Upstream's parseEdge / parseGenericTypes converts every literal `\n`
     // in a label string to `<br/>` BEFORE the label reaches the
@@ -844,7 +856,7 @@ pub fn measure_html_label(
     let stripped = strip_paired_markdown_markers(text);
     let concatenated: String = stripped.split('\n').collect();
     let max_line_w = text_width(&concatenated, family, size, bold, false);
-    let lh = line_height(family, size, bold, false);
+    let lh = html_label_line_height(size);
     let _ = (max_width_px, wrap_enabled); // currently unused; reserved.
     (max_line_w, lh)
 }
@@ -920,11 +932,11 @@ pub fn measure_html_markup_label(
 ) -> (f64, f64) {
     let (family, size, base_bold) = font.resolve();
     if text.is_empty() {
-        return (0.0, line_height(family, size, base_bold, false));
+        return (0.0, html_label_line_height(size));
     }
     let _ = (max_width_px, wrap_enabled);
     let segments = parse_html_text_segments(text, base_bold);
-    let lh = line_height(family, size, base_bold, false);
+    let lh = html_label_line_height(size);
     let total_w: f64 = segments
         .iter()
         .map(|(seg, bold)| text_width(seg, family, size, *bold, false))
@@ -1412,35 +1424,27 @@ mod tests {
             is_node: false,
             add_background: true,
             group_style: None,
-            group_transform: Some("translate(0, -8.1484375)".into()),
+            group_transform: Some("translate(0, 0)".into()),
             ..LabelOpts::default()
         };
-        let got = render_node_label("", 0.0, 16.296875, &opts);
+        let got = render_node_label("", 0.0, 0.0, &opts);
         // The outer `<g class="edgeLabel" …>` is omitted — this is the
         // inner "label" only; caller can compose it.
-        assert_eq!(
-            got,
-            r#"<g class="label" data-id="id_Animal_Duck_1" transform="translate(0, -8.1484375)"><foreignObject width="0" height="16.296875"><div style="display: table-cell; white-space: nowrap; line-height: 1.5; max-width: 200px; text-align: center;" xmlns="http://www.w3.org/1999/xhtml" class="labelBkg"><span class="edgeLabel "></span></div></foreignObject></g>"#
-        );
+        assert!(got.contains(r#"height="0""#));
+        assert!(got.contains(r#"<span class="edgeLabel "></span>"#));
+        assert!(!got.contains("<p>"));
     }
 
     #[test]
-    fn measure_html_label_jsdom_default_14sans() {
-        // "id1" at 14px sans-serif should match what the jsdom shim
-        // returns for a bare <div> with no font attrs.
+    fn measure_html_label_uses_browser_default_line_height() {
+        // Browser-rendered Mermaid uses 16px HTML labels with `line-height: 1.5`.
         let (w, h) = measure_html_label("id1", &HtmlLabelFont::default(), 200.0, true);
-        // Verify against expected Rust font_metrics::text_width output.
-        let expected_w = text_width("id1", "sans-serif", 14.0, false, false);
-        let expected_h = line_height("sans-serif", 14.0, false, false);
+        let (family, size, bold) = HtmlLabelFont::default().resolve();
+        let expected_w = text_width("id1", family, size, bold, false);
+        let expected_h = html_label_line_height(size);
         assert!((w - expected_w).abs() < 1e-9);
         assert!((h - expected_h).abs() < 1e-9);
-        // The block fixture 03 emits width="21.68359375" height="16.296875"
-        // for "id1". Our measurement must agree.
-        assert!(
-            (w - 21.68359375).abs() < 1e-6,
-            "w={w}, expected 21.68359375"
-        );
-        assert!((h - 16.296875).abs() < 1e-6, "h={h}, expected 16.296875");
+        assert_eq!(h, 24.0);
     }
 
     #[test]
@@ -1450,9 +1454,10 @@ mod tests {
         // concatenated textContent as a single line. We mirror that here:
         // height stays 1× line-height, width sums the concatenated text.
         let (w, h) = measure_html_label("a\nbb", &HtmlLabelFont::default(), 200.0, true);
-        let lh = line_height("sans-serif", 14.0, false, false);
+        let (family, size, bold) = HtmlLabelFont::default().resolve();
+        let lh = html_label_line_height(size);
         assert!((h - lh).abs() < 1e-9, "h={h} expected single line {lh}");
-        let expected_w = text_width("abb", "sans-serif", 14.0, false, false);
+        let expected_w = text_width("abb", family, size, bold, false);
         assert!(
             (w - expected_w).abs() < 1e-9,
             "w={w} expected concat width {expected_w}"

--- a/crates/mermaid-little/src/render/svg_class.rs
+++ b/crates/mermaid-little/src/render/svg_class.rs
@@ -1,5 +1,5 @@
-//! Class diagram SVG renderer — byte-exact output against
-//! `mermaid@11.14.0`'s unified (dagre + d3 + jsdom) pipeline.
+//! Class diagram SVG renderer following `mermaid@11.14.0`'s unified
+//! (dagre + d3) pipeline while sizing labels for real browser rendering.
 //!
 //! # Structure mirrored
 //!
@@ -38,8 +38,11 @@ use crate::render::unified_shell;
 use crate::theme::css as theme_css;
 use crate::theme::ThemeVariables;
 
-/// Public entry point — renders a [`ClassDiagram`] + [`ClassLayout`] into a
-/// byte-accurate SVG string matching upstream mermaid@11.14.0.
+const CLASS_BOX_PADDING: f64 = 12.0;
+const CLASS_HTML_LINE_HEIGHT: f64 = 24.0;
+const CLASS_EDGE_LABEL_LINE_HEIGHT: f64 = 21.0;
+
+/// Public entry point — renders a [`ClassDiagram`] + [`ClassLayout`] into SVG.
 pub fn render(
     d: &ClassDiagram,
     l: &ClassLayout,
@@ -50,16 +53,17 @@ pub fn render(
 
     // ── 1. Compute viewBox ──────────────────────────────────────────
     //
-    // Upstream's `setupViewPortForSVG` calls `svg.node().getBBox()` and
-    // pads by 8 on every side. Crucially, the `generate_ref.mjs` jsdom
-    // shim that produces the byte-exact reference SVGs *ignores
-    // transforms* when computing getBBox — it walks the descendant
-    // intrinsic boxes (path / foreignObject / rect / line / …) in
-    // their **local** coords. To stay byte-exact we mimic the same
-    // quirk here.
+    // Upstream's `setupViewPortForSVG` pads the rendered browser bbox by
+    // eight pixels. Earlier byte-exact fixtures used a jsdom shim that
+    // ignored transforms, but browsers do not. The layout pass now exposes a
+    // browser-facing bbox and the renderer pads that box directly.
     let pad = 8.0_f64;
-    let svg_bbox = compute_svg_bbox_local(l, d);
-    let (mut bx, mut by, mut bw, mut bh) = svg_bbox;
+    let (mut bx, mut by, mut bw, mut bh) = (
+        l.viewbox_x + pad,
+        l.viewbox_y + pad,
+        (l.viewbox_w - 2.0 * pad).max(0.0),
+        (l.viewbox_h - 2.0 * pad).max(0.0),
+    );
     // Pre-title bounds — used for the title's `x` anchor. Mermaid sets
     // the title `x` to the centre of the pre-title bbox so the title
     // hugs the diagram, not the title itself.
@@ -511,10 +515,11 @@ fn render_cluster(id: &str, n: &LayoutNode, _theme: &ThemeVariables) -> String {
         let lx = cx - lw / 2.0;
         let ly = cy - h / 2.0;
         out.push_str(&format!(
-            r#"<g class="cluster-label " transform="translate({tx}, {ty})"><foreignObject width="{lw}" height="16.296875"><div style="display: table-cell; white-space: nowrap; line-height: 1.5;" xmlns="http://www.w3.org/1999/xhtml"><span class="nodeLabel "><p>{t}</p></span></div></foreignObject></g>"#,
+            r#"<g class="cluster-label " transform="translate({tx}, {ty})"><foreignObject width="{lw}" height="{lh}"><div style="display: table-cell; white-space: nowrap; line-height: 1.5;" xmlns="http://www.w3.org/1999/xhtml"><span class="nodeLabel "><p>{t}</p></span></div></foreignObject></g>"#,
             tx = fmt_num(lx),
             ty = fmt_num(ly),
             lw = fmt_num(lw),
+            lh = fmt_num(CLASS_EDGE_LABEL_LINE_HEIGHT),
             t = html_escape(label),
         ));
     }
@@ -581,7 +586,7 @@ fn render_class_text_row_indexed(
 ) -> String {
     let family = "trebuchet ms,verdana,arial,sans-serif";
     let font = 14.0_f64;
-    let line_h = 16.296875_f64;
+    let line_h = CLASS_HTML_LINE_HEIGHT;
     // The post-decode raw display text — keeps `*`/`_` markers in place.
     // Used as input to both the markdown-textContent measurement and the
     // markdown-to-HTML pass that fills the `<p>` element.
@@ -640,7 +645,7 @@ fn render_note_node(id: &str, n: &LayoutNode, theme: &ThemeVariables) -> String 
     // Padding is 6 (config.class.padding ?? 6) — see classDb.getData.
     let padding = 6.0_f64;
     let bbox_w = drawn_w - 2.0 * padding;
-    let line_h = 16.296875_f64;
+    let line_h = CLASS_HTML_LINE_HEIGHT;
     let bbox_h = line_h;
 
     let x0 = -drawn_w / 2.0;
@@ -1061,9 +1066,9 @@ fn render_node(id: &str, n: &LayoutNode, theme: &ThemeVariables, d: &ClassDiagra
     // `y_internal = -h/2` — is what the post-adjustment loop pivots
     // around. drawn_h = h_internal + 2*PADDING + 2*PADDING (renderExtraBox
     // adds extraHeight = PADDING*2), so h_internal = drawn_h - 4 * PADDING.
-    let padding = 12.0_f64;
-    let h_internal = drawn_h - 4.0 * padding;
-    let y_internal = -h_internal / 2.0;
+    let padding = CLASS_BOX_PADDING;
+    let top_y = -drawn_h / 2.0;
+    let first_text_band_y = top_y + 2.0 * padding;
 
     // Annotation group: when the class has at least one annotation
     // (only the first is rendered, mirroring upstream textHelper.ts),
@@ -1071,7 +1076,7 @@ fn render_node(id: &str, n: &LayoutNode, theme: &ThemeVariables, d: &ClassDiagra
     // emit an empty group at translate(0, y_internal).
     let label_font = 14.0_f64;
     let label_family = "trebuchet ms,verdana,arial,sans-serif";
-    let label_h = 16.296875_f64;
+    let label_h = CLASS_HTML_LINE_HEIGHT;
     let annotation_text = class_node
         .and_then(|c| c.annotations.first())
         .map(|a| format!("«{}»", a));
@@ -1089,7 +1094,7 @@ fn render_node(id: &str, n: &LayoutNode, theme: &ThemeVariables, d: &ClassDiagra
         out.push_str(&format!(
             r#"<g class="annotation-group text" transform="translate({ax}, {ay})"><g class="label" style="" transform="translate(0,{ily})"><foreignObject width="{w}" height="{h}"><div style="display: table-cell; white-space: nowrap; line-height: 1.5; max-width: {mw}px; text-align: center;" xmlns="http://www.w3.org/1999/xhtml"><span class="nodeLabel markdown-node-label" style=""><p>{txt}</p></span></div></foreignObject></g></g>"#,
             ax = fmt_num(annotation_x),
-            ay = fmt_num(y_internal),
+            ay = fmt_num(first_text_band_y),
             ily = fmt_num(-label_h / 2.0),
             w = fmt_num(annotation_w),
             h = fmt_num(label_h),
@@ -1100,7 +1105,7 @@ fn render_node(id: &str, n: &LayoutNode, theme: &ThemeVariables, d: &ClassDiagra
         out.push_str(&format!(
             r#"<g class="annotation-group text" transform="translate({ax}, {ay})"></g>"#,
             ax = fmt_num(annotation_x),
-            ay = fmt_num(y_internal),
+            ay = fmt_num(first_text_band_y),
         ));
     }
 
@@ -1121,7 +1126,7 @@ fn render_node(id: &str, n: &LayoutNode, theme: &ThemeVariables, d: &ClassDiagra
     //     `lineBreakRegex` and rounds per line, taking the max.
     let label_w = crate::font_metrics::text_width(label, label_family, label_font, true, false);
     let label_x = -label_w / 2.0;
-    let label_y = y_internal + raw_annotation_h;
+    let label_y = first_text_band_y + raw_annotation_h;
     out.push_str(&format!(
         r#"<g class="label-group text" transform="translate({lx}, {ly})">"#,
         lx = fmt_num(label_x),
@@ -1196,9 +1201,6 @@ fn render_node(id: &str, n: &LayoutNode, theme: &ThemeVariables, d: &ClassDiagra
     // formulas collapse to the original constants we already use;
     // for non-empty rows, we replicate the textHelper transform plus the
     // classBox post-adjustment loop.
-    let has_members = class_node.is_some_and(|c| !c.members.is_empty());
-    let has_methods = class_node.is_some_and(|c| !c.methods.is_empty());
-    let render_extra_box = !has_members && !has_methods;
     // bbox.width as seen by classBox = max foreignObject width across
     // all visible groups. For empty members/methods this is just the
     // label's foreignObject width.
@@ -1258,57 +1260,10 @@ fn render_node(id: &str, n: &LayoutNode, theme: &ThemeVariables, d: &ClassDiagra
                                // sits at intrinsic (0,0); the union therefore collapses to a single
                                // (0, 0, max_w, line_h) box regardless of row count (see notes in
                                // layout/class.rs::estimate_classbox_dimensions).
-    let raw_members_h = if has_members { label_h } else { 0.0 };
-    let extra_sub = if render_extra_box { padding / 2.0 } else { 0.0 };
-    let annotation_h_cb = if raw_annotation_h - extra_sub == 0.0 {
-        0.0
-    } else {
-        raw_annotation_h - extra_sub
-    };
-    let label_h_cb = if raw_label_h - extra_sub == 0.0 {
-        0.0
-    } else {
-        raw_label_h - extra_sub
-    };
-    let members_h_cb = if raw_members_h - extra_sub == 0.0 {
-        0.0
-    } else {
-        raw_members_h - extra_sub
-    };
-    let h_internal_real = if render_extra_box {
-        drawn_h - 4.0 * padding
-    } else {
-        drawn_h - 2.0 * padding
-    };
-    let y_internal_real = -h_internal_real / 2.0;
-    let extra_box_offset = if render_extra_box {
-        padding
-    } else if !has_members && !has_methods {
-        -padding / 2.0
-    } else {
-        0.0
-    };
-    // Initial translateY set by textHelper for members:
-    //   annotationGroupHeight (raw, untouched by classBox subtraction)
-    //   + labelGroupHeight (raw)
-    //   + GAP * 2
-    // Note: textHelper uses the *raw* heights. classBox's subtracted
-    // values are only used in its own newTranslateY formula.
-    let members_translate_y_initial = raw_annotation_h + raw_label_h + 2.0 * padding;
-    let members_translate_y =
-        members_translate_y_initial + y_internal_real + padding - extra_box_offset;
-
-    // textHelper methods translateY uses post-set membersGroupHeight,
-    // but classBox *overrides* this for the methods-group with
-    //   newTranslateY = annotation_cb + label_cb + max(members_cb, GAP/2) + y + GAP*4 + PADDING
-    // (when `nodeHeightGreater` is false, the common case here).
-    let members_h_for_methods = members_h_cb.max(padding / 2.0);
-    let methods_translate_y = annotation_h_cb
-        + label_h_cb
-        + members_h_for_methods
-        + y_internal_real
-        + 4.0 * padding
-        + padding;
+    let member_row_count = class_node.map(|c| c.members.len()).unwrap_or(0);
+    let members_translate_y = label_y + raw_label_h + 2.0 * padding;
+    let methods_translate_y =
+        members_translate_y + member_row_count as f64 * label_h + 2.0 * padding;
 
     // Emit members-group.
     out.push_str(&format!(
@@ -1338,23 +1293,10 @@ fn render_node(id: &str, n: &LayoutNode, theme: &ThemeVariables, d: &ClassDiagra
     }
     out.push_str("</g>");
 
-    // Divider lines. Upstream emits these whenever
-    // `members.len() > 0 || methods.len() > 0 || renderExtraBox`. For
-    // class/186 (renderExtraBox=true) we emit both:
-    //   firstLineY  = annotationGroupHeight + labelGroupHeight + y_internal + PADDING
-    //   secondLineY = annotationGroupHeight + labelGroupHeight + membersGroupHeight + y_internal + GAP*2 + PADDING
-    //
-    // The `*Height` values are reduced by `PADDING/2` for the
-    // renderExtraBox path (truthy in JS even when negative, hence we
-    // reproduce the same "-6 / 10.296875 / -6" fall-out byte-for-byte).
-    // Use the same group heights classBox itself uses (the *_cb values),
-    // not the raw textHelper values. With `renderExtraBox=true` the
-    // empty-group case collapses into the legacy `-6 / 10.296875 / -6`
-    // constants byte-for-byte; non-empty groups go through the populated
-    // formula.
-    let first_line_y = annotation_h_cb + label_h_cb + y_internal_real + padding;
-    let second_line_y =
-        annotation_h_cb + label_h_cb + members_h_cb + y_internal_real + 2.0 * padding + padding;
+    // Divider lines sit in the gap immediately above the members/methods
+    // groups in browser-rendered Mermaid output.
+    let first_line_y = members_translate_y - 2.0 * padding;
+    let second_line_y = methods_translate_y - 2.0 * padding;
 
     out.push_str(&format!(
         r#"<g class="divider" style="{gs}"><path d=""#,
@@ -1467,6 +1409,7 @@ fn rough_curve(out: &mut String, x1: f64, y1: f64, x2: f64, y2: f64, c: f64, fir
 // their `pathBBox` is computed by parsing the same `d=` string the
 // renderer emits — i.e. apply marker offsets and walk the curveBasis
 // spline expansion.
+#[allow(dead_code)]
 fn compute_svg_bbox_local(l: &ClassLayout, d: &ClassDiagram) -> (f64, f64, f64, f64) {
     let mut min_x = f64::INFINITY;
     let mut min_y = f64::INFINITY;
@@ -2003,7 +1946,11 @@ fn render_edge_label(e: &crate::layout::unified::types::Edge, cross_cluster: boo
             false,
         )
     };
-    let label_h = 16.296875; // Default line height
+    let label_h = if label_text.is_empty() {
+        0.0
+    } else {
+        CLASS_EDGE_LABEL_LINE_HEIGHT
+    };
 
     let opts = LabelOpts {
         data_id: Some(&e.id),
@@ -2247,7 +2194,7 @@ fn render_edge_terminal(
         false,
         false,
     );
-    let fo_h = 16.296875_f64;
+    let fo_h = CLASS_EDGE_LABEL_LINE_HEIGHT;
     // Inner translate centres the foreignObject around its origin —
     // upstream's `computeLabelTransform` returns `(-w/2, -h/2)`.
     let inner_tx = -fo_w / 2.0;
@@ -2258,15 +2205,17 @@ fn render_edge_terminal(
     //   t.style.height = "12px";
     // i.e. it overwrites the foreignObject's inline `style.width` with
     // `label.length * 9` where `length` is JS UTF-16 code units. Replicate
-    // that here so terminal labels with multi-character multiplicities
+    // the width here so terminal labels with multi-character multiplicities
     // (e.g. "many", "0..n", "1..n") emit `width: 36px` instead of a
-    // hardcoded `9px`.
+    // hardcoded `9px`. Do not keep upstream's 12px style height: in a real
+    // browser it overrides the `height` attribute and clips the XHTML label.
     let style_w_px = text.encode_utf16().count() * 9;
     let fo_block = format!(
-        r#"<foreignObject width="{w}" height="{h}" style="width: {sw}px; height: 12px;"><div style="display: table-cell; white-space: nowrap; line-height: 1.5;" xmlns="http://www.w3.org/1999/xhtml"><span class="edgeLabel "><p>{txt}</p></span></div></foreignObject>"#,
+        r#"<foreignObject width="{w}" height="{h}" style="width: {sw}px; height: {sh}px;"><div style="display: table-cell; white-space: nowrap; line-height: 1.5;" xmlns="http://www.w3.org/1999/xhtml"><span class="edgeLabel "><p>{txt}</p></span></div></foreignObject>"#,
         w = fmt_num(fo_w),
         h = fmt_num(fo_h),
         sw = style_w_px,
+        sh = fmt_num(fo_h),
         txt = html_escape(text),
     );
 
@@ -2815,6 +2764,39 @@ mod tests {
         assert_byte_exact(&got, &expected_norm, rel)
     }
 
+    fn render_rel(rel: &str) -> String {
+        let base = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        let mmd = base.join("tests").join(format!("{}.mmd", rel));
+        let source =
+            std::fs::read_to_string(&mmd).unwrap_or_else(|e| panic!("read fixture {:?}: {e}", mmd));
+        let id = id_for_rel(rel);
+        render_fixture(&source, &id)
+    }
+
+    fn viewbox(svg: &str) -> [f64; 4] {
+        let start = svg.find(r#"viewBox=""#).expect("viewBox attribute") + r#"viewBox=""#.len();
+        let end = svg[start..]
+            .find('"')
+            .map(|i| start + i)
+            .expect("viewBox close quote");
+        let values: Vec<f64> = svg[start..end]
+            .split_whitespace()
+            .map(|part| part.parse::<f64>().expect("viewBox number"))
+            .collect();
+        assert_eq!(values.len(), 4);
+        [values[0], values[1], values[2], values[3]]
+    }
+
+    fn assert_class_fixture_has_browser_viewbox(rel: &str) {
+        let got = render_rel(rel);
+        assert!(got.contains(r#"class="classDiagram""#));
+        let vb = viewbox(&got);
+        assert_eq!(vb[0], 0.0, "{rel} should normalize the left browser bound");
+        assert_eq!(vb[1], 0.0, "{rel} should normalize the top browser bound");
+        assert!(vb[2] > 1.0, "{rel} width should be non-empty: {vb:?}");
+        assert!(vb[3] > 1.0, "{rel} height should be non-empty: {vb:?}");
+    }
+
     #[test]
     fn render_no_longer_returns_unsupported() {
         let d = parse("classDiagram\nclass Foo\n").unwrap();
@@ -2954,13 +2936,12 @@ mod tests {
         assert!(total > 0, "no class fixtures found");
     }
 
-    /// Byte-exact regression: the empty-members-and-methods class
-    /// fixtures (cypress/class/{39,50,101,186,191,196}) all share the
-    /// same upstream layout/render geometry. Pin down `186` so future
-    /// shape-utility refactors flag any drift.
+    /// Regression: this empty-members-and-methods fixture used to inherit a
+    /// jsdom-oriented negative viewBox. Browser consumption now normalizes the
+    /// visible content bounds instead.
     #[test]
-    fn class_186_is_byte_exact() {
-        assert!(check_one("ext_fixtures/cypress/class/186"));
+    fn class_186_has_browser_aligned_bounds() {
+        assert_class_fixture_has_browser_viewbox("ext_fixtures/cypress/class/186");
     }
 
     /// Diagnostic: reports shell-style alignment for the first class
@@ -2995,16 +2976,14 @@ mod tests {
         );
     }
 
-    /// Byte-exact regression: cypress fixtures 88/89/141/178 all share
-    /// a single dependency edge between two classes. They cover the
-    /// edge-spline contribution to viewBox and the markerOffset trim of
-    /// the `d=` path. Pin them down so the dependency-marker geometry
-    /// stays in sync.
+    /// Regression: cypress fixtures 88/89/141/178 all share a single
+    /// dependency edge between two classes. They cover edge-spline
+    /// contribution to the browser-facing viewBox after normalization.
     #[test]
-    fn class_88_89_141_178_are_byte_exact() {
+    fn class_88_89_141_178_have_browser_aligned_bounds() {
         for n in &["88", "89", "141", "178"] {
             let rel = format!("ext_fixtures/cypress/class/{}", n);
-            assert!(check_one(&rel), "{} should be byte-exact", rel);
+            assert_class_fixture_has_browser_viewbox(&rel);
         }
     }
 

--- a/crates/mermaid-little/src/render/svg_flowchart.rs
+++ b/crates/mermaid-little/src/render/svg_flowchart.rs
@@ -567,6 +567,7 @@ fn font_size_postprocess_node_svg(node: &UNode, svg: &str) -> String {
 /// the `x` attribute of the `<text class="flowchartTitleText">` element it
 /// appends — the title is then measured by jsdom's getBBox shim and pushes the
 /// outer bbox horizontally.
+#[allow(dead_code)]
 fn compute_viewbox(
     l: &FlowchartLayout,
     padding: f64,
@@ -986,6 +987,198 @@ fn compute_viewbox(
     (vb_x, vb_y, vb_w, vb_h, content_center_x)
 }
 
+/// Compute a viewBox for real browser rendering.
+///
+/// Older code mirrored the deterministic jsdom reference shim, which ignores
+/// many transforms while calculating `getBBox()`. Real Mermaid output is
+/// consumed by browsers, and browsers include the node/label transforms when
+/// deciding whether content is inside the SVG viewport. The shim-aligned box
+/// can therefore pass byte fixtures while clipping labels and bottom nodes in
+/// Chrome/Safari. This function unions the same high-level geometry the
+/// renderer emits, but in browser coordinates.
+fn compute_viewbox_browser(
+    l: &FlowchartLayout,
+    padding: f64,
+    title: Option<&str>,
+) -> (f64, f64, f64, f64, f64) {
+    use crate::render::foreign_object::{
+        measure_html_markup_label, replace_fa_icons, HtmlLabelFont,
+    };
+
+    struct BrowserBounds {
+        min_x: f64,
+        min_y: f64,
+        max_x: f64,
+        max_y: f64,
+    }
+
+    impl BrowserBounds {
+        fn empty() -> Self {
+            Self {
+                min_x: f64::INFINITY,
+                min_y: f64::INFINITY,
+                max_x: f64::NEG_INFINITY,
+                max_y: f64::NEG_INFINITY,
+            }
+        }
+
+        fn expand_box(&mut self, bx: f64, by: f64, bw: f64, bh: f64) {
+            if bw == 0.0 && bh == 0.0 {
+                return;
+            }
+            self.min_x = self.min_x.min(bx);
+            self.min_y = self.min_y.min(by);
+            self.max_x = self.max_x.max(bx + bw);
+            self.max_y = self.max_y.max(by + bh);
+        }
+
+        fn is_empty(&self) -> bool {
+            !self.min_x.is_finite()
+        }
+
+        fn width(&self) -> f64 {
+            self.max_x - self.min_x
+        }
+
+        fn height(&self) -> f64 {
+            self.max_y - self.min_y
+        }
+    }
+
+    let mut bounds = BrowserBounds::empty();
+
+    let font = HtmlLabelFont::default();
+
+    for n in &l.nodes {
+        if is_cyclic_helper_from_anchor_rewrite(n, l) {
+            continue;
+        }
+
+        let cx = n.x.unwrap_or(0.0);
+        let cy = n.y.unwrap_or(0.0);
+        let w = n.width.unwrap_or(0.0);
+        let h = n.height.unwrap_or(0.0);
+        bounds.expand_box(cx - w / 2.0, cy - h / 2.0, w, h);
+
+        let label_text = n.label.as_deref().unwrap_or("");
+        if !label_text.is_empty() {
+            let is_markdown = n.label_type.as_deref() == Some("markdown");
+            let label_escaped = if is_markdown {
+                crate::render::foreign_object::markdown_label_to_html(label_text)
+            } else {
+                crate::render::foreign_object::string_label_to_html(label_text)
+            };
+            let processed = replace_fa_icons(&label_escaped);
+            let node_bold = n
+                .css_styles
+                .as_deref()
+                .map(node_styles_have_bold)
+                .unwrap_or(false);
+            let label_font = if node_bold {
+                let mut f = font.clone();
+                f.bold = Some(true);
+                f
+            } else {
+                font.clone()
+            };
+            let (lw, lh) = if crate::render::foreign_object::contains_katex_marker(&processed) {
+                match crate::render::foreign_object::try_render_katex_label(&processed, &label_font)
+                {
+                    Some((_, w, h)) => (w, h),
+                    None => measure_html_markup_label(&processed, &label_font, 200.0, true),
+                }
+            } else {
+                measure_html_markup_label(&processed, &label_font, 200.0, true)
+            };
+            bounds.expand_box(cx - lw / 2.0, cy - lh / 2.0, lw, lh);
+        }
+    }
+
+    for e in &l.edges {
+        if is_replaced_self_loop(e) || is_cyclic_segment_from_anchor_rewrite(e) {
+            continue;
+        }
+        let Some(points) = &e.points else { continue };
+        if points.is_empty() {
+            continue;
+        }
+
+        let arrow_end = e.arrow_type_end.as_deref().unwrap_or("none");
+        let arrow_start = e.arrow_type_start.as_deref().unwrap_or("none");
+
+        let mut adjusted: Vec<Point> = points.clone();
+        apply_marker_offsets(&mut adjusted, arrow_end, arrow_start);
+
+        let curve_name = e.curve.as_deref().unwrap_or("basis");
+        let ctype = edges::CurveType::parse(curve_name).unwrap_or(edges::CurveType::Basis);
+        let visited = edges::pathbbox_points(&adjusted, ctype);
+        if visited.is_empty() {
+            continue;
+        }
+
+        let mut path_min_x = f64::INFINITY;
+        let mut path_min_y = f64::INFINITY;
+        let mut path_max_x = f64::NEG_INFINITY;
+        let mut path_max_y = f64::NEG_INFINITY;
+        for (px, py) in visited.iter() {
+            let rx = (px * 1000.0).round() / 1000.0;
+            let ry = (py * 1000.0).round() / 1000.0;
+            path_min_x = path_min_x.min(rx);
+            path_min_y = path_min_y.min(ry);
+            path_max_x = path_max_x.max(rx);
+            path_max_y = path_max_y.max(ry);
+        }
+        if path_min_x.is_finite() {
+            bounds.expand_box(
+                path_min_x,
+                path_min_y,
+                path_max_x - path_min_x,
+                path_max_y - path_min_y,
+            );
+        }
+    }
+
+    for e in &l.edges {
+        if is_replaced_self_loop(e) || is_cyclic_segment_from_anchor_rewrite(e) {
+            continue;
+        }
+        let label_text = e.label.as_deref().unwrap_or("");
+        if label_text.is_empty() {
+            continue;
+        }
+        let processed = replace_fa_icons(label_text);
+        let (lw, lh) = measure_html_markup_label(&processed, &font, 200.0, true);
+        let dagre_lx = e.label_x.unwrap_or(0.0);
+        let dagre_ly = e.label_y.unwrap_or(0.0);
+        let (lx, ly) = recompute_edge_label_position(e, l).unwrap_or((dagre_lx, dagre_ly));
+        bounds.expand_box(lx - lw / 2.0, ly - lh / 2.0, lw, lh);
+    }
+
+    if bounds.is_empty() {
+        return (0.0, 0.0, 1.0, 1.0, 0.0);
+    }
+
+    let content_center_x = bounds.min_x + bounds.width() / 2.0;
+
+    if let Some(t) = title {
+        if !t.is_empty() {
+            let tw = crate::font_metrics::text_width(t, "sans-serif", 16.0, false, false);
+            let lh = crate::render::foreign_object::html_label_line_height(16.0);
+            let title_y = bounds.min_y - 25.0 - lh;
+            bounds.expand_box(content_center_x - tw / 2.0, title_y, tw, lh);
+        }
+    }
+
+    let content_w = bounds.width();
+    let content_h = bounds.height();
+    let vb_x = bounds.min_x - padding;
+    let vb_y = bounds.min_y - padding;
+    let vb_w = (content_w + 2.0 * padding).max(1.0);
+    let vb_h = (content_h + 2.0 * padding).max(1.0);
+
+    (vb_x, vb_y, vb_w, vb_h, content_center_x)
+}
+
 /// Render a flowchart diagram as SVG.
 pub fn render(
     d: &FlowchartDiagram,
@@ -1294,7 +1487,7 @@ pub fn render(
     // bounds including shape geometry, edge curves, and label
     // positions. We compute from layout nodes and edges.
     let (vb_x, vb_y, vb_w, vb_h, content_center_x) =
-        compute_viewbox(l, padding, d.meta.title.as_deref());
+        compute_viewbox_browser(l, padding, d.meta.title.as_deref());
 
     // ── Assemble final SVG ─────────────────────────────────────────
     let acc_title = d.meta.acc_title.as_deref();
@@ -3288,9 +3481,8 @@ fn render_edge_path(
 
 fn render_edge_label(e: &UEdge, html_labels: bool, l: &FlowchartLayout) -> String {
     use crate::render::foreign_object::{
-        markdown_label_to_html, measure_html_label, measure_html_markup_label,
-        render_edge_label as fo_edge, replace_fa_icons, string_label_to_html, HtmlLabelFont,
-        LabelOpts,
+        markdown_label_to_html, measure_html_markup_label, render_edge_label as fo_edge,
+        replace_fa_icons, string_label_to_html, HtmlLabelFont, LabelOpts,
     };
     use crate::render::shapes::types::{build_div_style_prefix, build_label_style};
     let label_text = e.label.clone().unwrap_or_default();
@@ -3334,8 +3526,7 @@ fn render_edge_label(e: &UEdge, html_labels: bool, l: &FlowchartLayout) -> Strin
             }
         }
     } else if is_empty {
-        let (_, lh) = measure_html_label("X", &HtmlLabelFont::default(), 200.0, true);
-        (0.0, lh, None)
+        (0.0, 0.0, None)
     } else {
         let (w, h) = measure_html_markup_label(&processed, &HtmlLabelFont::default(), 200.0, true);
         (w, h, None)

--- a/crates/mermaid-little/src/render/svg_state.rs
+++ b/crates/mermaid-little/src/render/svg_state.rs
@@ -405,22 +405,11 @@ fn basis_spline_tight_bbox(
 /// the title text widens it), matching upstream's `insertTitle` which records
 /// the bounds center before adding the `<text>` element.
 fn compute_viewbox(l: &StateLayout, pad: f64, title: Option<&str>) -> (f64, f64, f64, f64, f64) {
-    // Simulate upstream's `svg.node().getBBox()` with the jsdom shim used
-    // to generate reference SVGs.  That shim collects intrinsic bounding
-    // boxes of all SVG primitives (rect, circle, path, foreignObject …)
-    // while **ignoring all transform attributes**.  Since every node group
-    // carries a `transform="translate(cx,cy)"` that the shim skips, each
-    // node contributes its LOCAL-coordinate bbox to the union:
-    //
-    //   regular state node  →  rect: {x:-w/2, y:-h/2, w, h}
-    //                          foreignObject: {x:0, y:0, w:lw, h:lh}
-    //                          union: {x:-w/2, x_max:max(w/2,lw), y:-h/2, y_max:max(h/2,lh)}
-    //
-    //   start/end circle    →  circle at cx=0,cy=0,r=7: {x:-7, y:-7, w:14, h:14}
-    //
-    // Edge paths live in <g class="edgePaths"> with no transform, so their
-    // `d`-attribute coordinates are already in the same space as node locals
-    // (i.e. the layout's absolute space — both merge correctly).
+    // Compute browser-facing bounds in rendered SVG coordinates. Earlier
+    // ports mirrored jsdom's historical `getBBox()` shim and ignored node
+    // transforms; real browsers apply the node `translate(cx, cy)` transform,
+    // so the viewBox must union transformed node boxes with absolute edge
+    // path and label boxes.
 
     let mut g_x_min: f64 = f64::INFINITY;
     let mut g_x_max: f64 = f64::NEG_INFINITY;
@@ -574,10 +563,12 @@ fn compute_viewbox(l: &StateLayout, pad: f64, title: Option<&str>) -> (f64, f64,
             // Local bbox = union of rect and foreignObject.
             (-hw, lw.max(hw), -hh, lh.max(hh))
         };
-        g_x_min = g_x_min.min(nx_min);
-        g_x_max = g_x_max.max(nx_max);
-        g_y_min = g_y_min.min(ny_min);
-        g_y_max = g_y_max.max(ny_max);
+        let tx = n.x.unwrap_or(0.0);
+        let ty = n.y.unwrap_or(0.0);
+        g_x_min = g_x_min.min(tx + nx_min);
+        g_x_max = g_x_max.max(tx + nx_max);
+        g_y_min = g_y_min.min(ty + ny_min);
+        g_y_max = g_y_max.max(ty + ny_max);
     }
 
     // Edge paths — compute tight bounding box of the rendered basis spline.
@@ -600,13 +591,8 @@ fn compute_viewbox(l: &StateLayout, pad: f64, title: Option<&str>) -> (f64, f64,
             g_y_min = g_y_min.min(by_min);
             g_y_max = g_y_max.max(by_max);
         }
-        // Edge label bbox.
-        // The upstream jsdom shim used to generate reference SVGs calls
-        // getBBox() without applying CSS/SVG transforms. So a foreignObject
-        // with width=lw, height=lh inside nested <g transform=...> groups
-        // contributes its UNTRANSFORMED local bbox [0,lw]×[0,lh] to the
-        // global getBBox union. We replicate this behavior here.
-        if e.label_x.is_some() {
+        // Edge label bbox in browser coordinates.
+        if let (Some(label_x), Some(label_y)) = (e.label_x, e.label_y) {
             // Get label text and measure width.
             let raw_label = e.label.as_deref().unwrap_or("");
             if !raw_label.trim().is_empty() {
@@ -614,13 +600,21 @@ fn compute_viewbox(l: &StateLayout, pad: f64, title: Option<&str>) -> (f64, f64,
                 let decoded = decode_mermaid_entities(raw_label);
                 if !decoded.trim().is_empty() {
                     use crate::font_metrics::text_width as ftw;
-                    let lw = ftw(decoded.trim(), "sans-serif", 14.0, false, false);
-                    let lh = 16.296875_f64; // one line height
-                                            // foreignObject LOCAL bbox (ignoring parent transforms): [0,lw]×[0,lh].
-                    g_x_min = g_x_min.min(0.0);
-                    g_x_max = g_x_max.max(lw);
-                    g_y_min = g_y_min.min(0.0);
-                    g_y_max = g_y_max.max(lh);
+                    use crate::render::foreign_object::{
+                        html_label_line_height, HTML_LABEL_FONT_SIZE,
+                    };
+                    let lw = ftw(
+                        decoded.trim(),
+                        "sans-serif",
+                        HTML_LABEL_FONT_SIZE,
+                        false,
+                        false,
+                    );
+                    let lh = html_label_line_height(HTML_LABEL_FONT_SIZE);
+                    g_x_min = g_x_min.min(label_x - lw / 2.0);
+                    g_x_max = g_x_max.max(label_x + lw / 2.0);
+                    g_y_min = g_y_min.min(label_y - lh / 2.0);
+                    g_y_max = g_y_max.max(label_y + lh / 2.0);
                 }
             }
         }
@@ -644,15 +638,14 @@ fn compute_viewbox(l: &StateLayout, pad: f64, title: Option<&str>) -> (f64, f64,
     let content_center_x = g_x_min + (g_x_max - g_x_min) / 2.0;
 
     // Expand bounds to include the diagram title text if present.
-    // The title <text> element has no inline font attributes, so jsdom's
-    // resolveFont falls back to default: sans-serif 14px.
-    // Its intrinsicBox is {x:0, y:0, width:text_width, height:lh} (x,y
-    // are always 0 regardless of the `x` attribute).
+    // The title <text> element has no inline font attributes. Keep this bound
+    // slightly browser-biased so title text cannot tighten the overall viewBox.
     if let Some(t) = title {
         if !t.is_empty() {
             use crate::font_metrics::text_width as ftw;
-            let tw = ftw(t, "sans-serif", 14.0, false, false);
-            let lh = 16.296875_f64;
+            use crate::render::foreign_object::{html_label_line_height, HTML_LABEL_FONT_SIZE};
+            let tw = ftw(t, "sans-serif", HTML_LABEL_FONT_SIZE, false, false);
+            let lh = html_label_line_height(HTML_LABEL_FONT_SIZE);
             g_x_min = g_x_min.min(0.0);
             g_x_max = g_x_max.max(tw);
             g_y_min = g_y_min.min(0.0);
@@ -1358,7 +1351,9 @@ fn recompute_edge_label_position(e: &Edge, _nodes: &[Node]) -> Option<(f64, f64)
 
 fn emit_edge_label(e: &Edge, nodes: &[Node]) -> String {
     use crate::font_metrics::text_width;
-    use crate::render::foreign_object::{self, LabelOpts};
+    use crate::render::foreign_object::{
+        self, html_label_line_height, LabelOpts, HTML_LABEL_FONT_SIZE,
+    };
 
     let raw = e.label.as_deref().unwrap_or("");
     // Decode mermaid #name; entities before rendering (upstream decodeEntities).
@@ -1388,10 +1383,16 @@ fn emit_edge_label(e: &Edge, nodes: &[Node]) -> String {
     // Since \n has zero advance in our font metrics, text_width(decoded) gives
     // the correct sum: each line's chars plus zero for each \n separator.
     let (lw, lh) = if decoded.is_empty() {
-        (0.0, 16.296875) // default line-height at 14px sans-serif
+        (0.0, 0.0)
     } else {
-        let tw = text_width(decoded.trim(), "sans-serif", 14.0, false, false);
-        (tw, 16.296875)
+        let tw = text_width(
+            decoded.trim(),
+            "sans-serif",
+            HTML_LABEL_FONT_SIZE,
+            false,
+            false,
+        );
+        (tw, html_label_line_height(HTML_LABEL_FONT_SIZE))
     };
 
     let (x, y) = recompute_edge_label_position(e, nodes)
@@ -1717,16 +1718,21 @@ fn emit_state_node(id: &str, n: &Node, _theme: &ThemeVariables) -> Option<String
 /// - A label group containing two foreignObjects: title and description.
 fn emit_rect_with_title(id: &str, n: &Node, _theme: &ThemeVariables) -> Option<String> {
     use crate::font_metrics::text_width as ft_w;
+    use crate::render::foreign_object::{html_label_line_height, HTML_LABEL_FONT_SIZE};
     const FONT_FAMILY: &str = "sans-serif";
-    const FONT_SIZE: f64 = 14.0;
+    const FONT_SIZE: f64 = HTML_LABEL_FONT_SIZE;
     const HALF_PAD: f64 = 4.0; // halfPadding = node.padding / 2 = 8/2 = 4
 
     let _w = n.width.unwrap_or(0.0);
     let h = n.height.unwrap_or(0.0);
     let padding = n.label_padding_x.unwrap_or(8.0);
-    let lh = h - padding; // = line_height (=16.296875)
-                          // Upstream rectWithTitle uses `"node " + node2.classes` (no trailing space),
-                          // not the `get_node_classes` helper (which appends a trailing space).
+    let lh = if h > padding {
+        h - padding
+    } else {
+        html_label_line_height(FONT_SIZE)
+    };
+    // Upstream rectWithTitle uses `"node " + node2.classes` (no trailing space),
+    // not the `get_node_classes` helper (which appends a trailing space).
     let css_cls = n.css_classes.as_deref().unwrap_or("undefined");
     let classes = format!("node {}", css_cls);
     let nid = n.dom_id.clone().unwrap_or_else(|| n.id.clone());

--- a/crates/mermaid-little/tests/diagram_bounds.rs
+++ b/crates/mermaid-little/tests/diagram_bounds.rs
@@ -1,0 +1,152 @@
+#![cfg(feature = "metrics-ttf-parser")]
+
+use mermaid_little::convert_with_id;
+
+#[derive(Debug)]
+struct ForeignObject {
+    text: String,
+    width: f64,
+    height: f64,
+}
+
+fn parse_number(value: &str) -> f64 {
+    value
+        .parse::<f64>()
+        .unwrap_or_else(|e| panic!("parse float {value:?}: {e}"))
+}
+
+fn viewbox(svg: &str) -> [f64; 4] {
+    let doc = roxmltree::Document::parse(svg).expect("valid svg");
+    let svg_node = doc
+        .descendants()
+        .find(|n| n.has_tag_name("svg"))
+        .expect("svg root");
+    let value = svg_node.attribute("viewBox").expect("viewBox");
+    let parts: Vec<f64> = value.split_whitespace().map(parse_number).collect();
+    assert_eq!(parts.len(), 4, "viewBox should have four numbers");
+    [parts[0], parts[1], parts[2], parts[3]]
+}
+
+fn foreign_objects(svg: &str) -> Vec<ForeignObject> {
+    let doc = roxmltree::Document::parse(svg).expect("valid svg");
+    doc.descendants()
+        .filter(|n| n.has_tag_name("foreignObject"))
+        .map(|node| ForeignObject {
+            text: node
+                .descendants()
+                .filter_map(|n| n.text())
+                .collect::<String>()
+                .trim()
+                .to_string(),
+            width: parse_number(node.attribute("width").unwrap_or("0")),
+            height: parse_number(node.attribute("height").unwrap_or("0")),
+        })
+        .collect()
+}
+
+#[test]
+fn flowchart_html_labels_have_browser_line_height_and_bounds() {
+    let source = r#"flowchart TD
+    A[Write Markdown] --> B[Render Preview]
+    B --> C{Review}
+    C -->|Pass| D[Publish]
+    C -->|Fail| A
+"#;
+    let svg = convert_with_id(source, "bounds-flowchart").expect("render flowchart");
+    let vb = viewbox(&svg);
+    assert_eq!(vb[0], 0.0);
+    assert_eq!(vb[1], 0.0);
+    assert!(vb[2] > 250.0, "flowchart viewBox is too narrow: {vb:?}");
+    assert!(
+        vb[3] > 410.0,
+        "flowchart viewBox does not include the bottom node: {vb:?}"
+    );
+
+    let labels = foreign_objects(&svg);
+    let non_empty: Vec<_> = labels.iter().filter(|fo| !fo.text.is_empty()).collect();
+    assert_eq!(non_empty.len(), 6);
+    for label in non_empty {
+        assert!(
+            label.height >= 24.0,
+            "HTML label {:?} has clipped height {}",
+            label.text,
+            label.height
+        );
+        assert!(
+            label.width > 0.0,
+            "HTML label {:?} has no width",
+            label.text
+        );
+    }
+
+    for label in labels.iter().filter(|fo| fo.text.is_empty()) {
+        assert_eq!(
+            label.height, 0.0,
+            "empty edge labels should not affect bounds"
+        );
+    }
+}
+
+#[test]
+fn class_diagram_labels_have_browser_line_height_and_empty_edge_label_zero_height() {
+    let source = r#"classDiagram
+    class Workspace {
+      +string id
+      +string root
+      +open()
+      +status()
+    }
+    class MarkdownFile {
+      +string path
+      +render()
+    }
+    Workspace "1" --> "*" MarkdownFile
+"#;
+    let svg = convert_with_id(source, "bounds-class").expect("render class diagram");
+    let vb = viewbox(&svg);
+    assert_eq!(vb[0], 0.0);
+    assert_eq!(vb[1], 0.0);
+    assert!(vb[2] > 145.0, "class viewBox is too narrow: {vb:?}");
+    assert!(vb[3] >= 400.0, "class viewBox is too short: {vb:?}");
+
+    let labels = foreign_objects(&svg);
+    let empty = labels
+        .iter()
+        .find(|fo| fo.text.is_empty())
+        .expect("empty relation edge label placeholder");
+    assert_eq!(empty.height, 0.0);
+
+    for label in labels.iter().filter(|fo| !fo.text.is_empty()) {
+        assert!(
+            label.height >= 21.0,
+            "class label {:?} has clipped height {}",
+            label.text,
+            label.height
+        );
+        assert!(
+            label.width > 0.0,
+            "class label {:?} has no width",
+            label.text
+        );
+    }
+}
+
+#[test]
+fn class_namespace_labels_do_not_use_jsdom_fixture_height() {
+    let source = r#"classDiagram
+namespace WorkspaceLayer {
+  class Workspace
+}
+"#;
+    let svg = convert_with_id(source, "bounds-class-namespace").expect("render class namespace");
+    let labels = foreign_objects(&svg);
+    let namespace = labels
+        .iter()
+        .find(|fo| fo.text.contains("WorkspaceLayer"))
+        .expect("namespace label");
+    assert!(
+        namespace.height >= 21.0,
+        "namespace label uses clipped fixture height {}",
+        namespace.height
+    );
+}

--- a/crates/mermaid-little/tests/flowchart_inline.rs
+++ b/crates/mermaid-little/tests/flowchart_inline.rs
@@ -84,16 +84,13 @@ fn is_elk_source(src: &str) -> bool {
     src.contains("flowchart-elk") || src.contains("layout: elk")
 }
 
-fn run_one(rel: &str) -> Result<(bool, String), String> {
+fn render_one(rel: &str) -> Result<String, String> {
     let base = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let mmd = base.join("tests").join(format!("{}.mmd", rel));
-    let svg_path = base.join("tests/reference").join(format!("{}.svg", rel));
     let source = fs::read_to_string(&mmd).map_err(|e| format!("read {:?}: {e}", mmd))?;
     if is_elk_source(&source) {
-        return Ok((false, "elk — out of scope".into()));
+        return Err("elk — out of scope".into());
     }
-    let expected =
-        fs::read_to_string(&svg_path).map_err(|e| format!("read {:?}: {e}", svg_path))?;
     let id = id_for(rel);
     let d = fcp::parse(&source).map_err(|e| format!("parse: {e}"))?;
     // Mirror lib.rs's `convert_with_id` pipeline so `%%{init: { theme,
@@ -106,7 +103,15 @@ fn run_one(rel: &str) -> Result<(bool, String), String> {
         theme::apply_theme_variables(&mut th, tv);
     }
     let l = fcl::layout(&d, &th).map_err(|e| format!("layout: {e}"))?;
-    let got = svg_flowchart::render(&d, &l, &th, &id).map_err(|e| format!("render: {e}"))?;
+    svg_flowchart::render(&d, &l, &th, &id).map_err(|e| format!("render: {e}"))
+}
+
+fn run_one(rel: &str) -> Result<(bool, String), String> {
+    let base = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let svg_path = base.join("tests/reference").join(format!("{}.svg", rel));
+    let expected =
+        fs::read_to_string(&svg_path).map_err(|e| format!("read {:?}: {e}", svg_path))?;
+    let got = render_one(rel)?;
     Ok((
         got == expected,
         if got == expected {
@@ -122,6 +127,20 @@ fn run_one(rel: &str) -> Result<(bool, String), String> {
             diff
         },
     ))
+}
+
+fn viewbox(svg: &str) -> [f64; 4] {
+    let start = svg.find(r#"viewBox=""#).expect("viewBox attribute") + r#"viewBox=""#.len();
+    let end = svg[start..]
+        .find('"')
+        .map(|i| start + i)
+        .expect("viewBox close quote");
+    let values: Vec<f64> = svg[start..end]
+        .split_whitespace()
+        .map(|part| part.parse::<f64>().expect("viewBox number"))
+        .collect();
+    assert_eq!(values.len(), 4);
+    [values[0], values[1], values[2], values[3]]
 }
 
 #[test]
@@ -260,10 +279,15 @@ fn flowchart_byte_exact_sweep() {
 }
 
 #[test]
-fn flowchart_134_isolated_cluster_dom_order_is_byte_exact() {
+fn flowchart_134_isolated_cluster_has_browser_aligned_bounds() {
     let rel = "ext_fixtures/cypress/flowchart/134";
-    let (ok, diff) = run_one(rel).unwrap();
-    assert!(ok, "{rel}: {diff}");
+    let svg = render_one(rel).unwrap();
+    assert!(svg.contains(r#"class="flowchart""#));
+    assert!(svg.contains(r#"<g class="clusters">"#));
+    assert!(svg.contains(r#"<g class="edgePaths">"#));
+    let vb = viewbox(&svg);
+    assert!(vb[2] > 1.0, "{rel} width should be non-empty: {vb:?}");
+    assert!(vb[3] > 1.0, "{rel} height should be non-empty: {vb:?}");
 }
 
 #[test]

--- a/crates/mermaid-little/tests/state_byte_exact.rs
+++ b/crates/mermaid-little/tests/state_byte_exact.rs
@@ -1,12 +1,13 @@
 #![cfg(feature = "metrics-ttf-parser")]
-//! State diagram byte-exact test harness.
+//! State diagram browser-bounds regression harness.
 //!
-//! Runs fixtures in `tests/ext_fixtures/cypress/state` through the Rust
-//! pipeline and diffs against the matching reference SVG.
+//! Runs selected fixtures in `tests/ext_fixtures/cypress/state` through the
+//! Rust pipeline and checks browser-facing SVG invariants.
 //!
-//! Compiled only with `metrics-ttf-parser` — byte parity vs upstream
-//! Mermaid's reference SVGs only holds when the layout pipeline runs
-//! against the static DejaVu fixtures.
+//! Compiled only with `metrics-ttf-parser` so layout uses deterministic text
+//! metrics. These tests deliberately avoid byte-exact reference checks for
+//! HTML labels because the renderer now follows real browser `line-height: 1.5`
+//! behavior instead of the historical jsdom fixture height.
 
 use mermaid_little::convert_with_id;
 use std::fs;
@@ -30,40 +31,79 @@ fn id_for(rel: &str) -> String {
     id
 }
 
+fn viewbox(svg: &str) -> [f64; 4] {
+    let doc = roxmltree::Document::parse(svg).expect("valid svg");
+    let svg_node = doc
+        .descendants()
+        .find(|n| n.has_tag_name("svg"))
+        .expect("svg root");
+    let value = svg_node.attribute("viewBox").expect("viewBox");
+    let parts: Vec<f64> = value
+        .split_whitespace()
+        .map(|part| part.parse::<f64>().expect("viewBox number"))
+        .collect();
+    assert_eq!(parts.len(), 4, "viewBox should have four numbers");
+    [parts[0], parts[1], parts[2], parts[3]]
+}
+
 #[track_caller]
-fn assert_byte_exact(rel: &str) {
+fn assert_browser_bounds(rel: &str) {
     let mut mmd = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     mmd.push("tests");
     mmd.push(format!("{}.mmd", rel));
-    let mut svg = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    svg.push("tests/reference");
-    svg.push(format!("{}.svg", rel));
 
     let source = fs::read_to_string(&mmd).unwrap_or_else(|e| panic!("reading {:?}: {}", mmd, e));
-    let expected = fs::read_to_string(&svg).unwrap_or_else(|e| panic!("reading {:?}: {}", svg, e));
     let id = id_for(rel);
     let got = convert_with_id(&source, &id).unwrap_or_else(|e| panic!("convert {}: {}", rel, e));
-
-    if got == expected {
+    if source.trim() == "info" {
+        assert!(got.contains("<svg"), "{rel} should still render an SVG");
         return;
     }
-    let idx = got
-        .bytes()
-        .zip(expected.bytes())
-        .position(|(a, b)| a != b)
-        .unwrap_or(got.len().min(expected.len()));
-    let lo = idx.saturating_sub(60);
-    let hi_g = (idx + 200).min(got.len());
-    let hi_e = (idx + 200).min(expected.len());
-    panic!(
-        "mismatch in {} at byte {} (got_len={} exp_len={})\n GOT: ...{}...\n EXP: ...{}...\n",
-        rel,
-        idx,
-        got.len(),
-        expected.len(),
-        &got[lo..hi_g],
-        &expected[lo..hi_e],
+    assert!(got.contains(r#"class="statediagram""#));
+
+    let vb = viewbox(&got);
+    assert!(
+        vb[2] > 1.0,
+        "{rel} viewBox width should be non-empty: {vb:?}"
     );
+    assert!(
+        vb[3] > 1.0,
+        "{rel} viewBox height should be non-empty: {vb:?}"
+    );
+
+    let doc = roxmltree::Document::parse(&got).expect("valid svg");
+    for node in doc
+        .descendants()
+        .filter(|node| node.has_tag_name("foreignObject"))
+    {
+        let text = node
+            .descendants()
+            .filter_map(|child| child.text())
+            .collect::<String>()
+            .trim()
+            .to_string();
+        if text.is_empty() {
+            continue;
+        }
+        let height = node
+            .attribute("height")
+            .unwrap_or("0")
+            .parse::<f64>()
+            .expect("foreignObject height");
+        let width = node
+            .attribute("width")
+            .unwrap_or("0")
+            .parse::<f64>()
+            .expect("foreignObject width");
+        assert!(
+            height >= 24.0,
+            "{rel} label {text:?} has clipped height {height}"
+        );
+        assert!(
+            width > 0.0,
+            "{rel} label {text:?} has zero foreignObject width"
+        );
+    }
 }
 
 /// Print a diff summary for all state fixtures (used for manual debugging).
@@ -142,63 +182,63 @@ fn sweep_dir(dir_rel: &str, ref_prefix: &str) {
 
 #[test]
 fn cypress_01() {
-    assert_byte_exact("ext_fixtures/cypress/state/01");
+    assert_browser_bounds("ext_fixtures/cypress/state/01");
 }
 #[test]
 fn cypress_02() {
-    assert_byte_exact("ext_fixtures/cypress/state/02");
+    assert_browser_bounds("ext_fixtures/cypress/state/02");
 }
 #[test]
 fn cypress_03() {
-    assert_byte_exact("ext_fixtures/cypress/state/03");
+    assert_browser_bounds("ext_fixtures/cypress/state/03");
 }
 #[test]
 fn cypress_04() {
-    assert_byte_exact("ext_fixtures/cypress/state/04");
+    assert_browser_bounds("ext_fixtures/cypress/state/04");
 }
 #[test]
 fn cypress_05() {
-    assert_byte_exact("ext_fixtures/cypress/state/05");
+    assert_browser_bounds("ext_fixtures/cypress/state/05");
 }
 #[test]
 fn cypress_06() {
-    assert_byte_exact("ext_fixtures/cypress/state/06");
+    assert_browser_bounds("ext_fixtures/cypress/state/06");
 }
 #[test]
 fn cypress_07() {
-    assert_byte_exact("ext_fixtures/cypress/state/07");
+    assert_browser_bounds("ext_fixtures/cypress/state/07");
 }
 #[test]
 fn cypress_08() {
-    assert_byte_exact("ext_fixtures/cypress/state/08");
+    assert_browser_bounds("ext_fixtures/cypress/state/08");
 }
 #[test]
 fn cypress_09() {
-    assert_byte_exact("ext_fixtures/cypress/state/09");
+    assert_browser_bounds("ext_fixtures/cypress/state/09");
 }
 #[test]
 fn cypress_10() {
-    assert_byte_exact("ext_fixtures/cypress/state/10");
+    assert_browser_bounds("ext_fixtures/cypress/state/10");
 }
 #[test]
 fn cypress_11() {
-    assert_byte_exact("ext_fixtures/cypress/state/11");
+    assert_browser_bounds("ext_fixtures/cypress/state/11");
 }
 #[test]
 fn cypress_12() {
-    assert_byte_exact("ext_fixtures/cypress/state/12");
+    assert_browser_bounds("ext_fixtures/cypress/state/12");
 }
 #[test]
 fn cypress_13() {
-    assert_byte_exact("ext_fixtures/cypress/state/13");
+    assert_browser_bounds("ext_fixtures/cypress/state/13");
 }
 #[test]
 fn cypress_14() {
-    assert_byte_exact("ext_fixtures/cypress/state/14");
+    assert_browser_bounds("ext_fixtures/cypress/state/14");
 }
 #[test]
 fn cypress_15() {
-    assert_byte_exact("ext_fixtures/cypress/state/15");
+    assert_browser_bounds("ext_fixtures/cypress/state/15");
 }
 
 /// Nested isolated cluster: `state PilotCockpit { state Parent { C } }`.
@@ -208,14 +248,14 @@ fn cypress_15() {
 /// the depth-toggled `statediagram-cluster-alt` class on Parent (depth 2).
 #[test]
 fn cypress_25() {
-    assert_byte_exact("ext_fixtures/cypress/state/25");
+    assert_browser_bounds("ext_fixtures/cypress/state/25");
 }
 
 /// Same nested-isolated-cluster shape as cypress/25 but using the v1
 /// `stateDiagram` keyword (no `-v2` suffix).
 #[test]
 fn cypress_67() {
-    assert_byte_exact("ext_fixtures/cypress/state/67");
+    assert_browser_bounds("ext_fixtures/cypress/state/67");
 }
 
 /// Composite state with a single leaf child, default rankdir TB so the
@@ -223,14 +263,14 @@ fn cypress_67() {
 /// post-process inside `dagre_bridge::layout_isolated_cluster`.
 #[test]
 fn cypress_30() {
-    assert_byte_exact("ext_fixtures/cypress/state/30");
+    assert_browser_bounds("ext_fixtures/cypress/state/30");
 }
 
 /// Same shape as `cypress/30` but using the `stateDiagram` (v1) keyword.
 /// Confirms the leaf-only-LR fix applies regardless of state grammar.
 #[test]
 fn cypress_68() {
-    assert_byte_exact("ext_fixtures/cypress/state/68");
+    assert_browser_bounds("ext_fixtures/cypress/state/68");
 }
 
 /// Composite state whose title label ("Long state name 2") is wider than
@@ -240,7 +280,7 @@ fn cypress_68() {
 /// renderer's viewbox includes the cluster-label foreignObject local bbox.
 #[test]
 fn cypress_28() {
-    assert_byte_exact("ext_fixtures/cypress/state/28");
+    assert_browser_bounds("ext_fixtures/cypress/state/28");
 }
 
 /// Composite state with concurrent-region `--` separators. Exercises the
@@ -255,7 +295,7 @@ fn cypress_28() {
 /// slot positions are stable across runs.
 #[test]
 fn cypress_44() {
-    assert_byte_exact("ext_fixtures/cypress/state/44");
+    assert_browser_bounds("ext_fixtures/cypress/state/44");
 }
 
 /// `[*] --> TV` outer transition with a `state TV { … }` composite child.
@@ -265,13 +305,13 @@ fn cypress_44() {
 /// column under TV. v2 grammar.
 #[test]
 fn cypress_22() {
-    assert_byte_exact("ext_fixtures/cypress/state/22");
+    assert_browser_bounds("ext_fixtures/cypress/state/22");
 }
 
 /// Same shape as cypress/22 with `stateDiagram` (v1) keyword.
 #[test]
 fn cypress_64() {
-    assert_byte_exact("ext_fixtures/cypress/state/64");
+    assert_browser_bounds("ext_fixtures/cypress/state/64");
 }
 
 /// Two sibling composite states (`state A {…}` / `state C {…}`), each with
@@ -282,7 +322,7 @@ fn cypress_64() {
 /// iterating the HashSet directly.
 #[test]
 fn cypress_33() {
-    assert_byte_exact("ext_fixtures/cypress/state/33");
+    assert_browser_bounds("ext_fixtures/cypress/state/33");
 }
 
 /// Two composite states S1 and S2 with cross-boundary edges (S1→S2 and
@@ -296,7 +336,7 @@ fn cypress_33() {
 /// `build_graph_filtered_ex` so anchor-rewritten edges come last.
 #[test]
 fn cypress_34() {
-    assert_byte_exact("ext_fixtures/cypress/state/34");
+    assert_browser_bounds("ext_fixtures/cypress/state/34");
 }
 
 /// Single TB column of ten composite states whose long titles
@@ -317,7 +357,7 @@ fn cypress_34() {
 ///    sits ~13px left of where mermaid-js puts it.
 #[test]
 fn cypress_47() {
-    assert_byte_exact("ext_fixtures/cypress/state/47");
+    assert_browser_bounds("ext_fixtures/cypress/state/47");
 }
 
 /// Dump diff for one fixture (set FIXTURE env var or default 26).

--- a/crates/supramark-diagram/Cargo.toml
+++ b/crates/supramark-diagram/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "supramark-diagram"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 rust-version = "1.82"
 license = "Apache-2.0"
@@ -12,7 +12,7 @@ description = "Facade assembling the four engines: default_registry() yields a u
 [dependencies]
 supramark-diagram-core = { path = "../supramark-diagram-core", version = "0.1" }
 d2-little = { path = "../d2-little", version = "=0.7.1-1" }
-mermaid-little = { path = "../mermaid-little", version = "11.14.0-2", features = ["metrics-ttf-parser", "semantic-serde"] }
+mermaid-little = { path = "../mermaid-little", version = "=11.14.0-3", features = ["metrics-ttf-parser", "semantic-serde"] }
 plantuml-little = { path = "../plantuml-little", version = "1.2026.2-4", default-features = false, features = ["metrics-ttf-parser", "semantic-serde"] }
 serde_json = "1"
 


### PR DESCRIPTION
## Summary
- size Mermaid HTML foreignObject labels using browser line-height instead of the old jsdom fixture height
- compute browser-facing viewBox bounds for flowchart, class, and state diagrams so transformed content is not clipped
- add browser-bounds regression coverage for flowchart, class labels, class namespaces, and state fixtures
- bump mermaid-little to 11.14.0-3 and supramark-diagram to 0.1.3 with an exact mermaid prerelease dependency

## Diagnosis
Official Mermaid 11.14.0 output for the failing samples still emits foreignObject height=16.296875 while the browser-resolved HTML label line box is taller. That reproduces the text clipping seen in Markon. Previous work in #59 identified the same line-height mismatch in the JS renderer; #62 made foreignObject overflow visible but did not update the Rust renderer geometry/viewBox enough for browser consumption.

Chrome DOM measurements after this change show 0 bad foreignObjects for the flowchart, class, and state repro SVGs, with at least 8px viewBox margin around rendered content.

## Validation
- cargo test -p mermaid-little --no-default-features --features metrics-ttf-parser
- cargo clippy -p mermaid-little --no-default-features --features metrics-ttf-parser -- -D warnings
- GRAPHVIZ_ANYWHERE_ALLOW_DOWNLOAD=1 cargo test -p supramark-diagram
- cargo package -p mermaid-little --allow-dirty
- Chrome headless DOM measurement of official Mermaid 11.14.0 vs local SVG outputs

Note: cargo package -p supramark-diagram cannot pass until mermaid-little 11.14.0-3 is published to crates.io, because it now depends on that exact prerelease version.
