### PR TITLE
fix: pad flowchart edge labels

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -868,7 +868,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "mermaid-little"
-version = "11.14.0-3"
+version = "11.14.0-4"
 dependencies = [
  "dagre 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger",
@@ -1477,7 +1477,7 @@ dependencies = [
 
 [[package]]
 name = "supramark-diagram"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "d2-little",
  "graphviz-anywhere",

--- a/crates/mermaid-little/Cargo.toml
+++ b/crates/mermaid-little/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mermaid-little"
-version = "11.14.0-3"
+version = "11.14.0-4"
 edition = "2021"
 rust-version = "1.82"
 license = "MIT"

--- a/crates/mermaid-little/FEATURES.md
+++ b/crates/mermaid-little/FEATURES.md
@@ -148,6 +148,10 @@ Mirrors plantuml-little:
   against a native pure-Rust pipeline; CI's `test-reference` job opts
   in to `MERMAID_LITTLE_TEST_BACKEND=wasm` for cross-platform
   determinism.
+- **Known intentional alignment warnings.** `tests/known_alignment_warnings.txt`
+  records narrow, reviewed visual improvements that intentionally differ
+  from upstream. Current entry: flowchart edge labels get 4px horizontal
+  padding because Mermaid 11.14.0 keeps their backgrounds flush with text.
 
 ## Acknowledgments
 

--- a/crates/mermaid-little/src/render/foreign_object.rs
+++ b/crates/mermaid-little/src/render/foreign_object.rs
@@ -257,6 +257,11 @@ pub struct LabelOpts<'a> {
     /// Whether the inner `<span>` gets the `nodeLabel` base class
     /// (`true`) or the `edgeLabel` base class (`false`).
     pub is_node: bool,
+    /// Extra horizontal CSS padding on the HTML label body. Upstream
+    /// Mermaid leaves flowchart edge-label backgrounds flush with text;
+    /// callers may opt into a small non-upstream visual readability
+    /// enhancement while keeping the default byte-exact path unchanged.
+    pub horizontal_padding: f64,
 }
 
 impl<'a> Default for LabelOpts<'a> {
@@ -272,7 +277,16 @@ impl<'a> Default for LabelOpts<'a> {
             max_width: 200.0,
             wrap_in_p: true,
             is_node: true,
+            horizontal_padding: 0.0,
         }
+    }
+}
+
+fn padded_width(text: &str, width: f64, opts: &LabelOpts<'_>) -> f64 {
+    if text.is_empty() || opts.horizontal_padding <= 0.0 {
+        width
+    } else {
+        width + opts.horizontal_padding * 2.0
     }
 }
 
@@ -284,6 +298,7 @@ impl<'a> Default for LabelOpts<'a> {
 /// defaults to `translate(-width/2, -height/2)` matching upstream
 /// `labelHelper`'s `useHtmlLabels` branch.
 pub fn render_node_label(text: &str, width: f64, height: f64, opts: &LabelOpts<'_>) -> String {
+    let width = padded_width(text, width, opts);
     let mut out = String::with_capacity(256 + text.len());
     // Outer <g class="label">.
     out.push_str("<g class=\"label\"");
@@ -380,6 +395,12 @@ pub fn foreign_object_body(text: &str, width: f64, height: f64, opts: &LabelOpts
         div_style.push_str(prefix);
     }
     div_style.push_str("display: table-cell; white-space: nowrap; line-height: 1.5;");
+    if !text.is_empty() && opts.horizontal_padding > 0.0 {
+        div_style.push_str(&format!(
+            " padding: 0 {}px;",
+            fmt_num(opts.horizontal_padding)
+        ));
+    }
     if opts.max_width.is_finite() {
         div_style.push_str(&format!(
             " max-width: {}px; text-align: center;",
@@ -1399,6 +1420,28 @@ mod tests {
             got,
             r#"<g class="edgeLabel" transform="translate(177.806640625, 41.60302734375)"><g class="label" data-id="L_DataStore_Process_0" transform="translate(-18.005859375, -8.1484375)"><foreignObject width="36.01171875" height="16.296875"><div style="display: table-cell; white-space: nowrap; line-height: 1.5; max-width: 200px; text-align: center;" xmlns="http://www.w3.org/1999/xhtml" class="labelBkg"><span class="edgeLabel "><p>input</p></span></div></foreignObject></g></g>"#
         );
+    }
+
+    #[test]
+    fn edge_label_padding_is_opt_in() {
+        let opts = LabelOpts {
+            data_id: Some("L_DataStore_Process_0"),
+            group_style: None,
+            horizontal_padding: 4.0,
+            ..LabelOpts::default()
+        };
+        let got = render_edge_label(
+            "input",
+            177.806640625,
+            41.60302734375,
+            36.01171875,
+            16.296875,
+            opts,
+        );
+
+        assert!(got.contains(r#"width="44.01171875""#));
+        assert!(got.contains(r#"transform="translate(-22.005859375, -8.1484375)""#));
+        assert!(got.contains("padding: 0 4px;"));
     }
 
     #[test]

--- a/crates/mermaid-little/src/render/svg_flowchart.rs
+++ b/crates/mermaid-little/src/render/svg_flowchart.rs
@@ -26,6 +26,15 @@ use crate::render::unified_shell;
 use crate::theme::css as theme_css;
 use crate::theme::ThemeVariables;
 
+/// Non-upstream readability enhancement for flowchart edge labels.
+///
+/// Mermaid 11.14.0 renders edge-label backgrounds flush with the text
+/// (`.edgeLabel p { padding: 0; }`). That is byte-aligned but visually tight,
+/// especially for short labels like `Pass` / `Fail`. Keep node labels and
+/// other diagram families byte-oriented; flowchart edge labels deliberately
+/// get a small symmetric horizontal cushion.
+const FLOWCHART_EDGE_LABEL_PADDING_X: f64 = 4.0;
+
 /// Compute the viewBox matching the upstream jsdom `getBBox()` shim.
 ///
 /// The reference generator patches `SVGElement.prototype.getBBox` with an
@@ -1148,6 +1157,7 @@ fn compute_viewbox_browser(
         }
         let processed = replace_fa_icons(label_text);
         let (lw, lh) = measure_html_markup_label(&processed, &font, 200.0, true);
+        let lw = lw + FLOWCHART_EDGE_LABEL_PADDING_X * 2.0;
         let dagre_lx = e.label_x.unwrap_or(0.0);
         let dagre_ly = e.label_y.unwrap_or(0.0);
         let (lx, ly) = recompute_edge_label_position(e, l).unwrap_or((dagre_lx, dagre_ly));
@@ -3589,6 +3599,11 @@ fn render_edge_label(e: &UEdge, html_labels: bool, l: &FlowchartLayout) -> Strin
             None
         } else {
             Some(&span_label_style)
+        },
+        horizontal_padding: if is_empty {
+            0.0
+        } else {
+            FLOWCHART_EDGE_LABEL_PADDING_X
         },
         ..LabelOpts::default()
     };

--- a/crates/mermaid-little/tests/diagram_bounds.rs
+++ b/crates/mermaid-little/tests/diagram_bounds.rs
@@ -1,6 +1,7 @@
 #![cfg(feature = "metrics-ttf-parser")]
 
 use mermaid_little::convert_with_id;
+use mermaid_little::render::foreign_object::{measure_html_markup_label, HtmlLabelFont};
 
 #[derive(Debug)]
 struct ForeignObject {
@@ -32,12 +33,21 @@ fn foreign_objects(svg: &str) -> Vec<ForeignObject> {
     doc.descendants()
         .filter(|n| n.has_tag_name("foreignObject"))
         .map(|node| ForeignObject {
-            text: node
-                .descendants()
-                .filter_map(|n| n.text())
-                .collect::<String>()
-                .trim()
-                .to_string(),
+            text: {
+                let p_text = node
+                    .descendants()
+                    .filter(|n| n.has_tag_name("p"))
+                    .filter_map(|n| n.text())
+                    .collect::<String>();
+                let text = if p_text.is_empty() {
+                    node.descendants()
+                        .filter_map(|n| n.text())
+                        .collect::<String>()
+                } else {
+                    p_text
+                };
+                text.trim().to_string()
+            },
             width: parse_number(node.attribute("width").unwrap_or("0")),
             height: parse_number(node.attribute("height").unwrap_or("0")),
         })
@@ -83,6 +93,34 @@ fn flowchart_html_labels_have_browser_line_height_and_bounds() {
         assert_eq!(
             label.height, 0.0,
             "empty edge labels should not affect bounds"
+        );
+    }
+}
+
+#[test]
+fn flowchart_edge_labels_have_readability_padding() {
+    let source = r#"flowchart TD
+    A[Write Markdown] --> B[Render Preview]
+    B --> C{Review}
+    C -->|Pass| D[Publish]
+    C -->|Fail| A
+"#;
+    let svg = convert_with_id(source, "bounds-flowchart-padding").expect("render flowchart");
+    let labels = foreign_objects(&svg);
+    let font = HtmlLabelFont::default();
+    let seen: Vec<_> = labels.iter().map(|fo| fo.text.as_str()).collect();
+
+    for edge_label in ["Pass", "Fail"] {
+        let label = labels
+            .iter()
+            .find(|fo| fo.text == edge_label)
+            .unwrap_or_else(|| panic!("edge label {edge_label:?} should render; saw {seen:?}"));
+        let (text_width, _) = measure_html_markup_label(edge_label, &font, 200.0, true);
+        let expected = text_width + 8.0;
+        assert!(
+            (label.width - expected).abs() < 1e-9,
+            "edge label {edge_label:?} width {} should include 4px left/right padding over measured text width {text_width}",
+            label.width
         );
     }
 }

--- a/crates/mermaid-little/tests/eval/README.md
+++ b/crates/mermaid-little/tests/eval/README.md
@@ -74,6 +74,16 @@ errors / warnings / matches with colour.
 
 Thresholds are tweakable via `CheckConfig`.
 
+## Known Warning / Ignored Alignment Diffs
+
+Rows in `tests/known_alignment_warnings.txt` document intentional
+non-upstream visual adjustments that sweep tests report as warnings instead
+of treating as regressions. Current entry:
+
+| scope | check | reason |
+|---|---|---|
+| flowchart | `edge-label-horizontal-padding` | Upstream Mermaid 11.14.0 keeps flowchart edge-label backgrounds flush with text (`.edgeLabel p { padding: 0; }`); mermaid-little adds 4px left/right padding for readability. |
+
 ## What's deferred
 
 * **SSIM for raw SVGs** — `ssim::ssim_svg` currently returns `Err(..)`.

--- a/crates/mermaid-little/tests/flowchart_inline.rs
+++ b/crates/mermaid-little/tests/flowchart_inline.rs
@@ -80,6 +80,34 @@ fn read_known_ignored() -> std::collections::HashSet<String> {
     set
 }
 
+fn read_known_alignment_warnings(scope: &str) -> Vec<String> {
+    let mut warnings = Vec::new();
+    let base = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let path = base.join("tests/known_alignment_warnings.txt");
+    if let Ok(text) = fs::read_to_string(&path) {
+        for line in text.lines() {
+            let line = line.trim();
+            if line.is_empty() || line.starts_with('#') {
+                continue;
+            }
+            let mut parts = line.splitn(3, '\t');
+            let Some(line_scope) = parts.next() else {
+                continue;
+            };
+            let Some(check) = parts.next() else {
+                continue;
+            };
+            let Some(reason) = parts.next() else {
+                continue;
+            };
+            if line_scope == scope {
+                warnings.push(format!("{check}: {reason}"));
+            }
+        }
+    }
+    warnings
+}
+
 fn is_elk_source(src: &str) -> bool {
     src.contains("flowchart-elk") || src.contains("layout: elk")
 }
@@ -271,6 +299,9 @@ fn flowchart_byte_exact_sweep() {
         }
     }
     eprintln!("[flowchart] byte-exact={}/{}", pass, total);
+    for warning in read_known_alignment_warnings("flowchart") {
+        eprintln!("[flowchart] warning-ignored {warning}");
+    }
     for (r, d) in diffs.iter().take(30) {
         eprintln!("[flowchart] diff {r}: {d}");
     }

--- a/crates/mermaid-little/tests/known_alignment_warnings.txt
+++ b/crates/mermaid-little/tests/known_alignment_warnings.txt
@@ -1,0 +1,10 @@
+# Known upstream-alignment warnings intentionally ignored by sweep tests.
+#
+# Format:
+#   <scope>  TAB  <check>  TAB  <reason>
+#
+# These are deliberate mermaid-little rendering policy choices, not missing
+# fixture skips. Keep this file small: each row must have a concrete visual
+# reason and must be covered by a focused test.
+
+flowchart	edge-label-horizontal-padding	Mermaid 11.14.0 keeps flowchart edge-label backgrounds flush with text (`.edgeLabel p { padding: 0; }`); mermaid-little adds 4px left/right padding for readability.

--- a/crates/supramark-diagram/Cargo.toml
+++ b/crates/supramark-diagram/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "supramark-diagram"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 rust-version = "1.82"
 license = "Apache-2.0"
@@ -12,7 +12,7 @@ description = "Facade assembling the four engines: default_registry() yields a u
 [dependencies]
 supramark-diagram-core = { path = "../supramark-diagram-core", version = "0.1" }
 d2-little = { path = "../d2-little", version = "=0.7.1-1" }
-mermaid-little = { path = "../mermaid-little", version = "=11.14.0-3", features = ["metrics-ttf-parser", "semantic-serde"] }
+mermaid-little = { path = "../mermaid-little", version = "=11.14.0-4", features = ["metrics-ttf-parser", "semantic-serde"] }
 plantuml-little = { path = "../plantuml-little", version = "1.2026.2-4", default-features = false, features = ["metrics-ttf-parser", "semantic-serde"] }
 serde_json = "1"
 


### PR DESCRIPTION
## Summary
- add opt-in horizontal padding support to HTML foreignObject labels
- apply 4px left/right padding to flowchart edge labels and include it in viewBox bounds
- record this intentional upstream divergence as a known alignment warning
- bump mermaid-little to 11.14.0-4 and supramark-diagram to 0.1.4

## Notes
Official Mermaid 11.14.0 keeps flowchart edge-label backgrounds flush with text (`.edgeLabel p { padding: 0; }`). This PR intentionally diverges for readability while documenting the difference in the alignment warning list.

## Verification
- cargo fmt -p mermaid-little -p supramark-diagram -- --check
- cargo clippy -p mermaid-little --features metrics-ttf-parser --tests -- -D warnings
- cargo test -p mermaid-little --features metrics-ttf-parser render::foreign_object::tests::edge_label_padding_is_opt_in -- --nocapture
- cargo test -p mermaid-little --features metrics-ttf-parser --test diagram_bounds -- --nocapture
- cargo test -p mermaid-little --features metrics-ttf-parser --test flowchart_inline flowchart_byte_exact_sweep -- --nocapture
- GRAPHVIZ_ANYWHERE_ALLOW_DOWNLOAD=1 cargo check -p supramark-diagram
- GRAPHVIZ_ANYWHERE_ALLOW_DOWNLOAD=1 cargo clippy -p supramark-diagram -- -D warnings