### PR TITLE
fix(plantuml): sequence group frame width via longest-path gaps (fixes #28)

### DIFF
--- a/crates/plantuml-little/src/layout/sequence.rs
+++ b/crates/plantuml-little/src/layout/sequence.rs
@@ -950,6 +950,10 @@ pub fn layout_sequence(sd: &SequenceDiagram, skin: &crate::style::SkinParams) ->
     // the constraint solver ensures centerX >= arrowPreferredWidth. Track this
     // so we can apply it when positioning participants.
     let mut min_first_center: f64 = 0.0;
+    // Multi-participant (span > 1) message constraints, collected as Java teoz
+    // difference constraints `posC[hi] - posC[lo] >= needed` and solved by
+    // longest-path in the positioning pass below. See `span_constraints` use.
+    let mut span_constraints: Vec<(usize, usize, f64)> = Vec::new();
     for event in &sd.events {
         match event {
             SeqEvent::AutoNumber { start } => {
@@ -1046,11 +1050,24 @@ pub fn layout_sequence(sd: &SequenceDiagram, skin: &crate::style::SkinParams) ->
                         + active_left_shift(ti_level);
                     let span = hi - lo; // number of gaps this message spans
                     if span > 0 {
-                        let per_gap = needed / span as f64;
-                        for min_gap in &mut min_gaps[lo..hi] {
-                            if per_gap > *min_gap {
-                                *min_gap = per_gap;
+                        if span == 1 {
+                            // Adjacent participants: widen the single gap directly.
+                            if needed > min_gaps[lo] {
+                                min_gaps[lo] = needed;
                             }
+                        } else {
+                            // Multi-participant span: the arrow + label needs the
+                            // TOTAL width from `lo` to `hi` to be >= `needed`, not
+                            // each individual gap. Java (teoz RealLine) models this
+                            // as a difference constraint `posC[hi] - posC[lo] >=
+                            // needed`, solved by longest-path when positioning.
+                            // Only the final gap absorbs any deficit; earlier gaps
+                            // keep their base width. Splitting `needed` evenly
+                            // across every gap over-constrains already-satisfied
+                            // spans (e.g. an Alice->Log message crossing a very
+                            // wide Alice->Bob gap wrongly inflates Bob->Log) —
+                            // see issue #28.
+                            span_constraints.push((lo, hi, needed));
                         }
                     }
                 }
@@ -1143,7 +1160,12 @@ pub fn layout_sequence(sd: &SequenceDiagram, skin: &crate::style::SkinParams) ->
         effective_margin
     };
 
-    // 3. Position participants left-to-right using computed gaps
+    // 3. Position participants left-to-right using computed gaps.
+    // This is a longest-path solve over difference constraints: each adjacent
+    // `min_gaps[i-1]` gives `posC[i] >= posC[i-1] + min_gaps[i-1]`, and each
+    // multi-span message gives `posC[hi] >= posC[lo] + needed`. A single forward
+    // pass is exact because every constraint has lo < i, so posC[lo] is already
+    // finalized when participant i is placed.
     let mut participants: Vec<ParticipantLayout> = Vec::with_capacity(n);
     let mut prev_center: Option<f64> = None;
     for (i, p) in sd.participants.iter().enumerate() {
@@ -1151,7 +1173,18 @@ pub fn layout_sequence(sd: &SequenceDiagram, skin: &crate::style::SkinParams) ->
             // Java: first participant center uses effective width (including
             // ParticipantPadding) so the padded box edge sits at left_margin.
             None => (left_margin + effective_widths[i] / 2.0).max(min_first_center),
-            Some(pc) => pc + min_gaps[i - 1],
+            Some(pc) => {
+                // Adjacent gap: participant boxes + span-1 messages + activation.
+                let mut cx = pc + min_gaps[i - 1];
+                // Multi-span message difference constraints (Java teoz RealLine):
+                // posC[i] >= posC[lo] + needed.
+                for &(lo, hi, needed) in &span_constraints {
+                    if hi == i {
+                        cx = cx.max(participants[lo].x + needed);
+                    }
+                }
+                cx
+            }
         };
 
         participants.push(ParticipantLayout {

--- a/crates/plantuml-little/tests/port_sequence_layout.rs
+++ b/crates/plantuml-little/tests/port_sequence_layout.rs
@@ -613,3 +613,157 @@ fn sequenceleftmessage_0002_teoz_structure() {
     assert!(l.messages[1].is_self);
     assert!(l.messages[1].y > l.messages[0].y, "msg[1] below msg[0]");
 }
+
+// ── Issue #28: sequence group frame must not be over-wide ───────────
+//
+// A message whose arrow spans a non-adjacent participant (here Alice -> Log,
+// which crosses Bob) must widen the TOTAL span only when needed, not every
+// gap. The previous code split the message width evenly across each gap,
+// which inflated the Bob -> Log gap (because Alice -> Bob was already very
+// wide from "Authentication Request"). That pushed Log 13.24px to the right
+// and made the alt/group frames 13.24px too wide, so labels sat flush on
+// the border.
+//
+// Golden coordinates below are taken from official PlantUML 1.2026.7beta3
+// (the SVG attached to the issue) and must match pixel-for-pixel.
+const ISSUE28: &str = "@startuml\n\
+Alice -> Bob: Authentication Request\n\
+alt successful case\n\
+  Bob -> Alice: Authentication Accepted\n\
+else some kind of failure\n\
+  Bob -> Alice: Authentication Failure\n\
+  group My own label\n\
+    Alice -> Log : Log attack start\n\
+    loop 1000 times\n\
+      Alice -> Bob: DNS Attack\n\
+    end\n\
+    Alice -> Log : Log attack end\n\
+  end\n\
+else Another type of failure\n\
+  Bob -> Alice: Please repeat\n\
+end\n\
+@enduml";
+
+/// Participant centre X positions must match official PlantUML exactly.
+/// Pre-fix the third participant (Log) was ~13.24px too far right.
+#[test]
+fn issue28_participant_positions_match_official() {
+    let l = layout(ISSUE28);
+    let xs: Vec<f64> = l.participants.iter().map(|p| p.x).collect();
+    assert_eq!(xs.len(), 3, "Alice, Bob, Log");
+
+    // Official PlantUML participant-box centres (head rect x + width/2).
+    let expected = [63.8335_f64, 248.1816, 298.336];
+    for (i, (got, want)) in xs.iter().zip(expected.iter()).enumerate() {
+        assert!(
+            (got - want).abs() < 0.01,
+            "participant[{i}] x = {got}, expected {want} (official PlantUML box centre)"
+        );
+    }
+
+    // The Bob -> Log gap is the base spacing only; it must NOT be inflated by
+    // the Alice -> Log messages crossing it. Official centre-to-centre gap
+    // = 298.336 - 248.1816 = 50.1544.
+    let bob_log_gap = xs[2] - xs[1];
+    assert!(
+        (bob_log_gap - 50.1544).abs() < 0.01,
+        "Bob->Log gap = {bob_log_gap:.4}, expected 50.1544 (official base spacing)"
+    );
+}
+
+/// The outermost (alt) frame width must match official PlantUML exactly.
+/// Pre-fix it was 341.2046 (13.24px too wide) because Log was misplaced.
+#[test]
+fn issue28_alt_frame_width_matches_official() {
+    use plantuml_little::model::sequence::FragmentKind;
+    let l = layout(ISSUE28);
+
+    // The outermost frame is the alt; it has the smallest x and largest width.
+    let alt = l
+        .fragments
+        .iter()
+        .find(|f| f.kind == FragmentKind::Alt)
+        .expect("alt fragment present");
+
+    assert!(
+        (alt.x - 10.0).abs() < 0.01,
+        "alt x = {}, expected 10.0",
+        alt.x
+    );
+    assert!(
+        (alt.width - 327.9619).abs() < 0.01,
+        "alt width = {}, expected 327.9619 (official PlantUML); pre-fix was 341.2046",
+        alt.width
+    );
+}
+
+// ── Multi-span message gap distribution (official longest-path) ──────
+//
+// Official PlantUML (teoz RealLine) treats an arrow that spans several
+// participants as a single difference constraint posC[hi] - posC[lo] >=
+// needed, solved by longest-path: every intermediate gap keeps its base
+// width and the FINAL gap absorbs the whole deficit. The pre-fix code
+// distributed `needed` evenly across every gap. Golden values below are
+// official PlantUML output (verified against the teoz engine, which the
+// default sequence renderer mirrors).
+
+/// 3 participants, one long Alice -> C message: gap AB stays at the base
+/// spacing, gap BC absorbs the full remaining width.
+#[test]
+fn multispan_message_puts_deficit_in_last_gap_3p() {
+    let l = layout(
+        "@startuml\n\
+		 participant A\n\
+		 participant B\n\
+		 participant C\n\
+		 A -> C : XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX\n\
+		 @enduml",
+    );
+    let xs: Vec<f64> = l.participants.iter().map(|p| p.x).collect();
+    let gap_ab = xs[1] - xs[0];
+    let gap_bc = xs[2] - xs[1];
+
+    // gap AB is the base participant spacing (not inflated by the A->C text).
+    assert!(
+        (gap_ab - 33.591).abs() < 0.05,
+        "gap AB = {gap_ab:.3}, expected ~33.591 (base; not inflated)"
+    );
+    // gap BC carries essentially the entire label width.
+    assert!(
+        (gap_bc - 275.394).abs() < 0.05,
+        "gap BC = {gap_bc:.3}, expected ~275.394 (absorbs the deficit)"
+    );
+    // Pre-fix both gaps were ~154 (even split).
+    assert!(
+        gap_bc > gap_ab * 2.0,
+        "deficit must land in the last gap, not be split evenly"
+    );
+}
+
+/// 4 participants, one long Alice -> D message: gaps AB and BC stay at the
+/// base spacing; only gap CD absorbs the deficit.
+#[test]
+fn multispan_message_puts_deficit_in_last_gap_4p() {
+    let l = layout(
+        "@startuml\n\
+		 participant A\n\
+		 participant B\n\
+		 participant C\n\
+		 participant D\n\
+		 A -> D : XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX\n\
+		 @enduml",
+    );
+    let xs: Vec<f64> = l.participants.iter().map(|p| p.x).collect();
+    let gap_ab = xs[1] - xs[0];
+    let gap_bc = xs[2] - xs[1];
+    let gap_cd = xs[3] - xs[2];
+
+    assert!(
+        (gap_ab - 33.591).abs() < 0.05 && (gap_bc - 33.69).abs() < 0.05,
+        "gaps AB={gap_ab:.3}, BC={gap_bc:.3} must stay at base spacing"
+    );
+    assert!(
+        (gap_cd - 241.704).abs() < 0.05,
+        "gap CD = {gap_cd:.3}, expected ~241.704 (absorbs the deficit)"
+    );
+}

--- a/crates/plantuml-little/tests/port_sequence_render.rs
+++ b/crates/plantuml-little/tests/port_sequence_render.rs
@@ -325,3 +325,45 @@ fn default_participant_rect_has_rounded_corners() {
         "rounded corner attributes should be on a <rect> element, found: {tag_name}",
     );
 }
+
+// ── Issue #28: alt/group frames must match official width ───────────
+//
+// When a message spans a non-adjacent participant (Alice -> Log crossing
+// Bob), the group/alt frames must keep the official width. The previous
+// layout inflated the Bob -> Log gap, which made the outer frames ~13px
+// too wide. This checks the rendered SVG, not just the layout struct, so
+// it guards the user-visible "label pressed against the border" symptom.
+// Golden width 327.9619 is from official PlantUML 1.2026.7beta3.
+#[test]
+fn issue28_frame_width_matches_official_in_svg() {
+    let svg = convert(
+        "@startuml\n\
+		 Alice -> Bob: Authentication Request\n\
+		 alt successful case\n\
+		   Bob -> Alice: Authentication Accepted\n\
+		 else some kind of failure\n\
+		   Bob -> Alice: Authentication Failure\n\
+		   group My own label\n\
+		     Alice -> Log : Log attack start\n\
+		     loop 1000 times\n\
+		       Alice -> Bob: DNS Attack\n\
+		     end\n\
+		     Alice -> Log : Log attack end\n\
+		   end\n\
+		 else Another type of failure\n\
+		   Bob -> Alice: Please repeat\n\
+		 end\n\
+		 @enduml",
+    );
+
+    // The outermost frame is the first fill="none" stroke-width:1.5 rect.
+    let frame = extract_all_attrs(&svg, "<rect", "width")
+        .into_iter()
+        .next()
+        .expect("a frame rect");
+    let w: f64 = frame.parse().expect("numeric width");
+    assert!(
+        (w - 327.9619).abs() < 0.01,
+        "outer frame width = {w}, expected 327.9619 (official PlantUML); pre-fix was 341.2046"
+    );
+}


### PR DESCRIPTION
## Problem

PlantUML sequence diagrams rendered group/`alt`/`loop` frames ~13px too wide, so the frame labels sat flush against the border — the symptom reported in #28.

Root cause: when a message arrow spans a **non-adjacent** participant (e.g. `Alice -> Log`, which crosses `Bob`), the puma layout split the message's required width **evenly across every gap** it spanned. Because the `Alice -> Bob` gap was already very wide (from `Authentication Request`), the `Alice -> Log` messages needlessly inflated the `Bob -> Log` gap, pushing `Log` ~13px to the right and widening every enclosing frame.

## Fix

Match the official PlantUML algorithm. A multi-span message is the same **difference constraint** the official teoz `RealLine` solver uses:

```
posC[hi] − posC[lo] >= needed
```

collected per message and solved by **longest-path** when positioning participants (a single forward pass is exact, since every constraint has `lo < i`). Only the final gap absorbs any deficit; earlier gaps keep their base width. Span-1 (adjacent) messages are unchanged.

## Verification — pixel-level, via the official algorithm

The issue's input now renders **pixel-identical** to official PlantUML `1.2026.7beta3` (the SVG attached to the issue):

| element | official | before | after |
|---|---|---|---|
| Log lifeline x | 297.71 | 310.9526 | **297.71** |
| Bob→Log gap | 50.0567 | 63.2993 | **50.0567** |
| alt frame width | 327.9619 | 341.2046 | **327.9619** |

A full element-by-element diff of the rendered SVG (all 20 texts, 6 frame rects, 3 pentagon tabs, 2 separator lines) against the official output matches exactly. The multi-span gap distribution now also matches the official behaviour — a long `A -> C` message puts its full deficit in the last gap (`[33.6, 275.4]`) instead of splitting evenly (`[154.5, 154.4]`).

## Tests added

- `issue28_participant_positions_match_official` — participant centres match official box centres exactly.
- `issue28_alt_frame_width_matches_official` — alt frame width = 327.9619.
- `issue28_frame_width_matches_official_in_svg` — guards the user-visible symptom at the SVG level.
- `multispan_message_puts_deficit_in_last_gap_3p` / `_4p` — the longest-path distribution invariant.

All 263 reference-SVG tests, the full sequence suite (layout + render), and clippy pass with no regressions.

Fixes #28.

🤖 Generated with [Claude Code](https://claude.com/claude-code)