### PR TITLE
fix(d2): byte-exact elk layout via faithful d2elklayout port (#34)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -395,15 +395,28 @@ jobs:
       - name: clippy (deny warnings)
         run: cargo clippy -p d2-little --all-targets -- -D warnings
 
-      # NOTE: when the elk bridge (PR #69) lands, tests/elk_bridge.rs needs Node +
-      # elkjs available or its byte-exact/parity cases skip vacuously. Add before
-      # the test step:
-      #   - uses: actions/setup-node@v4
-      #     with: { node-version: "22" }
-      #   - run: npm install elkjs@0.8.2   # or the runner d2-little expects
-      # so the "byte-exact vs upstream d2" claim is guarded, not skipped.
+      # tests/elk_bridge.rs drives the elkjs bridge end-to-end (prepare →
+      # `node tests/elk_runner.mjs` → render) and asserts byte-exact SVG
+      # parity with upstream d2 v0.7.1. The runner resolves `elkjs@0.8.2`
+      # (the exact version d2 v0.7.1 bundles) from packages/engines, so
+      # install it there. Without node+elkjs these tests skip vacuously and
+      # the "byte-exact vs upstream d2" claim is unguarded.
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Install elkjs@0.8.2 for elk bridge tests
+        run: npm install elkjs@0.8.2 --prefix packages/engines --no-save --no-audit --no-fund
+
       - name: cargo test (lib + integration)
         run: cargo test -p d2-little --lib --tests
+
+      # The 293-fixture parity sweep is `#[ignore]` (heavy; ~1 min). Run it
+      # explicitly so the `>=190` floor guards against elk-bridge regressions
+      # — without this a silent drift in parity would not fail CI.
+      - name: elk bridge parity sweep (>=190 floor)
+        run: cargo test -p d2-little --test elk_bridge -- --ignored elk_bridge_fixture_parity
 
   # plantuml-little: the port integration tests (issue #28 frame width, issue
   # #36 create/destroy geometry) live under tests/port_sequence_*.rs and are

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -410,12 +410,14 @@ jobs:
         # npm can't parse packages/engines/package.json (bun `workspace:*`
         # protocol), so install elkjs in an isolated dir and symlink it into
         # packages/engines/node_modules — where the elk runner resolves it
-        # via Node's upward module walk.
+        # via Node's upward module walk. The `cd` is wrapped in a subshell so
+        # the repo-relative `ln -s` target still resolves from the workspace root.
         run: |
-          mkdir -p /tmp/elkjs && cd /tmp/elkjs && npm init -y >/dev/null
-          npm install elkjs@0.8.2 --no-audit --no-fund
+          mkdir -p /tmp/elkjs-install
+          (cd /tmp/elkjs-install && npm init -y >/dev/null && npm install elkjs@0.8.2 --no-audit --no-fund)
           mkdir -p packages/engines/node_modules
-          ln -s /tmp/elkjs/node_modules/elkjs packages/engines/node_modules/elkjs
+          ln -s /tmp/elkjs-install/node_modules/elkjs packages/engines/node_modules/elkjs
+          node -e 'require("module").createRequire(process.cwd()+"/packages/engines/package.json")("elkjs/lib/elk.bundled.js"); console.log("elkjs resolves OK")'
 
       - name: cargo test (lib + integration)
         run: cargo test -p d2-little --lib --tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -424,7 +424,9 @@ jobs:
       # explicitly so the `>=190` floor guards against elk-bridge regressions
       # — without this a silent drift in parity would not fail CI.
       - name: elk bridge parity sweep (>=190 floor)
-        run: cargo test -p d2-little --test elk_bridge -- --ignored elk_bridge_fixture_parity
+        env:
+          D2_ELK_DEBUG: '1'
+        run: cargo test -p d2-little --test elk_bridge -- --ignored elk_bridge_fixture_parity --nocapture
 
   # plantuml-little: the port integration tests (issue #28 frame width, issue
   # #36 create/destroy geometry) live under tests/port_sequence_*.rs and are

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -407,7 +407,15 @@ jobs:
           node-version: '22'
 
       - name: Install elkjs@0.8.2 for elk bridge tests
-        run: npm install elkjs@0.8.2 --prefix packages/engines --no-save --no-audit --no-fund
+        # npm can't parse packages/engines/package.json (bun `workspace:*`
+        # protocol), so install elkjs in an isolated dir and symlink it into
+        # packages/engines/node_modules — where the elk runner resolves it
+        # via Node's upward module walk.
+        run: |
+          mkdir -p /tmp/elkjs && cd /tmp/elkjs && npm init -y >/dev/null
+          npm install elkjs@0.8.2 --no-audit --no-fund
+          mkdir -p packages/engines/node_modules
+          ln -s /tmp/elkjs/node_modules/elkjs packages/engines/node_modules/elkjs
 
       - name: cargo test (lib + integration)
         run: cargo test -p d2-little --lib --tests

--- a/.gitignore
+++ b/.gitignore
@@ -52,7 +52,7 @@ ios/*.xcodeproj/xcuserdata
 
 # Android
 android/app/build/
-android/.gradle/
+.gradle/
 
 # Local tool state
 .claude/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -313,6 +313,8 @@ name = "d2-little-web"
 version = "0.7.1-1"
 dependencies = [
  "d2-little",
+ "serde",
+ "serde_json",
  "wasm-bindgen",
 ]
 

--- a/bun.lock
+++ b/bun.lock
@@ -35,7 +35,7 @@
     },
     "crates/d2-little/packages/web": {
       "name": "@actrium/d2-little-web",
-      "version": "0.7.2",
+      "version": "0.7.1-1",
       "devDependencies": {
         "typescript": "^5.7.0",
       },
@@ -277,7 +277,7 @@
       },
       "devDependencies": {
         "echarts": "^5.5.0",
-        "elkjs": "^0.9.3",
+        "elkjs": "0.8.2",
         "typescript": "^5.5.0",
         "vega": "^5.30.0",
         "vega-lite": "^5.21.0",
@@ -287,7 +287,7 @@
         "@actrium/mermaid-little-web": "workspace:*",
         "@actrium/plantuml-little-web": "workspace:*",
         "echarts": "^5",
-        "elkjs": "^0.9",
+        "elkjs": "0.8.2",
         "vega": "^5",
         "vega-lite": "^5",
       },
@@ -1941,7 +1941,7 @@
 
     "electron-to-chromium": ["electron-to-chromium@1.5.267", "", {}, "sha512-0Drusm6MVRXSOJpGbaSVgcQsuB4hEkMpHXaVstcPmhu5LIedxs1xNK/nIxmQIU/RPC0+1/o0AVZfBTkTNJOdUw=="],
 
-    "elkjs": ["elkjs@0.9.3", "", {}, "sha512-f/ZeWvW/BCXbhGEf1Ujp29EASo/lk1FDnETgNKwJrsVvGZhUWCZyg3xLJjAsxfOmt8KjswHmI5EwCQcPMpOYhQ=="],
+    "elkjs": ["elkjs@0.8.2", "", {}, "sha512-L6uRgvZTH+4OF5NE/MBbzQx/WYpru1xCBE9respNj6qznEewGUIfhzmm7horWWxbNO2M0WckQypGctR8lH79xQ=="],
 
     "emittery": ["emittery@0.13.1", "", {}, "sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -178,6 +178,7 @@
         "@supramark/feature-html-page": "workspace:*",
         "@supramark/feature-map": "workspace:*",
         "@supramark/feature-math": "workspace:*",
+        "@supramark/markdown-native-rn": "workspace:*",
         "@supramark/rn": "workspace:*",
         "echarts": "^5.5.0",
         "expo": "~54",
@@ -276,6 +277,7 @@
       },
       "devDependencies": {
         "echarts": "^5.5.0",
+        "elkjs": "^0.9.3",
         "typescript": "^5.5.0",
         "vega": "^5.30.0",
         "vega-lite": "^5.21.0",
@@ -285,6 +287,7 @@
         "@actrium/mermaid-little-web": "workspace:*",
         "@actrium/plantuml-little-web": "workspace:*",
         "echarts": "^5",
+        "elkjs": "^0.9",
         "vega": "^5",
         "vega-lite": "^5",
       },
@@ -293,6 +296,7 @@
         "@actrium/mermaid-little-web",
         "@actrium/plantuml-little-web",
         "echarts",
+        "elkjs",
         "vega",
         "vega-lite",
       ],
@@ -1936,6 +1940,8 @@
     "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
 
     "electron-to-chromium": ["electron-to-chromium@1.5.267", "", {}, "sha512-0Drusm6MVRXSOJpGbaSVgcQsuB4hEkMpHXaVstcPmhu5LIedxs1xNK/nIxmQIU/RPC0+1/o0AVZfBTkTNJOdUw=="],
+
+    "elkjs": ["elkjs@0.9.3", "", {}, "sha512-f/ZeWvW/BCXbhGEf1Ujp29EASo/lk1FDnETgNKwJrsVvGZhUWCZyg3xLJjAsxfOmt8KjswHmI5EwCQcPMpOYhQ=="],
 
     "emittery": ["emittery@0.13.1", "", {}, "sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ=="],
 

--- a/crates/d2-little/examples/dump_elk.rs
+++ b/crates/d2-little/examples/dump_elk.rs
@@ -1,0 +1,74 @@
+//! Drive the elkjs bridge end-to-end on a D2 source (native, no wasm):
+//! prepare → node elk_runner.js (elkjs@0.8.2) → render → SVG.
+//!
+//! Usage:
+//!   cargo run --example dump_elk -- "<d2 source>" > out.svg
+//!   cargo run --example dump_elk -- "$(cat case.d2)" /tmp/official.svg
+//!
+//! When a second arg (path to an official d2 elk SVG) is given, prints a
+//! byte-diff summary so you can iterate toward byte-exact parity.
+
+use std::io::Write;
+use std::process::{Command, Stdio};
+
+fn run_elk(elk_graph_json: &str) -> Result<String, String> {
+    // Locate the runner relative to the crate root (CARGO_MANIFEST_DIR is
+    // set at compile time), so the example works from any cwd.
+    let runner = format!("{}/tests/elk_runner.js", env!("CARGO_MANIFEST_DIR"));
+    let mut child = Command::new("node")
+        .arg(&runner)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|e| format!("spawn node: {e}"))?;
+    {
+        let mut stdin = child.stdin.take().ok_or("no stdin")?;
+        stdin
+            .write_all(elk_graph_json.as_bytes())
+            .map_err(|e| format!("write stdin: {e}"))?;
+    }
+    let out = child.wait_with_output().map_err(|e| format!("wait: {e}"))?;
+    if !out.status.success() {
+        return Err(String::from_utf8_lossy(&out.stderr).to_string());
+    }
+    Ok(String::from_utf8_lossy(&out.stdout).to_string())
+}
+
+fn main() {
+    let script = std::env::args().nth(1).expect("script arg");
+    let opts = d2_little::CompileOptions {
+        pad: Some(0),
+        ..d2_little::CompileOptions::default()
+    };
+    let (prepared, request) =
+        d2_little::prepare_for_external_layout(&script, &opts).expect("prepare");
+
+    if request.multi_board || request.has_sequence || request.has_grid || request.has_near {
+        eprintln!("WARN: request flags multi/seq/grid/near — elk bridge may not match");
+    }
+
+    let elk_graph_json = serde_json::to_string(&request.elk_graph).unwrap();
+    let laid = run_elk(&elk_graph_json).expect("elk.layout");
+    let elk_graph: d2_little::layout_bridge::ElkGraph =
+        serde_json::from_str(&laid).expect("deserialize laid-out graph");
+    let result = d2_little::layout_bridge::LayoutResult { elk_graph };
+
+    let svg = d2_little::render_with_external_layout(prepared, &result).expect("render");
+    let svg_str = String::from_utf8_lossy(&svg).to_string();
+    print!("{}", svg_str);
+
+    if let Some(exp_path) = std::env::args().nth(2) {
+        let exp = std::fs::read_to_string(&exp_path).expect("read official svg");
+        let pos = svg_str
+            .chars()
+            .zip(exp.chars())
+            .position(|(a, b)| a != b)
+            .unwrap_or(svg_str.len().min(exp.len()));
+        eprintln!("--- diff vs {} ---", exp_path);
+        eprintln!("ours len={}, exp len={}, first diff at {}", svg_str.len(), exp.len(), pos);
+        let s = pos.saturating_sub(60);
+        eprintln!("OURS: {:?}", &svg_str[s..(pos + 80).min(svg_str.len())]);
+        eprintln!("EXP : {:?}", &exp[s..(pos + 80).min(exp.len())]);
+    }
+}

--- a/crates/d2-little/examples/dump_elk.rs
+++ b/crates/d2-little/examples/dump_elk.rs
@@ -1,5 +1,5 @@
 //! Drive the elkjs bridge end-to-end on a D2 source (native, no wasm):
-//! prepare → node elk_runner.js (elkjs@0.8.2) → render → SVG.
+//! prepare → node elk_runner.mjs (elkjs@0.8.2) → render → SVG.
 //!
 //! Usage:
 //!   cargo run --example dump_elk -- "<d2 source>" > out.svg
@@ -14,7 +14,7 @@ use std::process::{Command, Stdio};
 fn run_elk(elk_graph_json: &str) -> Result<String, String> {
     // Locate the runner relative to the crate root (CARGO_MANIFEST_DIR is
     // set at compile time), so the example works from any cwd.
-    let runner = format!("{}/tests/elk_runner.js", env!("CARGO_MANIFEST_DIR"));
+    let runner = format!("{}/tests/elk_runner.mjs", env!("CARGO_MANIFEST_DIR"));
     let mut child = Command::new("node")
         .arg(&runner)
         .stdin(Stdio::piped())

--- a/crates/d2-little/examples/dump_elk.rs
+++ b/crates/d2-little/examples/dump_elk.rs
@@ -44,18 +44,26 @@ fn main() {
     let (prepared, request) =
         d2_little::prepare_for_external_layout(&script, &opts).expect("prepare");
 
-    if request.multi_board || request.has_sequence || request.has_grid || request.has_near {
-        eprintln!("WARN: request flags multi/seq/grid/near — elk bridge may not match");
-    }
-
-    let elk_graph_json = serde_json::to_string(&request.elk_graph).unwrap();
-    let laid = run_elk(&elk_graph_json).expect("elk.layout");
-    let elk_graph: d2_little::layout_bridge::ElkGraph =
-        serde_json::from_str(&laid).expect("deserialize laid-out graph");
-    let result = d2_little::layout_bridge::LayoutResult { elk_graph };
-
-    let svg = d2_little::render_with_external_layout(prepared, &result).expect("render");
-    let svg_str = String::from_utf8_lossy(&svg).to_string();
+    // Match the production host: sequence / grid / `near:` diagrams fall
+    // back to the dagre `convert` path (engine-independent specialized
+    // layouts). `prepared` is dropped.
+    let svg_str = if request.multi_board
+        || request.has_sequence
+        || request.has_grid
+        || request.has_near
+    {
+        drop(prepared);
+        let svg = d2_little::d2_to_svg(&script).expect("dagre fallback");
+        String::from_utf8_lossy(&svg).to_string()
+    } else {
+        let elk_graph_json = serde_json::to_string(&request.elk_graph).unwrap();
+        let laid = run_elk(&elk_graph_json).expect("elk.layout");
+        let elk_graph: d2_little::layout_bridge::ElkGraph =
+            serde_json::from_str(&laid).expect("deserialize laid-out graph");
+        let result = d2_little::layout_bridge::LayoutResult { elk_graph };
+        let svg = d2_little::render_with_external_layout(prepared, &result).expect("render");
+        String::from_utf8_lossy(&svg).to_string()
+    };
     print!("{}", svg_str);
 
     if let Some(exp_path) = std::env::args().nth(2) {

--- a/crates/d2-little/examples/dump_elk.rs
+++ b/crates/d2-little/examples/dump_elk.rs
@@ -47,23 +47,20 @@ fn main() {
     // Match the production host: sequence / grid / `near:` diagrams fall
     // back to the dagre `convert` path (engine-independent specialized
     // layouts). `prepared` is dropped.
-    let svg_str = if request.multi_board
-        || request.has_sequence
-        || request.has_grid
-        || request.has_near
-    {
-        drop(prepared);
-        let svg = d2_little::d2_to_svg(&script).expect("dagre fallback");
-        String::from_utf8_lossy(&svg).to_string()
-    } else {
-        let elk_graph_json = serde_json::to_string(&request.elk_graph).unwrap();
-        let laid = run_elk(&elk_graph_json).expect("elk.layout");
-        let elk_graph: d2_little::layout_bridge::ElkGraph =
-            serde_json::from_str(&laid).expect("deserialize laid-out graph");
-        let result = d2_little::layout_bridge::LayoutResult { elk_graph };
-        let svg = d2_little::render_with_external_layout(prepared, &result).expect("render");
-        String::from_utf8_lossy(&svg).to_string()
-    };
+    let svg_str =
+        if request.multi_board || request.has_sequence || request.has_grid || request.has_near {
+            drop(prepared);
+            let svg = d2_little::d2_to_svg(&script).expect("dagre fallback");
+            String::from_utf8_lossy(&svg).to_string()
+        } else {
+            let elk_graph_json = serde_json::to_string(&request.elk_graph).unwrap();
+            let laid = run_elk(&elk_graph_json).expect("elk.layout");
+            let elk_graph: d2_little::layout_bridge::ElkGraph =
+                serde_json::from_str(&laid).expect("deserialize laid-out graph");
+            let result = d2_little::layout_bridge::LayoutResult { elk_graph };
+            let svg = d2_little::render_with_external_layout(prepared, &result).expect("render");
+            String::from_utf8_lossy(&svg).to_string()
+        };
     print!("{}", svg_str);
 
     if let Some(exp_path) = std::env::args().nth(2) {
@@ -74,7 +71,12 @@ fn main() {
             .position(|(a, b)| a != b)
             .unwrap_or(svg_str.len().min(exp.len()));
         eprintln!("--- diff vs {} ---", exp_path);
-        eprintln!("ours len={}, exp len={}, first diff at {}", svg_str.len(), exp.len(), pos);
+        eprintln!(
+            "ours len={}, exp len={}, first diff at {}",
+            svg_str.len(),
+            exp.len(),
+            pos
+        );
         let s = pos.saturating_sub(60);
         eprintln!("OURS: {:?}", &svg_str[s..(pos + 80).min(svg_str.len())]);
         eprintln!("EXP : {:?}", &exp[s..(pos + 80).min(exp.len())]);

--- a/crates/d2-little/packages/web/Cargo.toml
+++ b/crates/d2-little/packages/web/Cargo.toml
@@ -26,3 +26,6 @@ wasm-opt = false
 [dependencies]
 d2-little = { path = "../.." }
 wasm-bindgen = "0.2"
+# Serialise the elk layout request/result across the wasm boundary.
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"

--- a/crates/d2-little/packages/web/src/index.ts
+++ b/crates/d2-little/packages/web/src/index.ts
@@ -14,7 +14,8 @@
  * ```
  */
 
-// Re-export the raw wasm-bindgen API. `convert` and `version` are the
-// two public functions; everything else (`__wbg_set_wasm` etc.) stays
-// internal to the generated JS.
-export { convert, version } from './wasm/d2_little_web.js';
+// Re-export the raw wasm-bindgen API. `convert` (dagre) and `version` are the
+// always-available entries; `prepare` / `render` / `drop_prepared` form the
+// elkjs layout bridge (the host runs `elkjs.layout` between `prepare` and
+// `render`). Everything else (`__wbg_set_wasm` etc.) stays internal.
+export { convert, version, prepare, render, drop_prepared } from './wasm/d2_little_web.js';

--- a/crates/d2-little/packages/web/src/lib.rs
+++ b/crates/d2-little/packages/web/src/lib.rs
@@ -6,8 +6,22 @@
 //! so no external JS bridge is required — unlike the plantuml-little
 //! wasm wrapper, which has to be wired up to a Graphviz engine.
 //!
+//! ## elk layout bridge
+//!
+//! For D2 sources that request `vars.d2-config.layout-engine: elk`, the
+//! host can render via the elkjs bridge: call [`prepare`] to obtain a
+//! layout-request JSON + handle, run elkjs `elk.layout` on the request,
+//! then call [`render`] with the result. [`convert`] is unchanged and
+//! remains the dagre-only path. The engines layer (`@supramark/engines`)
+//! orchestrates the prepare → elkjs → render sequence and falls back to
+//! [`convert`] when `prepare` reports an unsupported feature (sequence /
+//! grid / containers / `near:` / multi-board).
+//!
 //! `version()` returns the crate version embedded at compile time so
 //! hosts can assert the wasm bytes match what they bundled.
+
+use std::cell::Cell;
+use std::collections::HashMap;
 
 use wasm_bindgen::prelude::*;
 
@@ -26,4 +40,104 @@ pub fn convert(input: &str) -> Result<String, JsValue> {
 #[wasm_bindgen]
 pub fn version() -> String {
     env!("CARGO_PKG_VERSION").to_string()
+}
+
+// ---------------------------------------------------------------------------
+// prepare / render: external-layout bridge (elkjs)
+// ---------------------------------------------------------------------------
+
+thread_local! {
+    /// Prepared graphs awaiting a host-supplied layout. Keyed by the handle
+    /// returned from `prepare`; consumed (removed) by `render`. wasm is
+    /// single-threaded so this needs no locking.
+    static PREPARED: std::cell::RefCell<HashMap<u32, d2_little::PreparedLayout>> =
+        std::cell::RefCell::new(HashMap::new());
+    static NEXT_HANDLE: Cell<u32> = Cell::new(1);
+}
+
+/// Result of [`prepare`]: a handle to the prepared graph state held inside
+/// the wasm instance, plus a `request` JSON describing what the host must
+/// lay out. Pass the handle and a result JSON to [`render`] to finish.
+#[wasm_bindgen]
+pub struct PrepareResult {
+    handle: u32,
+    /// [`d2_little::layout_bridge::LayoutRequest`] serialised to JSON.
+    request: String,
+}
+
+#[wasm_bindgen]
+impl PrepareResult {
+    #[wasm_bindgen(getter)]
+    pub fn handle(&self) -> u32 {
+        self.handle
+    }
+
+    #[wasm_bindgen(getter)]
+    pub fn request(&self) -> String {
+        self.request.clone()
+    }
+}
+
+/// Parse + compile + measure a D2 source WITHOUT running the built-in
+/// dagre layout. Returns a handle plus a layout-request JSON the host
+/// feeds to its external layout engine (elkjs). The host falls back to
+/// [`convert`] when `request.multi_board === true` or any feature flag
+/// (`has_sequence` / `has_grid` / `has_near` / `has_containers`) is set.
+///
+/// Contracts:
+/// - Each `prepare` allocates a handle; the host MUST pair it with a
+///   `render` call to free the stashed graph, or call [`drop_prepared`].
+/// - Single active prepare is the supported model; handles leak until
+///   consumed.
+#[wasm_bindgen]
+pub fn prepare(input: &str) -> Result<PrepareResult, JsValue> {
+    let opts = d2_little::CompileOptions {
+        pad: Some(0),
+        ..d2_little::CompileOptions::default()
+    };
+    let (prepared, request) =
+        d2_little::prepare_for_external_layout(input, &opts).map_err(|e| JsValue::from_str(&e))?;
+    let request_json = serde_json::to_string(&request)
+        .map_err(|e| JsValue::from_str(&format!("layout request serialize: {e}")))?;
+
+    let handle = NEXT_HANDLE.with(|c| {
+        let h = c.get();
+        c.set(h.wrapping_add(1));
+        h
+    });
+    PREPARED.with(|p| p.borrow_mut().insert(handle, prepared));
+
+    Ok(PrepareResult {
+        handle,
+        request: request_json,
+    })
+}
+
+/// Apply a host-computed layout to a previously-prepared graph and render
+/// it to SVG. `layout_json` is a [`d2_little::layout_bridge::LayoutResult`]
+/// serialised to JSON (one board, matching `prepare`'s request). Consumes
+/// and drops the handle.
+#[wasm_bindgen]
+pub fn render(handle: u32, layout_json: &str) -> Result<String, JsValue> {
+    let prepared = PREPARED
+        .with(|p| p.borrow_mut().remove(&handle))
+        .ok_or_else(|| JsValue::from_str(&format!("unknown prepare handle: {handle}")))?;
+
+    let result: d2_little::layout_bridge::LayoutResult =
+        serde_json::from_str(layout_json).map_err(|e| {
+            JsValue::from_str(&format!("layout result deserialize: {e}"))
+        })?;
+
+    d2_little::render_with_external_layout(prepared, &result)
+        .map(|bytes| String::from_utf8_lossy(&bytes).into_owned())
+        .map_err(|e| JsValue::from_str(&e))
+}
+
+/// Drop a prepared-graph handle without rendering (frees wasm memory).
+/// Idempotent — a missing or already-consumed handle is a no-op.
+#[wasm_bindgen]
+pub fn drop_prepared(handle: u32) {
+    PREPARED.with(|p| {
+        p.borrow_mut().remove(&handle);
+    });
 }

--- a/crates/d2-little/packages/web/src/lib.rs
+++ b/crates/d2-little/packages/web/src/lib.rs
@@ -82,7 +82,7 @@ impl PrepareResult {
 /// dagre layout. Returns a handle plus a layout-request JSON the host
 /// feeds to its external layout engine (elkjs). The host falls back to
 /// [`convert`] when `request.multi_board === true` or any feature flag
-/// (`has_sequence` / `has_grid` / `has_near` / `has_containers`) is set.
+/// (`has_sequence` / `has_grid` / `has_near`) is set.
 ///
 /// Contracts:
 /// - Each `prepare` allocates a handle; the host MUST pair it with a

--- a/crates/d2-little/packages/web/src/wasm/d2_little_web.d.ts
+++ b/crates/d2-little/packages/web/src/wasm/d2_little_web.d.ts
@@ -6,5 +6,18 @@
 // during TypeScript compilation. At runtime (after build), the relative
 // import resolves to `dist/wasm/d2_little_web.js`, which is the actual
 // wasm-pack output.
+//
+// `prepare` / `render` / `drop_prepared` form the elkjs layout bridge
+// (host runs `elkjs.layout` between `prepare` and `render`); `convert` is
+// the dagre-only path.
+
+export class PrepareResult {
+  readonly handle: number;
+  readonly request: string;
+}
+
 export function convert(input: string): string;
 export function version(): string;
+export function prepare(input: string): PrepareResult;
+export function render(handle: number, layout_json: string): string;
+export function drop_prepared(handle: number): void;

--- a/crates/d2-little/scripts/elk_parity_check.py
+++ b/crates/d2-little/scripts/elk_parity_check.py
@@ -3,7 +3,7 @@
 
 Iterates all `tests/e2e_testdata/<cat>/<name>/elk/sketch.exp.svg` whose script
 is known (from tests/e2e_dagre_svg_cases.json), runs the dump_elk example
-(prepare -> node elk_runner.js -> render), and reports byte-exact pass/fail.
+(prepare -> node elk_runner.mjs -> render), and reports byte-exact pass/fail.
 
 Usage: python3 scripts/elk_parity_check.py [binary]
   binary defaults to target/debug/examples/dump_elk
@@ -15,7 +15,7 @@ import sys
 
 ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 BIN = sys.argv[1] if len(sys.argv) > 1 else os.path.join(ROOT, "../../target/debug/examples/dump_elk")
-RUNNER = os.path.join(ROOT, "tests/elk_runner.js")
+RUNNER = os.path.join(ROOT, "tests/elk_runner.mjs")
 
 
 def load_scripts():

--- a/crates/d2-little/scripts/elk_parity_check.py
+++ b/crates/d2-little/scripts/elk_parity_check.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Compare the d2-little elk bridge output to every elk fixture.
+
+Iterates all `tests/e2e_testdata/<cat>/<name>/elk/sketch.exp.svg` whose script
+is known (from tests/e2e_dagre_svg_cases.json), runs the dump_elk example
+(prepare -> node elk_runner.js -> render), and reports byte-exact pass/fail.
+
+Usage: python3 scripts/elk_parity_check.py [binary]
+  binary defaults to target/debug/examples/dump_elk
+"""
+import json
+import os
+import subprocess
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+BIN = sys.argv[1] if len(sys.argv) > 1 else os.path.join(ROOT, "../../target/debug/examples/dump_elk")
+RUNNER = os.path.join(ROOT, "tests/elk_runner.js")
+
+
+def load_scripts():
+    cases = json.load(open(os.path.join(ROOT, "tests/e2e_dagre_svg_cases.json")))
+    m = {}
+    for c in cases:
+        m[(c["family"], c["fixture_name"])] = c["script"]
+    return m
+
+
+def main():
+    scripts = load_scripts()
+    elk_dirs = []
+    for root, dirs, _ in os.walk(os.path.join(ROOT, "tests/e2e_testdata")):
+        if "elk" in dirs and os.path.exists(os.path.join(root, "elk", "sketch.exp.svg")):
+            rel = os.path.relpath(root, os.path.join(ROOT, "tests/e2e_testdata"))
+            parts = rel.split(os.sep)
+            if len(parts) == 2:
+                elk_dirs.append((parts[0], parts[1]))
+
+    passed = 0
+    failed = 0
+    skipped = 0
+    failures = []
+    for cat, name in elk_dirs:
+        script = scripts.get((cat, name))
+        exp = os.path.join(ROOT, "tests/e2e_testdata", cat, name, "elk", "sketch.exp.svg")
+        if script is None:
+            skipped += 1
+            continue
+        try:
+            out = subprocess.run(
+                [BIN, script], cwd=ROOT, capture_output=True, text=True, timeout=60,
+                env={**os.environ, "PATH": os.environ["PATH"]},
+            )
+        except subprocess.TimeoutExpired:
+            failed += 1
+            failures.append((cat, name, "timeout"))
+            continue
+        if out.returncode != 0:
+            failed += 1
+            failures.append((cat, name, "err: " + out.stderr.strip()[:120]))
+            continue
+        ours = out.stdout
+        exp_text = open(exp).read()
+        if ours == exp_text:
+            passed += 1
+        else:
+            failed += 1
+            # find first diff
+            pos = next((i for i, (a, b) in enumerate(zip(ours, exp_text)) if a != b), min(len(ours), len(exp_text)))
+            failures.append((cat, name, f"diff@{pos} ours{len(ours)} exp{len(exp_text)}: {ours[pos:pos+50]!r} vs {exp_text[pos:pos+50]!r}"))
+
+    print(f"\n=== elk parity: {passed} passed, {failed} failed, {skipped} skipped (no script) ===")
+    for cat, name, msg in failures[:40]:
+        print(f"  FAIL {cat}/{name}: {msg}")
+    if len(failures) > 40:
+        print(f"  ... and {len(failures)-40} more failures")
+    return 0 if failed == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/crates/d2-little/src/dagre_layout.rs
+++ b/crates/d2-little/src/dagre_layout.rs
@@ -296,10 +296,8 @@ fn get_longest_edge_chain_tail(g: &Graph, container: ObjId) -> ObjId {
 /// Position every non-root object's label and icon based on object
 /// properties alone (icon / label / children presence, label-vs-box
 /// overflow). This is the same per-object pass that runs at the top of
-/// [`layout_with_exclude`]; external layout backends (e.g. the elkjs
-/// bridge, which skips dagre entirely) call this so default label
-/// placement matches dagre's conventions without running dagre.
-pub fn position_object_labels(g: &mut crate::graph::Graph) {
+/// [`layout_with_exclude`].
+fn position_object_labels(g: &mut crate::graph::Graph) {
     for i in 0..g.objects.len() {
         if i == g.root {
             continue;

--- a/crates/d2-little/src/dagre_layout.rs
+++ b/crates/d2-little/src/dagre_layout.rs
@@ -293,6 +293,21 @@ fn get_longest_edge_chain_tail(g: &Graph, container: ObjId) -> ObjId {
 // ---------------------------------------------------------------------------
 
 /// Set default label and icon positions for an object.
+/// Position every non-root object's label and icon based on object
+/// properties alone (icon / label / children presence, label-vs-box
+/// overflow). This is the same per-object pass that runs at the top of
+/// [`layout_with_exclude`]; external layout backends (e.g. the elkjs
+/// bridge, which skips dagre entirely) call this so default label
+/// placement matches dagre's conventions without running dagre.
+pub fn position_object_labels(g: &mut crate::graph::Graph) {
+    for i in 0..g.objects.len() {
+        if i == g.root {
+            continue;
+        }
+        position_labels_icons(&mut g.objects[i]);
+    }
+}
+
 fn position_labels_icons(obj: &mut crate::graph::Object) {
     if obj.icon.is_some() && obj.icon_position.is_none() {
         if !obj.children_array.is_empty() {
@@ -847,13 +862,7 @@ pub fn layout_with_exclude(
     };
 
     // Position labels and icons
-    for i in 0..g.objects.len() {
-        if i == g.root {
-            continue;
-        }
-        // Borrow-safe: copy needed data, modify object
-        position_labels_icons(&mut g.objects[i]);
-    }
+    position_object_labels(g);
 
     // Compute max label dimensions for rank separation
     let mut max_label_width = 0;

--- a/crates/d2-little/src/layout_bridge.rs
+++ b/crates/d2-little/src/layout_bridge.rs
@@ -348,7 +348,11 @@ pub fn build_layout_request(g: &mut Graph) -> LayoutRequest {
                 node_size_constraints: Some("MINIMUM_SIZE".to_string()),
                 content_alignment: Some("H_CENTER V_CENTER".to_string()),
                 direction: String::new(),
-                algorithm: Some("layered".to_string()),
+                // NOTE: d2 does NOT set `elk.algorithm` on container nodes —
+                // only on the root. Setting it here makes elkjs treat the
+                // compound as a separate layout root and skip hierarchical
+                // child placement (children end up at 0,0). Inherited via
+                // the root's `INCLUDE_CHILDREN`.
                 node_spacing: Some(DEFAULT_NODE_SPACING),
                 edge_node_spacing: Some(DEFAULT_EDGE_NODE_SPACING),
                 self_loop_spacing,

--- a/crates/d2-little/src/layout_bridge.rs
+++ b/crates/d2-little/src/layout_bridge.rs
@@ -967,6 +967,7 @@ struct EndpointInfo {
     label_dims: crate::graph::Dimensions,
     has_icon: bool,
     icon_pos: Option<String>,
+    has_modifier: bool,
 }
 
 impl EndpointInfo {
@@ -979,6 +980,7 @@ impl EndpointInfo {
             label_dims: o.label_dimensions,
             has_icon: o.has_icon(),
             icon_pos: o.icon_position.clone(),
+            has_modifier: o.get_modifier_element_adjustments() != (0.0, 0.0),
         }
     }
 }
@@ -1045,10 +1047,24 @@ fn trace_src(info: &EndpointInfo, route: &mut [Point], start: &mut usize, end: u
             }
         }
     }
-    // Non-outside-label/icon: the route already starts at the shape border
-    // (elkjs places it there), so — like d2's no-op move for rectangular
-    // shapes — we leave it. Point-moving here (intersections[0] selection)
-    // regresses non-outside cases (issue #34).
+    // Non-outside-label/icon: only 3d/multiple shapes need the endpoint moved
+    // to the (offset) box border — elkjs placed the route at the original
+    // border, but the modifier offset shifted the trace box. For plain
+    // rectangles the route is already at the border, and intersections[0]
+    // selection is a float-fragile no-op that regresses issue #34, so skip.
+    if info.has_modifier {
+        let ints = info.box_.intersections(&seg);
+        if !ints.is_empty() {
+            route[*start] = ints[0];
+            seg.end = ints[0];
+            if *start + 1 < end && seg.length() < MIN_SEGMENT_LEN {
+                route[*start + 1] = route[*start];
+                *start += 1;
+            }
+        }
+        let shape = crate::shape::Shape::new(&info.shape_type, info.box_);
+        route[*start] = crate::shape::trace_to_shape_border(&shape, &route[*start], &route[*start + 1]);
+    }
 }
 
 /// Trace the DST endpoint. Mirror of `trace_src`: `end` moves backward.
@@ -1112,7 +1128,21 @@ fn trace_dst(info: &EndpointInfo, route: &mut [Point], start: usize, end: &mut u
             }
         }
     }
-    // Non-outside-label/icon: route already at the border — leave it (see trace_src).
+    // Non-outside-label/icon: only 3d/multiple shapes need the endpoint moved
+    // to the offset box border (see trace_src).
+    if info.has_modifier {
+        let ints = info.box_.intersections(&seg);
+        if !ints.is_empty() {
+            route[*end] = ints[0];
+            seg.start = ints[0];
+            if *end - 1 > start && seg.length() < MIN_SEGMENT_LEN {
+                route[*end - 1] = route[*end];
+                *end -= 1;
+            }
+        }
+        let shape = crate::shape::Shape::new(&info.shape_type, info.box_);
+        route[*end] = crate::shape::trace_to_shape_border(&shape, &route[*end], &route[*end - 1]);
+    }
 }
 
 /// Faithful port of d2 `Edge.TraceToShape` for the elk path. Mutates the

--- a/crates/d2-little/src/layout_bridge.rs
+++ b/crates/d2-little/src/layout_bridge.rs
@@ -19,7 +19,7 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::geo::{Point, Segment, Spacing};
+use crate::geo::{Box2D, Point, Segment, Spacing};
 use crate::graph::{Graph, ObjId};
 use crate::label::{self, Position};
 use crate::shape::ShapeOps;
@@ -587,10 +587,13 @@ pub fn apply_layout(g: &mut Graph, result: &LayoutResult) -> Result<(), String> 
             }
         }
 
-        let route = g.edges[ei].route.clone();
-        let (new_start, new_end) = g.edges[ei].trace_to_shape(&route, 0, route.len() - 1, g);
+        // Faithful port of d2 `Edge.TraceToShape` (outside-label / outside-icon
+        // / shape-border tracing). Uses the EXPANDED obj.box_ (margin shrink
+        // does not refresh it — see apply_margins), so edges stop at outside
+        // labels (e.g. image bottom labels) rather than the shrunk shape box.
+        let (new_start, new_end) = trace_to_shape_full(g, ei);
         let has_label = !g.edges[ei].label.value.is_empty();
-        g.edges[ei].route = route[new_start..=new_end].to_vec();
+        g.edges[ei].route = g.edges[ei].route[new_start..=new_end].to_vec();
         if has_label {
             g.edges[ei].label_position = Some(Position::InsideMiddleCenter.as_str().to_string());
         }
@@ -927,8 +930,208 @@ fn shift_end(g: &mut Graph, ei: usize, delta: f64, is_horizontal: bool) {
 }
 
 // ---------------------------------------------------------------------------
-// deleteBends (layout.go:659-884).
+// TraceToShape (d2graph/layout.go:414) — faithful port, elk-only.
 // ---------------------------------------------------------------------------
+
+const MIN_SEGMENT_LEN: f64 = 10.0;
+
+/// d2 `findOuterIntersection` — pick the intersection point on the outer side
+/// of an outside label/icon (so the edge stops at the outer border).
+fn find_outer_intersection(position: Position, mut intersections: Vec<Point>) -> Point {
+    match position {
+        Position::OutsideTopLeft | Position::OutsideTopCenter | Position::OutsideTopRight => {
+            intersections.sort_by(|a, b| a.y.partial_cmp(&b.y).unwrap_or(std::cmp::Ordering::Equal));
+        }
+        Position::OutsideBottomLeft | Position::OutsideBottomCenter | Position::OutsideBottomRight => {
+            intersections.sort_by(|a, b| b.y.partial_cmp(&a.y).unwrap_or(std::cmp::Ordering::Equal));
+        }
+        Position::OutsideLeftTop | Position::OutsideLeftMiddle | Position::OutsideLeftBottom => {
+            intersections.sort_by(|a, b| a.x.partial_cmp(&b.x).unwrap_or(std::cmp::Ordering::Equal));
+        }
+        Position::OutsideRightTop | Position::OutsideRightMiddle | Position::OutsideRightBottom => {
+            intersections.sort_by(|a, b| b.x.partial_cmp(&a.x).unwrap_or(std::cmp::Ordering::Equal));
+        }
+        _ => {}
+    }
+    intersections.into_iter().next().unwrap_or(Point::new(0.0, 0.0))
+}
+
+/// Snapshot of one endpoint's trace inputs (so we can mutate the route without
+/// holding a borrow into `g.objects`).
+struct EndpointInfo {
+    box_: Box2D,
+    #[allow(dead_code)]
+    shape_type: String,
+    has_label: bool,
+    label_pos: Option<String>,
+    label_dims: crate::graph::Dimensions,
+    has_icon: bool,
+    icon_pos: Option<String>,
+}
+
+impl EndpointInfo {
+    fn from_obj(o: &crate::graph::Object) -> Self {
+        EndpointInfo {
+            box_: o.box_,
+            shape_type: crate::target::dsl_shape_to_shape_type(&o.shape.value).to_string(),
+            has_label: o.has_label(),
+            label_pos: o.label_position.clone(),
+            label_dims: o.label_dimensions,
+            has_icon: o.has_icon(),
+            icon_pos: o.icon_position.clone(),
+        }
+    }
+}
+
+/// Trace the SRC endpoint of the route. Faithful port of d2's src half of
+/// `Edge.TraceToShape`. Mutates `route` in place, advances `*start`.
+fn trace_src(info: &EndpointInfo, route: &mut [Point], start: &mut usize, end: usize) {
+    // startingSegment = {Start: points[start+1], End: points[start]}
+    let mut seg = Segment::new(route[*start + 1], route[*start]);
+    let mut overlaps_outside_label = false;
+
+    if info.has_label {
+        if let Some(lp_str) = &info.label_pos {
+            let lp = Position::from_string(lp_str);
+            if lp.is_outside() {
+                let lw = info.label_dims.width as f64;
+                let lh = info.label_dims.height as f64;
+                let label_tl = lp.get_point_on_box(&info.box_, label::PADDING, lw, lh);
+                let mut label_box = Box2D::new(label_tl, lw, lh);
+                label_box.top_left.x -= label::PADDING;
+                label_box.width += 2.0 * label::PADDING;
+                while label_box.contains(&seg.end) && *start + 1 > end {
+                    seg.start = seg.end;
+                    seg.end = route[*start + 2];
+                    *start += 1;
+                }
+                let ints = label_box.intersections(&seg);
+                if !ints.is_empty() {
+                    overlaps_outside_label = true;
+                    let p = if ints.len() > 1 { find_outer_intersection(lp, ints) } else { ints[0] };
+                    route[*start] = p;
+                    seg.end = p;
+                    if *start + 1 < end && seg.length() < MIN_SEGMENT_LEN {
+                        route[*start + 1] = route[*start];
+                        *start += 1;
+                    }
+                }
+            }
+        }
+    }
+    if !overlaps_outside_label && info.has_icon {
+        if let Some(ip_str) = &info.icon_pos {
+            let ip = Position::from_string(ip_str);
+            if ip.is_outside() {
+                let iw = crate::target::MAX_ICON_SIZE as f64;
+                let ih = crate::target::MAX_ICON_SIZE as f64;
+                let icon_tl = ip.get_point_on_box(&info.box_, label::PADDING, iw, ih);
+                let icon_box = Box2D::new(icon_tl, iw, ih);
+                while icon_box.contains(&seg.end) && *start + 1 > end {
+                    seg.start = seg.end;
+                    seg.end = route[*start + 2];
+                    *start += 1;
+                }
+                let ints = icon_box.intersections(&seg);
+                if !ints.is_empty() {
+                    let p = if ints.len() > 1 { find_outer_intersection(ip, ints) } else { ints[0] };
+                    route[*start] = p;
+                    seg.end = p;
+                    if *start + 1 < end && seg.length() < MIN_SEGMENT_LEN {
+                        route[*start + 1] = route[*start];
+                        *start += 1;
+                    }
+                }
+            }
+        }
+    }
+    // Non-outside-label/icon: the route already starts at the shape border
+    // (elkjs places it there), so — like d2's no-op move for rectangular
+    // shapes — we leave it. Point-moving here (intersections[0] selection)
+    // regresses non-outside cases (issue #34).
+}
+
+/// Trace the DST endpoint. Mirror of `trace_src`: `end` moves backward.
+fn trace_dst(info: &EndpointInfo, route: &mut [Point], start: usize, end: &mut usize) {
+    // endingSegment = {Start: points[end-1], End: points[end]}
+    let mut seg = Segment::new(route[*end - 1], route[*end]);
+    let mut overlaps_outside_label = false;
+
+    if info.has_label {
+        if let Some(lp_str) = &info.label_pos {
+            let lp = Position::from_string(lp_str);
+            if lp.is_outside() {
+                let lw = info.label_dims.width as f64;
+                let lh = info.label_dims.height as f64;
+                let label_tl = lp.get_point_on_box(&info.box_, label::PADDING, lw, lh);
+                let mut label_box = Box2D::new(label_tl, lw, lh);
+                label_box.top_left.x -= label::PADDING;
+                label_box.width += 2.0 * label::PADDING;
+                while label_box.contains(&seg.start) && *end - 1 > start {
+                    seg.end = seg.start;
+                    seg.start = route[*end - 2];
+                    *end -= 1;
+                }
+                let ints = label_box.intersections(&seg);
+                if !ints.is_empty() {
+                    overlaps_outside_label = true;
+                    let p = if ints.len() > 1 { find_outer_intersection(lp, ints) } else { ints[0] };
+                    route[*end] = p;
+                    seg.end = p;
+                    if *end - 1 > start && seg.length() < MIN_SEGMENT_LEN {
+                        route[*end - 1] = route[*end];
+                        *end -= 1;
+                    }
+                }
+            }
+        }
+    }
+    if !overlaps_outside_label && info.has_icon {
+        if let Some(ip_str) = &info.icon_pos {
+            let ip = Position::from_string(ip_str);
+            if ip.is_outside() {
+                let iw = crate::target::MAX_ICON_SIZE as f64;
+                let ih = crate::target::MAX_ICON_SIZE as f64;
+                let icon_tl = ip.get_point_on_box(&info.box_, label::PADDING, iw, ih);
+                let icon_box = Box2D::new(icon_tl, iw, ih);
+                while icon_box.contains(&seg.start) && *end - 1 > start {
+                    seg.end = seg.start;
+                    seg.start = route[*end - 2];
+                    *end -= 1;
+                }
+                let ints = icon_box.intersections(&seg);
+                if !ints.is_empty() {
+                    let p = if ints.len() > 1 { find_outer_intersection(ip, ints) } else { ints[0] };
+                    route[*end] = p;
+                    seg.end = p;
+                    if *end - 1 > start && seg.length() < MIN_SEGMENT_LEN {
+                        route[*end - 1] = route[*end];
+                        *end -= 1;
+                    }
+                }
+            }
+        }
+    }
+    // Non-outside-label/icon: route already at the border — leave it (see trace_src).
+}
+
+/// Faithful port of d2 `Edge.TraceToShape` for the elk path. Mutates the
+/// edge route in place (moving endpoints to label/icon/shape borders and
+/// merging too-short segments) and returns the new (start, end) indices.
+pub fn trace_to_shape_full(g: &mut Graph, ei: usize) -> (usize, usize) {
+    let (src_id, dst_id) = (g.edges[ei].src, g.edges[ei].dst);
+    let src_info = EndpointInfo::from_obj(&g.objects[src_id]);
+    let dst_info = EndpointInfo::from_obj(&g.objects[dst_id]);
+    let mut start = 0usize;
+    let mut end = g.edges[ei].route.len() - 1;
+
+    trace_src(&src_info, &mut g.edges[ei].route, &mut start, end);
+    trace_dst(&dst_info, &mut g.edges[ei].route, start, &mut end);
+
+    (start, end)
+}
+
+
 
 fn delete_bends(g: &mut Graph) {
     // S-shapes at source/target (layout.go:662-773).

--- a/crates/d2-little/src/layout_bridge.rs
+++ b/crates/d2-little/src/layout_bridge.rs
@@ -6,7 +6,9 @@
 //! `elk.layout`, then post-processes the result (parent-relative → absolute
 //! coordinates, margin shrink-back, `TraceToShape`, `deleteBends`). This
 //! module is a faithful Rust port of `d2layouts/d2elklayout/layout.go`
-//! (d2 v0.7.1), so output is byte-comparable with upstream d2 elk.
+//! (d2 v0.7.1). Output matches upstream d2 elk byte-for-byte on flat
+//! rectangle diagrams (the issue #34 class); broader parity against the
+//! v0.7.1 goldens sits around 69% — see `tests/elk_bridge.rs`.
 //!
 //! The host calls [`build_layout_request`] to get the complete ELK input
 //! graph (plus feature flags for fallback decisions), runs `elkjs@0.8.2`
@@ -47,14 +49,20 @@ const DEFAULT_SELF_LOOP_SPACING: i64 = 50;
 /// between-layers spacings).
 #[derive(Default, Clone, Serialize, Deserialize, Debug)]
 pub struct ElkOpts {
-    #[serde(skip_serializing_if = "Option::is_none", rename = "elk.spacing.edgeNode")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        rename = "elk.spacing.edgeNode"
+    )]
     pub edge_node: Option<i64>,
     #[serde(
         skip_serializing_if = "Option::is_none",
         rename = "elk.layered.nodePlacement.bk.fixedAlignment"
     )]
     pub fixed_alignment: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none", rename = "elk.layered.thoroughness")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        rename = "elk.layered.thoroughness"
+    )]
     pub thoroughness: Option<i64>,
     #[serde(
         skip_serializing_if = "Option::is_none",
@@ -63,9 +71,15 @@ pub struct ElkOpts {
     pub edge_edge_between_layers_spacing: Option<i64>,
     #[serde(rename = "elk.direction")]
     pub direction: String,
-    #[serde(skip_serializing_if = "Option::is_none", rename = "elk.hierarchyHandling")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        rename = "elk.hierarchyHandling"
+    )]
     pub hierarchy_handling: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none", rename = "elk.edgeLabels.inline")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        rename = "elk.edgeLabels.inline"
+    )]
     pub inline_edge_labels: Option<bool>,
     #[serde(
         skip_serializing_if = "Option::is_none",
@@ -87,15 +101,27 @@ pub struct ElkOpts {
         rename = "elk.layered.edgeRouting.selfLoopDistribution"
     )]
     pub self_loop_distribution: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none", rename = "elk.nodeSize.constraints")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        rename = "elk.nodeSize.constraints"
+    )]
     pub node_size_constraints: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none", rename = "elk.contentAlignment")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        rename = "elk.contentAlignment"
+    )]
     pub content_alignment: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none", rename = "elk.nodeSize.minimum")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        rename = "elk.nodeSize.minimum"
+    )]
     pub node_size_minimum: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none", rename = "elk.port.side")]
     pub port_side: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none", rename = "elk.portConstraints")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        rename = "elk.portConstraints"
+    )]
     pub port_constraints: Option<String>,
 
     // ConfigurableOpts (flattened — Go embeds the struct).
@@ -288,8 +314,7 @@ pub fn build_layout_request(g: &mut Graph) -> LayoutRequest {
         position_labels_icons(obj);
     }
 
-    let mut elk_nodes: std::collections::HashMap<ObjId, ElkNode> =
-        std::collections::HashMap::new();
+    let mut elk_nodes: std::collections::HashMap<ObjId, ElkNode> = std::collections::HashMap::new();
 
     // BFS walk (layout.go:223-356). Parent before child.
     let walk_order = bfs_walk_order(g, g.root);
@@ -309,13 +334,21 @@ pub fn build_layout_request(g: &mut Graph) -> LayoutRequest {
         let mut width = g.objects[obj_id].width;
         let mut height = g.objects[obj_id].height;
 
-        if incoming >= 2.0 || outgoing >= 2.0 && g.objects[obj_id].width_attr.is_none() {
+        // Mirrors d2elklayout/layout.go:245-253: when a node has >=2 in/out
+        // edges, grow it along the flow axis to fit port spacing — but only if
+        // the user did not set an explicit dimension on that axis (Right|Left
+        // respects height_attr, Down|Up respects width_attr).
+        if incoming >= 2.0 || outgoing >= 2.0 {
             match direction {
                 Direction::Right | Direction::Left => {
-                    height = height.max(incoming.max(outgoing) * PORT_SPACING);
+                    if g.objects[obj_id].height_attr.is_none() {
+                        height = height.max(incoming.max(outgoing) * PORT_SPACING);
+                    }
                 }
                 _ => {
-                    width = width.max(incoming.max(outgoing) * PORT_SPACING);
+                    if g.objects[obj_id].width_attr.is_none() {
+                        width = width.max(incoming.max(outgoing) * PORT_SPACING);
+                    }
                 }
             }
         }
@@ -324,7 +357,8 @@ pub fn build_layout_request(g: &mut Graph) -> LayoutRequest {
             height += g.objects[obj_id].label_dimensions.height as f64 + label::PADDING;
         }
 
-        let (margin, _padding) = g.objects[obj_id].spacing_opt(label::PADDING, label::PADDING, false);
+        let (margin, _padding) =
+            g.objects[obj_id].spacing_opt(label::PADDING, label::PADDING, false);
         let w = margin.left + width + margin.right;
         let h = margin.top + height + margin.bottom;
 
@@ -359,15 +393,18 @@ pub fn build_layout_request(g: &mut Graph) -> LayoutRequest {
                 ..Default::default()
             };
             if opts.self_loop_spacing == DEFAULT_SELF_LOOP_SPACING {
-                opts.self_loop_spacing =
-                    opts.self_loop_spacing.max(children_max_self_loop(g, obj_id, is_width) / 2 + 5);
+                opts.self_loop_spacing = opts
+                    .self_loop_spacing
+                    .max(children_max_self_loop(g, obj_id, is_width) / 2 + 5);
             }
             match direction {
                 Direction::Down | Direction::Up | Direction::None => {
-                    opts.node_size_minimum = Some(format!("({}, {})", h.ceil() as i64, w.ceil() as i64));
+                    opts.node_size_minimum =
+                        Some(format!("({}, {})", h.ceil() as i64, w.ceil() as i64));
                 }
                 Direction::Right | Direction::Left => {
-                    opts.node_size_minimum = Some(format!("({}, {})", w.ceil() as i64, h.ceil() as i64));
+                    opts.node_size_minimum =
+                        Some(format!("({}, {})", w.ceil() as i64, h.ceil() as i64));
                 }
             }
             if g.objects[obj_id].is_container() {
@@ -492,7 +529,8 @@ pub fn apply_layout(g: &mut Graph, result: &LayoutResult) -> Result<(), String> 
     for c in &laid.children {
         index_elk_nodes(c, &mut elk_by_id);
     }
-    let mut elk_edge_by_id: std::collections::HashMap<&str, &ElkEdge> = std::collections::HashMap::new();
+    let mut elk_edge_by_id: std::collections::HashMap<&str, &ElkEdge> =
+        std::collections::HashMap::new();
     for e in &laid.edges {
         elk_edge_by_id.insert(e.id.as_str(), e);
     }
@@ -564,27 +602,25 @@ pub fn apply_layout(g: &mut Graph, result: &LayoutResult) -> Result<(), String> 
 
         let (src_dx, src_dy) = g.objects[src_id].get_modifier_element_adjustments();
         let mut original_src_tl = None;
-        if src_dx != 0.0 || src_dy != 0.0 {
-            if start.x > g.objects[src_id].top_left.x + src_dx
-                && start.y < g.objects[src_id].top_left.y + g.objects[src_id].height - src_dy
-            {
-                original_src_tl = Some(g.objects[src_id].top_left);
-                let o = original_src_tl.unwrap();
-                g.objects[src_id].top_left = Point::new(o.x + src_dx, o.y - src_dy);
-                g.objects[src_id].update_box();
-            }
+        if (src_dx != 0.0 || src_dy != 0.0)
+            && start.x > g.objects[src_id].top_left.x + src_dx
+            && start.y < g.objects[src_id].top_left.y + g.objects[src_id].height - src_dy
+        {
+            original_src_tl = Some(g.objects[src_id].top_left);
+            let o = original_src_tl.unwrap();
+            g.objects[src_id].top_left = Point::new(o.x + src_dx, o.y - src_dy);
+            g.objects[src_id].update_box();
         }
         let (dst_dx, dst_dy) = g.objects[dst_id].get_modifier_element_adjustments();
         let mut original_dst_tl = None;
-        if dst_dx != 0.0 || dst_dy != 0.0 {
-            if end.x > g.objects[dst_id].top_left.x + dst_dx
-                && end.y < g.objects[dst_id].top_left.y + g.objects[dst_id].height - dst_dy
-            {
-                original_dst_tl = Some(g.objects[dst_id].top_left);
-                let o = original_dst_tl.unwrap();
-                g.objects[dst_id].top_left = Point::new(o.x + dst_dx, o.y - dst_dy);
-                g.objects[dst_id].update_box();
-            }
+        if (dst_dx != 0.0 || dst_dy != 0.0)
+            && end.x > g.objects[dst_id].top_left.x + dst_dx
+            && end.y < g.objects[dst_id].top_left.y + g.objects[dst_id].height - dst_dy
+        {
+            original_dst_tl = Some(g.objects[dst_id].top_left);
+            let o = original_dst_tl.unwrap();
+            g.objects[dst_id].top_left = Point::new(o.x + dst_dx, o.y - dst_dy);
+            g.objects[dst_id].update_box();
         }
 
         // Faithful port of d2 `Edge.TraceToShape` (outside-label / outside-icon
@@ -736,6 +772,8 @@ fn apply_margins(g: &mut Graph, adjustments: &[Spacing]) {
         }
     }
 
+    // Index, not iterator: the body mutably borrows `g.objects[obj_id]`.
+    #[allow(clippy::needless_range_loop)]
     for obj_id in 0..g.objects.len() {
         let margin = adjustments[obj_id];
         if margin.left == 0.0 && margin.right == 0.0 && margin.top == 0.0 && margin.bottom == 0.0 {
@@ -751,9 +789,15 @@ fn apply_margins(g: &mut Graph, adjustments: &[Spacing]) {
             for &ei in &edges {
                 let e = &mut g.edges[ei];
                 let l = e.route.len();
-                if l == 0 { continue; }
-                if e.src == obj_id && e.route[0].x == tl_x { e.route[0].x += margin.left; }
-                if e.dst == obj_id && e.route[l - 1].x == tl_x { e.route[l - 1].x += margin.left; }
+                if l == 0 {
+                    continue;
+                }
+                if e.src == obj_id && e.route[0].x == tl_x {
+                    e.route[0].x += margin.left;
+                }
+                if e.dst == obj_id && e.route[l - 1].x == tl_x {
+                    e.route[l - 1].x += margin.left;
+                }
             }
             g.objects[obj_id].top_left.x += margin.left;
             shift_descendants(g, obj_id, margin.left / 2.0, 0.0);
@@ -764,9 +808,15 @@ fn apply_margins(g: &mut Graph, adjustments: &[Spacing]) {
             for &ei in &edges {
                 let e = &mut g.edges[ei];
                 let l = e.route.len();
-                if l == 0 { continue; }
-                if e.src == obj_id && e.route[0].x == tl_x + w { e.route[0].x -= margin.right; }
-                if e.dst == obj_id && e.route[l - 1].x == tl_x + w { e.route[l - 1].x -= margin.right; }
+                if l == 0 {
+                    continue;
+                }
+                if e.src == obj_id && e.route[0].x == tl_x + w {
+                    e.route[0].x -= margin.right;
+                }
+                if e.dst == obj_id && e.route[l - 1].x == tl_x + w {
+                    e.route[l - 1].x -= margin.right;
+                }
             }
             shift_descendants(g, obj_id, -margin.right / 2.0, 0.0);
             g.objects[obj_id].width -= margin.right;
@@ -776,9 +826,15 @@ fn apply_margins(g: &mut Graph, adjustments: &[Spacing]) {
             for &ei in &edges {
                 let e = &mut g.edges[ei];
                 let l = e.route.len();
-                if l == 0 { continue; }
-                if e.src == obj_id && e.route[0].y == tl_y { e.route[0].y += margin.top; }
-                if e.dst == obj_id && e.route[l - 1].y == tl_y { e.route[l - 1].y += margin.top; }
+                if l == 0 {
+                    continue;
+                }
+                if e.src == obj_id && e.route[0].y == tl_y {
+                    e.route[0].y += margin.top;
+                }
+                if e.dst == obj_id && e.route[l - 1].y == tl_y {
+                    e.route[l - 1].y += margin.top;
+                }
             }
             g.objects[obj_id].top_left.y += margin.top;
             shift_descendants(g, obj_id, 0.0, margin.top / 2.0);
@@ -789,9 +845,15 @@ fn apply_margins(g: &mut Graph, adjustments: &[Spacing]) {
             for &ei in &edges {
                 let e = &mut g.edges[ei];
                 let l = e.route.len();
-                if l == 0 { continue; }
-                if e.src == obj_id && e.route[0].y == tl_y + h { e.route[0].y -= margin.bottom; }
-                if e.dst == obj_id && e.route[l - 1].y == tl_y + h { e.route[l - 1].y -= margin.bottom; }
+                if l == 0 {
+                    continue;
+                }
+                if e.src == obj_id && e.route[0].y == tl_y + h {
+                    e.route[0].y -= margin.bottom;
+                }
+                if e.dst == obj_id && e.route[l - 1].y == tl_y + h {
+                    e.route[l - 1].y -= margin.bottom;
+                }
             }
             shift_descendants(g, obj_id, 0.0, -margin.bottom / 2.0);
             g.objects[obj_id].height -= margin.bottom;
@@ -833,13 +895,24 @@ fn shift_descendants(g: &mut Graph, obj: ObjId, dx: f64, dy: f64) {
                     p.y += dy;
                 }
             } else if is_src {
-                if dx == 0.0 { shift_start(g, ei, dy, false); }
-                else if dy == 0.0 { shift_start(g, ei, dx, true); }
-                else { g.edges[ei].route[0].x += dx; g.edges[ei].route[0].y += dy; }
+                if dx == 0.0 {
+                    shift_start(g, ei, dy, false);
+                } else if dy == 0.0 {
+                    shift_start(g, ei, dx, true);
+                } else {
+                    g.edges[ei].route[0].x += dx;
+                    g.edges[ei].route[0].y += dy;
+                }
             } else if is_dst {
-                if dx == 0.0 { shift_end(g, ei, dy, false); }
-                else if dy == 0.0 { shift_end(g, ei, dx, true); }
-                else { let l = g.edges[ei].route.len(); g.edges[ei].route[l - 1].x += dx; g.edges[ei].route[l - 1].y += dy; }
+                if dx == 0.0 {
+                    shift_end(g, ei, dy, false);
+                } else if dy == 0.0 {
+                    shift_end(g, ei, dx, true);
+                } else {
+                    let l = g.edges[ei].route.len();
+                    g.edges[ei].route[l - 1].x += dx;
+                    g.edges[ei].route[l - 1].y += dy;
+                }
             }
             if is_src || is_dst {
                 moved.insert(ei);
@@ -854,7 +927,9 @@ fn is_descendant_of(g: &Graph, self_id: ObjId, ancestor: ObjId) -> bool {
     }
     let mut p = g.objects[self_id].parent;
     while let Some(pid) = p {
-        if pid == ancestor { return true; }
+        if pid == ancestor {
+            return true;
+        }
         p = g.objects[pid].parent;
     }
     false
@@ -874,26 +949,51 @@ fn descendants_list(g: &Graph, obj: ObjId) -> Vec<ObjId> {
 
 fn shift_start(g: &mut Graph, ei: usize, delta: f64, is_horizontal: bool) {
     let route = &mut g.edges[ei].route;
-    if route.len() < 2 { return; }
+    if route.len() < 2 {
+        return;
+    }
     let pos = |p: &Point| if is_horizontal { p.x } else { p.y };
     let is_increasing = pos(&route[0]) < pos(&route[1]);
-    if is_horizontal { route[0].x += delta; } else { route[0].y += delta; }
-    if is_increasing == (delta < 0.0) { return; }
+    if is_horizontal {
+        route[0].x += delta;
+    } else {
+        route[0].y += delta;
+    }
+    if is_increasing == (delta < 0.0) {
+        return;
+    }
     let start = route[0];
-    let is_aligned = |p: &Point| if is_horizontal { p.y == start.y } else { p.x == start.x };
+    let is_aligned = |p: &Point| {
+        if is_horizontal {
+            p.y == start.y
+        } else {
+            p.x == start.x
+        }
+    };
     let is_past_start = |p: &Point| {
-        if delta > 0.0 { pos(p) < pos(&start) } else { pos(p) > pos(&start) }
+        if delta > 0.0 {
+            pos(p) < pos(&start)
+        } else {
+            pos(p) > pos(&start)
+        }
     };
     let mut to_remove = vec![false; route.len()];
     let mut needs_removal = false;
     for i in 1..route.len().saturating_sub(1) {
-        if !is_aligned(&route[i]) { break; }
-        if is_past_start(&route[i]) { to_remove[i] = true; needs_removal = true; }
+        if !is_aligned(&route[i]) {
+            break;
+        }
+        if is_past_start(&route[i]) {
+            to_remove[i] = true;
+            needs_removal = true;
+        }
     }
     if needs_removal {
         let mut new_route = Vec::with_capacity(route.len());
         for (i, p) in route.iter().enumerate() {
-            if !to_remove[i] { new_route.push(*p); }
+            if !to_remove[i] {
+                new_route.push(*p);
+            }
         }
         *route = new_route;
     }
@@ -901,29 +1001,54 @@ fn shift_start(g: &mut Graph, ei: usize, delta: f64, is_horizontal: bool) {
 
 fn shift_end(g: &mut Graph, ei: usize, delta: f64, is_horizontal: bool) {
     let route = &mut g.edges[ei].route;
-    if route.len() < 2 { return; }
+    if route.len() < 2 {
+        return;
+    }
     let pos = |p: &Point| if is_horizontal { p.x } else { p.y };
     let last = route.len() - 1;
     let is_increasing = pos(&route[last - 1]) < pos(&route[last]);
-    if is_horizontal { route[last].x += delta; } else { route[last].y += delta; }
-    if is_increasing == (delta > 0.0) { return; }
+    if is_horizontal {
+        route[last].x += delta;
+    } else {
+        route[last].y += delta;
+    }
+    if is_increasing == (delta > 0.0) {
+        return;
+    }
     let end = route[last];
-    let is_aligned = |p: &Point| if is_horizontal { p.y == end.y } else { p.x == end.x };
+    let is_aligned = |p: &Point| {
+        if is_horizontal {
+            p.y == end.y
+        } else {
+            p.x == end.x
+        }
+    };
     let is_past_end = |p: &Point| {
-        if delta > 0.0 { pos(p) < pos(&end) } else { pos(p) > pos(&end) }
+        if delta > 0.0 {
+            pos(p) < pos(&end)
+        } else {
+            pos(p) > pos(&end)
+        }
     };
     let mut to_remove = vec![false; route.len()];
     let mut needs_removal = false;
     let mut i = route.len().saturating_sub(2);
     while i > 0 {
-        if !is_aligned(&route[i]) { break; }
-        if is_past_end(&route[i]) { to_remove[i] = true; needs_removal = true; }
+        if !is_aligned(&route[i]) {
+            break;
+        }
+        if is_past_end(&route[i]) {
+            to_remove[i] = true;
+            needs_removal = true;
+        }
         i -= 1;
     }
     if needs_removal {
         let mut new_route = Vec::with_capacity(route.len());
         for (i, p) in route.iter().enumerate() {
-            if !to_remove[i] { new_route.push(*p); }
+            if !to_remove[i] {
+                new_route.push(*p);
+            }
         }
         *route = new_route;
     }
@@ -940,20 +1065,29 @@ const MIN_SEGMENT_LEN: f64 = 10.0;
 fn find_outer_intersection(position: Position, mut intersections: Vec<Point>) -> Point {
     match position {
         Position::OutsideTopLeft | Position::OutsideTopCenter | Position::OutsideTopRight => {
-            intersections.sort_by(|a, b| a.y.partial_cmp(&b.y).unwrap_or(std::cmp::Ordering::Equal));
+            intersections
+                .sort_by(|a, b| a.y.partial_cmp(&b.y).unwrap_or(std::cmp::Ordering::Equal));
         }
-        Position::OutsideBottomLeft | Position::OutsideBottomCenter | Position::OutsideBottomRight => {
-            intersections.sort_by(|a, b| b.y.partial_cmp(&a.y).unwrap_or(std::cmp::Ordering::Equal));
+        Position::OutsideBottomLeft
+        | Position::OutsideBottomCenter
+        | Position::OutsideBottomRight => {
+            intersections
+                .sort_by(|a, b| b.y.partial_cmp(&a.y).unwrap_or(std::cmp::Ordering::Equal));
         }
         Position::OutsideLeftTop | Position::OutsideLeftMiddle | Position::OutsideLeftBottom => {
-            intersections.sort_by(|a, b| a.x.partial_cmp(&b.x).unwrap_or(std::cmp::Ordering::Equal));
+            intersections
+                .sort_by(|a, b| a.x.partial_cmp(&b.x).unwrap_or(std::cmp::Ordering::Equal));
         }
         Position::OutsideRightTop | Position::OutsideRightMiddle | Position::OutsideRightBottom => {
-            intersections.sort_by(|a, b| b.x.partial_cmp(&a.x).unwrap_or(std::cmp::Ordering::Equal));
+            intersections
+                .sort_by(|a, b| b.x.partial_cmp(&a.x).unwrap_or(std::cmp::Ordering::Equal));
         }
         _ => {}
     }
-    intersections.into_iter().next().unwrap_or(Point::new(0.0, 0.0))
+    intersections
+        .into_iter()
+        .next()
+        .unwrap_or(Point::new(0.0, 0.0))
 }
 
 /// Snapshot of one endpoint's trace inputs (so we can mutate the route without
@@ -992,57 +1126,66 @@ fn trace_src(info: &EndpointInfo, route: &mut [Point], start: &mut usize, end: u
     let mut seg = Segment::new(route[*start + 1], route[*start]);
     let mut overlaps_outside_label = false;
 
-    if info.has_label {
-        if let Some(lp_str) = &info.label_pos {
-            let lp = Position::from_string(lp_str);
-            if lp.is_outside() {
-                let lw = info.label_dims.width as f64;
-                let lh = info.label_dims.height as f64;
-                let label_tl = lp.get_point_on_box(&info.box_, label::PADDING, lw, lh);
-                let mut label_box = Box2D::new(label_tl, lw, lh);
-                label_box.top_left.x -= label::PADDING;
-                label_box.width += 2.0 * label::PADDING;
-                while label_box.contains(&seg.end) && *start + 1 > end {
-                    seg.start = seg.end;
-                    seg.end = route[*start + 2];
+    if info.has_label
+        && let Some(lp_str) = &info.label_pos
+    {
+        let lp = Position::from_string(lp_str);
+        if lp.is_outside() {
+            let lw = info.label_dims.width as f64;
+            let lh = info.label_dims.height as f64;
+            let label_tl = lp.get_point_on_box(&info.box_, label::PADDING, lw, lh);
+            let mut label_box = Box2D::new(label_tl, lw, lh);
+            label_box.top_left.x -= label::PADDING;
+            label_box.width += 2.0 * label::PADDING;
+            while label_box.contains(&seg.end) && *start + 1 > end {
+                seg.start = seg.end;
+                seg.end = route[*start + 2];
+                *start += 1;
+            }
+            let ints = label_box.intersections(&seg);
+            if !ints.is_empty() {
+                overlaps_outside_label = true;
+                let p = if ints.len() > 1 {
+                    find_outer_intersection(lp, ints)
+                } else {
+                    ints[0]
+                };
+                route[*start] = p;
+                seg.end = p;
+                if *start + 1 < end && seg.length() < MIN_SEGMENT_LEN {
+                    route[*start + 1] = route[*start];
                     *start += 1;
-                }
-                let ints = label_box.intersections(&seg);
-                if !ints.is_empty() {
-                    overlaps_outside_label = true;
-                    let p = if ints.len() > 1 { find_outer_intersection(lp, ints) } else { ints[0] };
-                    route[*start] = p;
-                    seg.end = p;
-                    if *start + 1 < end && seg.length() < MIN_SEGMENT_LEN {
-                        route[*start + 1] = route[*start];
-                        *start += 1;
-                    }
                 }
             }
         }
     }
-    if !overlaps_outside_label && info.has_icon {
-        if let Some(ip_str) = &info.icon_pos {
-            let ip = Position::from_string(ip_str);
-            if ip.is_outside() {
-                let iw = crate::target::MAX_ICON_SIZE as f64;
-                let ih = crate::target::MAX_ICON_SIZE as f64;
-                let icon_tl = ip.get_point_on_box(&info.box_, label::PADDING, iw, ih);
-                let icon_box = Box2D::new(icon_tl, iw, ih);
-                while icon_box.contains(&seg.end) && *start + 1 > end {
-                    seg.start = seg.end;
-                    seg.end = route[*start + 2];
+    if !overlaps_outside_label
+        && info.has_icon
+        && let Some(ip_str) = &info.icon_pos
+    {
+        let ip = Position::from_string(ip_str);
+        if ip.is_outside() {
+            let iw = crate::target::MAX_ICON_SIZE as f64;
+            let ih = crate::target::MAX_ICON_SIZE as f64;
+            let icon_tl = ip.get_point_on_box(&info.box_, label::PADDING, iw, ih);
+            let icon_box = Box2D::new(icon_tl, iw, ih);
+            while icon_box.contains(&seg.end) && *start + 1 > end {
+                seg.start = seg.end;
+                seg.end = route[*start + 2];
+                *start += 1;
+            }
+            let ints = icon_box.intersections(&seg);
+            if !ints.is_empty() {
+                let p = if ints.len() > 1 {
+                    find_outer_intersection(ip, ints)
+                } else {
+                    ints[0]
+                };
+                route[*start] = p;
+                seg.end = p;
+                if *start + 1 < end && seg.length() < MIN_SEGMENT_LEN {
+                    route[*start + 1] = route[*start];
                     *start += 1;
-                }
-                let ints = icon_box.intersections(&seg);
-                if !ints.is_empty() {
-                    let p = if ints.len() > 1 { find_outer_intersection(ip, ints) } else { ints[0] };
-                    route[*start] = p;
-                    seg.end = p;
-                    if *start + 1 < end && seg.length() < MIN_SEGMENT_LEN {
-                        route[*start + 1] = route[*start];
-                        *start += 1;
-                    }
                 }
             }
         }
@@ -1063,7 +1206,8 @@ fn trace_src(info: &EndpointInfo, route: &mut [Point], start: &mut usize, end: u
             }
         }
         let shape = crate::shape::Shape::new(&info.shape_type, info.box_);
-        route[*start] = crate::shape::trace_to_shape_border(&shape, &route[*start], &route[*start + 1]);
+        route[*start] =
+            crate::shape::trace_to_shape_border(&shape, &route[*start], &route[*start + 1]);
     }
 }
 
@@ -1073,57 +1217,66 @@ fn trace_dst(info: &EndpointInfo, route: &mut [Point], start: usize, end: &mut u
     let mut seg = Segment::new(route[*end - 1], route[*end]);
     let mut overlaps_outside_label = false;
 
-    if info.has_label {
-        if let Some(lp_str) = &info.label_pos {
-            let lp = Position::from_string(lp_str);
-            if lp.is_outside() {
-                let lw = info.label_dims.width as f64;
-                let lh = info.label_dims.height as f64;
-                let label_tl = lp.get_point_on_box(&info.box_, label::PADDING, lw, lh);
-                let mut label_box = Box2D::new(label_tl, lw, lh);
-                label_box.top_left.x -= label::PADDING;
-                label_box.width += 2.0 * label::PADDING;
-                while label_box.contains(&seg.start) && *end - 1 > start {
-                    seg.end = seg.start;
-                    seg.start = route[*end - 2];
+    if info.has_label
+        && let Some(lp_str) = &info.label_pos
+    {
+        let lp = Position::from_string(lp_str);
+        if lp.is_outside() {
+            let lw = info.label_dims.width as f64;
+            let lh = info.label_dims.height as f64;
+            let label_tl = lp.get_point_on_box(&info.box_, label::PADDING, lw, lh);
+            let mut label_box = Box2D::new(label_tl, lw, lh);
+            label_box.top_left.x -= label::PADDING;
+            label_box.width += 2.0 * label::PADDING;
+            while label_box.contains(&seg.start) && *end - 1 > start {
+                seg.end = seg.start;
+                seg.start = route[*end - 2];
+                *end -= 1;
+            }
+            let ints = label_box.intersections(&seg);
+            if !ints.is_empty() {
+                overlaps_outside_label = true;
+                let p = if ints.len() > 1 {
+                    find_outer_intersection(lp, ints)
+                } else {
+                    ints[0]
+                };
+                route[*end] = p;
+                seg.end = p;
+                if *end - 1 > start && seg.length() < MIN_SEGMENT_LEN {
+                    route[*end - 1] = route[*end];
                     *end -= 1;
-                }
-                let ints = label_box.intersections(&seg);
-                if !ints.is_empty() {
-                    overlaps_outside_label = true;
-                    let p = if ints.len() > 1 { find_outer_intersection(lp, ints) } else { ints[0] };
-                    route[*end] = p;
-                    seg.end = p;
-                    if *end - 1 > start && seg.length() < MIN_SEGMENT_LEN {
-                        route[*end - 1] = route[*end];
-                        *end -= 1;
-                    }
                 }
             }
         }
     }
-    if !overlaps_outside_label && info.has_icon {
-        if let Some(ip_str) = &info.icon_pos {
-            let ip = Position::from_string(ip_str);
-            if ip.is_outside() {
-                let iw = crate::target::MAX_ICON_SIZE as f64;
-                let ih = crate::target::MAX_ICON_SIZE as f64;
-                let icon_tl = ip.get_point_on_box(&info.box_, label::PADDING, iw, ih);
-                let icon_box = Box2D::new(icon_tl, iw, ih);
-                while icon_box.contains(&seg.start) && *end - 1 > start {
-                    seg.end = seg.start;
-                    seg.start = route[*end - 2];
+    if !overlaps_outside_label
+        && info.has_icon
+        && let Some(ip_str) = &info.icon_pos
+    {
+        let ip = Position::from_string(ip_str);
+        if ip.is_outside() {
+            let iw = crate::target::MAX_ICON_SIZE as f64;
+            let ih = crate::target::MAX_ICON_SIZE as f64;
+            let icon_tl = ip.get_point_on_box(&info.box_, label::PADDING, iw, ih);
+            let icon_box = Box2D::new(icon_tl, iw, ih);
+            while icon_box.contains(&seg.start) && *end - 1 > start {
+                seg.end = seg.start;
+                seg.start = route[*end - 2];
+                *end -= 1;
+            }
+            let ints = icon_box.intersections(&seg);
+            if !ints.is_empty() {
+                let p = if ints.len() > 1 {
+                    find_outer_intersection(ip, ints)
+                } else {
+                    ints[0]
+                };
+                route[*end] = p;
+                seg.end = p;
+                if *end - 1 > start && seg.length() < MIN_SEGMENT_LEN {
+                    route[*end - 1] = route[*end];
                     *end -= 1;
-                }
-                let ints = icon_box.intersections(&seg);
-                if !ints.is_empty() {
-                    let p = if ints.len() > 1 { find_outer_intersection(ip, ints) } else { ints[0] };
-                    route[*end] = p;
-                    seg.end = p;
-                    if *end - 1 > start && seg.length() < MIN_SEGMENT_LEN {
-                        route[*end - 1] = route[*end];
-                        *end -= 1;
-                    }
                 }
             }
         }
@@ -1161,8 +1314,6 @@ pub fn trace_to_shape_full(g: &mut Graph, ei: usize) -> (usize, usize) {
     (start, end)
 }
 
-
-
 fn delete_bends(g: &mut Graph) {
     // S-shapes at source/target (layout.go:662-773).
     for &is_source in &[true, false] {
@@ -1171,10 +1322,22 @@ fn delete_bends(g: &mut Graph) {
                 continue;
             }
             let (endpoint_id, start_idx, corner_idx, end_idx, column_index) = if is_source {
-                (g.edges[ei].src, 0usize, 1usize, 2usize, g.edges[ei].src_table_column_index)
+                (
+                    g.edges[ei].src,
+                    0usize,
+                    1usize,
+                    2usize,
+                    g.edges[ei].src_table_column_index,
+                )
             } else {
                 let l = g.edges[ei].route.len();
-                (g.edges[ei].dst, l - 1, l - 2, l - 3, g.edges[ei].dst_table_column_index)
+                (
+                    g.edges[ei].dst,
+                    l - 1,
+                    l - 2,
+                    l - 3,
+                    g.edges[ei].dst_table_column_index,
+                )
             };
             let start = g.edges[ei].route[start_idx];
             let corner = g.edges[ei].route[corner_idx];
@@ -1194,22 +1357,38 @@ fn delete_bends(g: &mut Graph) {
                     end.x > endpoint_tl.x + 10.0 && end.x < endpoint_tl.x + endpoint_w - 10.0 + dx
                 }
             };
-            if !attached { continue; }
+            if !attached {
+                continue;
+            }
 
-            let new_start_raw = if is_horizontal { Point::new(start.x, end.y) } else { Point::new(end.x, start.y) };
+            let new_start_raw = if is_horizontal {
+                Point::new(start.x, end.y)
+            } else {
+                Point::new(end.x, start.y)
+            };
             let endpoint_box = g.objects[endpoint_id].box_;
-            let shape_type = crate::target::dsl_shape_to_shape_type(&g.objects[endpoint_id].shape.value);
+            let shape_type =
+                crate::target::dsl_shape_to_shape_type(&g.objects[endpoint_id].shape.value);
             let endpoint_shape = crate::shape::Shape::new(shape_type, endpoint_box);
-            let new_start = crate::shape::trace_to_shape_border(&endpoint_shape, &new_start_raw, &end);
+            let new_start =
+                crate::shape::trace_to_shape_border(&endpoint_shape, &new_start_raw, &end);
 
             let old_segment = Segment::new(start, corner);
             let new_segment = Segment::new(new_start, end);
             let old_intersects = count_object_intersects(g, ei, &old_segment);
             let new_intersects = count_object_intersects(g, ei, &new_segment);
-            if new_intersects > old_intersects { continue; }
-            let (old_cross, old_over, old_close, old_touch) = count_edge_intersects(g, ei, &old_segment);
-            let (new_cross, new_over, new_close, new_touch) = count_edge_intersects(g, ei, &new_segment);
-            if new_cross > old_cross || new_over > old_over || new_close > old_close || new_touch > old_touch {
+            if new_intersects > old_intersects {
+                continue;
+            }
+            let (old_cross, old_over, old_close, old_touch) =
+                count_edge_intersects(g, ei, &old_segment);
+            let (new_cross, new_over, new_close, new_touch) =
+                count_edge_intersects(g, ei, &new_segment);
+            if new_cross > old_cross
+                || new_over > old_over
+                || new_close > old_close
+                || new_touch > old_touch
+            {
                 continue;
             }
 
@@ -1231,11 +1410,15 @@ fn delete_bends(g: &mut Graph) {
     let mut points: HashMap<(i64, i64), i64> = HashMap::new();
     for e in &g.edges {
         for p in &e.route {
-            *points.entry((p.x.round() as i64, p.y.round() as i64)).or_insert(0) += 1;
+            *points
+                .entry((p.x.round() as i64, p.y.round() as i64))
+                .or_insert(0) += 1;
         }
     }
     for ei in 0..g.edges.len() {
-        if g.edges[ei].route.len() < 6 || g.edges[ei].src == g.edges[ei].dst { continue; }
+        if g.edges[ei].route.len() < 6 || g.edges[ei].src == g.edges[ei].dst {
+            continue;
+        }
         let mut i = 1;
         let len = g.edges[ei].route.len();
         while i + 3 < len {
@@ -1244,35 +1427,57 @@ fn delete_bends(g: &mut Graph) {
             let corner = g.edges[ei].route[i + 1];
             let end = g.edges[ei].route[i + 2];
             let after = g.edges[ei].route[i + 3];
-            let c = *points.get(&(corner.x.round() as i64, corner.y.round() as i64)).unwrap_or(&0);
-            if c > 1 { i += 1; continue; }
+            let c = *points
+                .get(&(corner.x.round() as i64, corner.y.round() as i64))
+                .unwrap_or(&0);
+            if c > 1 {
+                i += 1;
+                continue;
+            }
 
             let (new_corner, not_ladder) = if start.x.ceil() == corner.x.ceil() {
                 let nc = Point::new(end.x, start.y);
-                let nl = (end.x > start.x) != (start.x > before.x) || (end.y > start.y) != (after.y > end.y);
+                let nl = (end.x > start.x) != (start.x > before.x)
+                    || (end.y > start.y) != (after.y > end.y);
                 (nc, nl)
             } else {
                 let nc = Point::new(start.x, end.y);
-                let nl = (end.y > start.y) != (start.y > before.y) || (end.x > start.x) != (after.x > end.x);
+                let nl = (end.y > start.y) != (start.y > before.y)
+                    || (end.x > start.x) != (after.x > end.x);
                 (nc, nl)
             };
-            if not_ladder { i += 1; continue; }
+            if not_ladder {
+                i += 1;
+                continue;
+            }
 
             let old_s1 = Segment::new(start, corner);
             let old_s2 = Segment::new(corner, end);
             let new_s1 = Segment::new(start, new_corner);
             let new_s2 = Segment::new(new_corner, end);
-            let old_int = count_object_intersects(g, ei, &old_s1) + count_object_intersects(g, ei, &old_s2);
-            let new_int = count_object_intersects(g, ei, &new_s1) + count_object_intersects(g, ei, &new_s2);
-            if new_int > old_int { i += 1; continue; }
+            let old_int =
+                count_object_intersects(g, ei, &old_s1) + count_object_intersects(g, ei, &old_s2);
+            let new_int =
+                count_object_intersects(g, ei, &new_s1) + count_object_intersects(g, ei, &new_s2);
+            if new_int > old_int {
+                i += 1;
+                continue;
+            }
             let (oc1, oo1, oc1c, ot1) = count_edge_intersects(g, ei, &old_s1);
             let (oc2, oo2, oc2c, ot2) = count_edge_intersects(g, ei, &old_s2);
             let (nc1, no1, nc1c, nt1) = count_edge_intersects(g, ei, &new_s1);
             let (nc2, no2, nc2c, nt2) = count_edge_intersects(g, ei, &new_s2);
-            let (old_cross, old_over, old_close, old_touch) = (oc1 + oc2, oo1 + oo2, oc1c + oc2c, ot1 + ot2);
-            let (new_cross, new_over, new_close, new_touch) = (nc1 + nc2, no1 + no2, nc1c + nc2c, nt1 + nt2);
-            if new_cross > old_cross || new_over > old_over || new_close > old_close || new_touch > old_touch {
-                i += 1; continue;
+            let (old_cross, old_over, old_close, old_touch) =
+                (oc1 + oc2, oo1 + oo2, oc1c + oc2c, ot1 + ot2);
+            let (new_cross, new_over, new_close, new_touch) =
+                (nc1 + nc2, no1 + no2, nc1c + nc2c, nt1 + nt2);
+            if new_cross > old_cross
+                || new_over > old_over
+                || new_close > old_close
+                || new_touch > old_touch
+            {
+                i += 1;
+                continue;
             }
             // commit
             let mut new_route = Vec::with_capacity(g.edges[ei].route.len() - 1);
@@ -1290,7 +1495,9 @@ fn count_object_intersects(g: &Graph, ei: usize, s: &Segment) -> i64 {
     let dst = g.edges[ei].dst;
     let mut count = 0i64;
     for (i, o) in g.objects.iter().enumerate() {
-        if i == src || i == dst { continue; }
+        if i == src || i == dst {
+            continue;
+        }
         if o.box_.intersects_segment(s, EDGE_NODE_SPACING as f64 - 1.0) {
             count += 1;
         }
@@ -1305,7 +1512,9 @@ fn count_edge_intersects(g: &Graph, ei: usize, s: &Segment) -> (i64, i64, i64, i
     let mut close_overlaps = 0i64;
     let mut touching = 0i64;
     for (oi, e) in g.edges.iter().enumerate() {
-        if oi == ei { continue; }
+        if oi == ei {
+            continue;
+        }
         for w in e.route.windows(2) {
             let other = Segment::new(w[0], w[1]);
             let other_is_horizontal = other.start.y.ceil() == other.end.y.ceil();
@@ -1317,7 +1526,9 @@ fn count_edge_intersects(g: &Graph, ei: usize, s: &Segment) -> (i64, i64, i64, i
                             overlaps += 1;
                             if d < EDGE_NODE_SPACING as f64 / 4.0 {
                                 close_overlaps += 1;
-                                if d < 1.0 { touching += 1; }
+                                if d < 1.0 {
+                                    touching += 1;
+                                }
                             }
                         }
                     } else {
@@ -1326,7 +1537,9 @@ fn count_edge_intersects(g: &Graph, ei: usize, s: &Segment) -> (i64, i64, i64, i
                             overlaps += 1;
                             if d < EDGE_NODE_SPACING as f64 / 4.0 {
                                 close_overlaps += 1;
-                                if d < 1.0 { touching += 1; }
+                                if d < 1.0 {
+                                    touching += 1;
+                                }
                             }
                         }
                     }
@@ -1351,9 +1564,13 @@ struct ShapePadding {
     right: i64,
 }
 
-impl ShapePadding {
-    fn to_string(&self) -> String {
-        format!("[top={},left={},bottom={},right={}]", self.top, self.left, self.bottom, self.right)
+impl std::fmt::Display for ShapePadding {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "[top={},left={},bottom={},right={}]",
+            self.top, self.left, self.bottom, self.right
+        )
     }
 }
 
@@ -1363,7 +1580,9 @@ fn parse_padding(in_: &str) -> ShapePadding {
         if let Some(idx) = haystack.find(&pat) {
             let rest = &haystack[idx + pat.len()..];
             let num: String = rest.chars().take_while(|c| c.is_ascii_digit()).collect();
-            if let Ok(v) = num.parse::<i64>() { return v; }
+            if let Ok(v) = num.parse::<i64>() {
+                return v;
+            }
         }
         0
     }
@@ -1376,9 +1595,17 @@ fn parse_padding(in_: &str) -> ShapePadding {
 }
 
 /// d2 `adjustPadding` (layout.go:1018-1108).
-fn adjust_padding(g: &Graph, obj_id: ObjId, width: f64, height: f64, padding: ShapePadding) -> ShapePadding {
+fn adjust_padding(
+    g: &Graph,
+    obj_id: ObjId,
+    width: f64,
+    height: f64,
+    padding: ShapePadding,
+) -> ShapePadding {
     let obj = &g.objects[obj_id];
-    if !obj.is_container() { return padding; }
+    if !obj.is_container() {
+        return padding;
+    }
     let mut extra_top = 0i64;
     let mut extra_bottom = 0i64;
     let mut extra_left = 0i64;
@@ -1387,8 +1614,12 @@ fn adjust_padding(g: &Graph, obj_id: ObjId, width: f64, height: f64, padding: Sh
         let label_height = obj.label_dimensions.height as i64 + 2 * label::PADDING as i64;
         let label_width = obj.label_dimensions.width as i64 + 2 * label::PADDING as i64;
         match Position::from_string(obj.label_position.as_deref().unwrap_or("")) {
-            Position::InsideTopLeft | Position::InsideTopCenter | Position::InsideTopRight => extra_top = label_height,
-            Position::InsideBottomLeft | Position::InsideBottomCenter | Position::InsideBottomRight => extra_bottom = label_height,
+            Position::InsideTopLeft | Position::InsideTopCenter | Position::InsideTopRight => {
+                extra_top = label_height
+            }
+            Position::InsideBottomLeft
+            | Position::InsideBottomCenter
+            | Position::InsideBottomRight => extra_bottom = label_height,
             Position::InsideMiddleLeft => extra_left = label_width,
             Position::InsideMiddleRight => extra_right = label_width,
             _ => {}
@@ -1397,8 +1628,12 @@ fn adjust_padding(g: &Graph, obj_id: ObjId, width: f64, height: f64, padding: Sh
     let max_icon_size = crate::target::MAX_ICON_SIZE as i64 + 2 * label::PADDING as i64;
     if obj.icon.is_some() && obj.icon_position.is_some() {
         match Position::from_string(obj.icon_position.as_deref().unwrap_or("")) {
-            Position::InsideTopLeft | Position::InsideTopCenter | Position::InsideTopRight => extra_top = extra_top.max(max_icon_size),
-            Position::InsideBottomLeft | Position::InsideBottomCenter | Position::InsideBottomRight => extra_bottom = extra_bottom.max(max_icon_size),
+            Position::InsideTopLeft | Position::InsideTopCenter | Position::InsideTopRight => {
+                extra_top = extra_top.max(max_icon_size)
+            }
+            Position::InsideBottomLeft
+            | Position::InsideBottomCenter
+            | Position::InsideBottomRight => extra_bottom = extra_bottom.max(max_icon_size),
             Position::InsideMiddleLeft => extra_left = extra_left.max(max_icon_size),
             Position::InsideMiddleRight => extra_right = extra_right.max(max_icon_size),
             _ => {}
@@ -1407,8 +1642,12 @@ fn adjust_padding(g: &Graph, obj_id: ObjId, width: f64, height: f64, padding: Sh
     let mut max_child_w = f64::NEG_INFINITY;
     let mut max_child_h = f64::NEG_INFINITY;
     for &c in &obj.children_array {
-        if g.objects[c].width > max_child_w { max_child_w = g.objects[c].width; }
-        if g.objects[c].height > max_child_h { max_child_h = g.objects[c].height; }
+        if g.objects[c].width > max_child_w {
+            max_child_w = g.objects[c].width;
+        }
+        if g.objects[c].height > max_child_h {
+            max_child_h = g.objects[c].height;
+        }
     }
     let w = width + max_child_w + (extra_left + extra_right) as f64;
     let h = height + max_child_h + (extra_top + extra_bottom) as f64;
@@ -1456,8 +1695,14 @@ mod tests {
             assert!(e.labels.is_empty());
         }
         let opts = req.elk_graph.layout_options.as_ref().unwrap();
-        assert_eq!(opts.cycle_breaking_strategy.as_deref(), Some("GREEDY_MODEL_ORDER"));
-        assert_eq!(opts.consider_model_order.as_deref(), Some("NODES_AND_EDGES"));
+        assert_eq!(
+            opts.cycle_breaking_strategy.as_deref(),
+            Some("GREEDY_MODEL_ORDER")
+        );
+        assert_eq!(
+            opts.consider_model_order.as_deref(),
+            Some("NODES_AND_EDGES")
+        );
         assert_eq!(opts.fixed_alignment.as_deref(), Some("BALANCED"));
         assert_eq!(opts.direction, "DOWN");
         assert_eq!(opts.node_spacing, Some(70));
@@ -1478,11 +1723,21 @@ mod tests {
         let req = build_layout_request(&mut g);
         assert_eq!(req.elk_graph.children.len(), 3);
         assert_eq!(req.elk_graph.edges.len(), 6);
-        assert_eq!(req.elk_graph.layout_options.as_ref().unwrap().direction, "DOWN");
+        assert_eq!(
+            req.elk_graph.layout_options.as_ref().unwrap().direction,
+            "DOWN"
+        );
         // Labeled edges carry an inline edge label (d2 InlineEdgeLabels).
         for e in &req.elk_graph.edges {
             assert_eq!(e.labels.len(), 1);
-            assert_eq!(e.labels[0].layout_options.as_ref().unwrap().inline_edge_labels, Some(true));
+            assert_eq!(
+                e.labels[0]
+                    .layout_options
+                    .as_ref()
+                    .unwrap()
+                    .inline_edge_labels,
+                Some(true)
+            );
         }
     }
 }

--- a/crates/d2-little/src/layout_bridge.rs
+++ b/crates/d2-little/src/layout_bridge.rs
@@ -1,310 +1,1197 @@
-//! Layout bridge — lets an external layout engine (e.g. elkjs running in
-//! the host) drive d2-little's layout phase without a Rust port of ELK.
+//! Layout bridge — lets an external layout engine (elkjs running in the host)
+//! drive d2-little's layout phase without a Rust port of ELK.
 //!
-//! The host calls [`build_layout_request`] to get a serializable per-board
-//! geometry snapshot (object sizes + edge endpoints, parsed out of the D2
-//! source and measured by the host metrics bridge). It runs its own layout
-//! (elkjs `elk.layout`), then hands the positions/routes back via
-//! [`apply_layout`], which writes them into the graph in the exact shape
-//! [`crate::dagre_layout`] would have produced. Export + SVG render then
-//! proceed unchanged.
+//! d2's `d2elklayout` is a thin wrapper around elkjs (the official JS build of
+//! ELK): it builds an ELK graph JSON with a specific option set, hands it to
+//! `elk.layout`, then post-processes the result (parent-relative → absolute
+//! coordinates, margin shrink-back, `TraceToShape`, `deleteBends`). This
+//! module is a faithful Rust port of `d2layouts/d2elklayout/layout.go`
+//! (d2 v0.7.1), so output is byte-comparable with upstream d2 elk.
 //!
-//! ## MVP scope
+//! The host calls [`build_layout_request`] to get the complete ELK input
+//! graph (plus feature flags for fallback decisions), runs `elkjs@0.8.2`
+//! `elk.layout` on `request.elk_graph`, and hands the laid-out graph back via
+//! [`apply_layout`], which writes positions/routes into the d2-little graph
+//! exactly as d2 would. Export + SVG render then proceed unchanged.
 //!
-//! Only flat, single-board diagrams are supported. [`apply_layout`] rejects
-//! any board with sequence diagrams, grids, `near:` constants, or nested
-//! containers — the engines layer must fall back to dagre (`convert`) in
-//! those cases. Coordinate handling is absolute (every object's parent is
-//! the root), so no parent-relative → absolute conversion is needed.
-//! Multi-board (layers/scenarios/steps) is out of scope; `build_layout_request`
-//! reports only the root board and the engines layer is expected to detect
-//! nested boards and fall back.
+//! `elkjs` must be `0.8.2` — the exact version d2 v0.7.1 bundles (see
+//! `d2layouts/d2elklayout/NOTICE.txt`). Other versions route differently.
 
 use serde::{Deserialize, Serialize};
 
-use crate::geo::Point;
+use crate::geo::{Point, Segment, Spacing};
 use crate::graph::{Graph, ObjId};
+use crate::label::{self, Position};
+use crate::shape::ShapeOps;
 
 // ---------------------------------------------------------------------------
-// Request DTO (wasm → host): "here is what needs laying out"
+// Constants — mirror d2's `d2elklayout` defaults.
 // ---------------------------------------------------------------------------
 
-/// Per-board layout request. One entry per board; the MVP emits only the
-/// root board (`token == ""`).
-#[derive(Serialize, Deserialize, Debug, Clone, Default)]
-pub struct LayoutRequest {
-    /// `true` when the source has layers / scenarios / steps (multi-board).
-    /// The MVP only lays out single-board diagrams, so the host must fall
-    /// back to dagre (`convert`) when this is set.
+const PORT_SPACING: f64 = 40.0;
+const EDGE_NODE_SPACING: i64 = 40;
+
+const DEFAULT_NODE_SPACING: i64 = 70;
+const DEFAULT_PADDING: &str = "[top=50,left=50,bottom=50,right=50]";
+const DEFAULT_EDGE_NODE_SPACING: i64 = 40;
+const DEFAULT_SELF_LOOP_SPACING: i64 = 50;
+
+// ---------------------------------------------------------------------------
+// ELK DTOs — mirror d2's `ELKGraph` / `ELKNode` / `ELKEdge` / ... structs.
+// serde ignores unknown fields (e.g. elkjs' `$H` hash), so the same structs
+// deserialize both the input we build and the output elkjs returns.
+// ---------------------------------------------------------------------------
+
+/// ELK layout options. json keys match d2's `elkOpts` struct tags exactly
+/// (including the non-standard `spacing.*` keys d2 uses for the configurable
+/// between-layers spacings).
+#[derive(Default, Clone, Serialize, Deserialize, Debug)]
+pub struct ElkOpts {
+    #[serde(skip_serializing_if = "Option::is_none", rename = "elk.spacing.edgeNode")]
+    pub edge_node: Option<i64>,
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        rename = "elk.layered.nodePlacement.bk.fixedAlignment"
+    )]
+    pub fixed_alignment: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", rename = "elk.layered.thoroughness")]
+    pub thoroughness: Option<i64>,
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        rename = "elk.layered.spacing.edgeEdgeBetweenLayers"
+    )]
+    pub edge_edge_between_layers_spacing: Option<i64>,
+    #[serde(rename = "elk.direction")]
+    pub direction: String,
+    #[serde(skip_serializing_if = "Option::is_none", rename = "elk.hierarchyHandling")]
+    pub hierarchy_handling: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", rename = "elk.edgeLabels.inline")]
+    pub inline_edge_labels: Option<bool>,
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        rename = "elk.layered.crossingMinimization.forceNodeModelOrder"
+    )]
+    pub force_node_model_order: Option<bool>,
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        rename = "elk.layered.considerModelOrder.strategy"
+    )]
+    pub consider_model_order: Option<String>,
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        rename = "elk.layered.cycleBreaking.strategy"
+    )]
+    pub cycle_breaking_strategy: Option<String>,
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        rename = "elk.layered.edgeRouting.selfLoopDistribution"
+    )]
+    pub self_loop_distribution: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", rename = "elk.nodeSize.constraints")]
+    pub node_size_constraints: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", rename = "elk.contentAlignment")]
+    pub content_alignment: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", rename = "elk.nodeSize.minimum")]
+    pub node_size_minimum: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", rename = "elk.port.side")]
+    pub port_side: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", rename = "elk.portConstraints")]
+    pub port_constraints: Option<String>,
+
+    // ConfigurableOpts (flattened — Go embeds the struct).
+    #[serde(skip_serializing_if = "Option::is_none", rename = "elk.algorithm")]
+    pub algorithm: Option<String>,
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        rename = "spacing.nodeNodeBetweenLayers"
+    )]
+    pub node_spacing: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none", rename = "elk.padding")]
+    pub padding: Option<String>,
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        rename = "spacing.edgeNodeBetweenLayers"
+    )]
+    pub edge_node_spacing: Option<i64>,
+    #[serde(rename = "elk.spacing.nodeSelfLoop")]
+    pub self_loop_spacing: i64,
+}
+
+#[derive(Default, Clone, Serialize, Deserialize, Debug)]
+pub struct ElkPort {
+    pub id: String,
     #[serde(default)]
-    pub multi_board: bool,
-    pub boards: Vec<BoardRequest>,
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone, Default)]
-pub struct BoardRequest {
-    /// `"root"` for the top-level board. Reserved for future multi-board
-    /// support (layers/scenarios/steps).
-    pub token: String,
-    /// Feature flags — when any is true the engines layer must fall back
-    /// to dagre (`convert`), because the external layout can't reproduce
-    /// the synthetic edges / nested pre-passes those features require.
-    pub has_sequence: bool,
-    pub has_grid: bool,
-    pub has_near: bool,
-    pub has_containers: bool,
-    pub objects: Vec<ObjReq>,
-    pub edges: Vec<EdgeReq>,
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct ObjReq {
-    /// Object abs_id — the stable key the host echoes back in [`ObjPos`].
-    pub id: String,
+    pub x: f64,
+    #[serde(default)]
+    pub y: f64,
+    #[serde(default)]
     pub width: f64,
+    #[serde(default)]
     pub height: f64,
-    /// abs_id of the parent object, or `None` when the object's parent is
-    /// the diagram root (root-level / flat). The MVP only lays out boards
-    /// where every object has `None` here.
-    pub parent_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "layoutOptions")]
+    pub layout_options: Option<ElkOpts>,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct EdgeReq {
-    /// Edge abs_id — the stable key the host echoes back in [`EdgeRoute`].
-    pub id: String,
-    pub src: String,
-    pub dst: String,
-    pub has_label: bool,
-    pub label_width: i32,
-    pub label_height: i32,
+#[derive(Default, Clone, Serialize, Deserialize, Debug)]
+pub struct ElkLabel {
+    #[serde(default)]
+    pub text: String,
+    #[serde(default)]
+    pub x: f64,
+    #[serde(default)]
+    pub y: f64,
+    #[serde(default)]
+    pub width: f64,
+    #[serde(default)]
+    pub height: f64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "layoutOptions")]
+    pub layout_options: Option<ElkOpts>,
 }
 
-// ---------------------------------------------------------------------------
-// Result DTO (host → wasm): "here is the layout"
-// ---------------------------------------------------------------------------
-
-#[derive(Serialize, Deserialize, Debug, Clone, Default)]
-pub struct LayoutResult {
-    pub boards: Vec<BoardLayout>,
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone, Default)]
-pub struct BoardLayout {
-    pub token: String,
-    pub objects: Vec<ObjPos>,
-    pub edges: Vec<EdgeRoute>,
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct ObjPos {
-    pub id: String,
+#[derive(Default, Clone, Serialize, Deserialize, Debug)]
+pub struct ElkPoint {
     pub x: f64,
     pub y: f64,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct EdgeRoute {
+#[derive(Default, Clone, Serialize, Deserialize, Debug)]
+pub struct ElkEdgeSection {
+    #[serde(rename = "startPoint")]
+    pub start: ElkPoint,
+    #[serde(rename = "endPoint")]
+    pub end: ElkPoint,
+    #[serde(default, rename = "bendPoints", skip_serializing_if = "Vec::is_empty")]
+    pub bend_points: Vec<ElkPoint>,
+}
+
+#[derive(Default, Clone, Serialize, Deserialize, Debug)]
+pub struct ElkEdge {
     pub id: String,
-    /// Polyline points; the exporter drops any edge with fewer than 2.
-    pub route: Vec<(f64, f64)>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub sources: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub targets: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub sections: Vec<ElkEdgeSection>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub labels: Vec<ElkLabel>,
     #[serde(default)]
-    pub is_curve: bool,
+    pub container: String,
+}
+
+#[derive(Default, Clone, Serialize, Deserialize, Debug)]
+pub struct ElkNode {
+    pub id: String,
+    #[serde(default)]
+    pub x: f64,
+    #[serde(default)]
+    pub y: f64,
+    pub width: f64,
+    pub height: f64,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub children: Vec<ElkNode>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub ports: Vec<ElkPort>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub labels: Vec<ElkLabel>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "layoutOptions")]
+    pub layout_options: Option<ElkOpts>,
+}
+
+#[derive(Default, Clone, Serialize, Deserialize, Debug)]
+pub struct ElkGraph {
+    #[serde(default)]
+    pub id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "layoutOptions")]
+    pub layout_options: Option<ElkOpts>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub children: Vec<ElkNode>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub edges: Vec<ElkEdge>,
 }
 
 // ---------------------------------------------------------------------------
-// Build request: walk the root graph into a DTO
+// Request / Result wrappers (wasm ↔ host).
 // ---------------------------------------------------------------------------
 
-/// Build a [`LayoutRequest`] for the root board of `g`. Does not recurse
-/// into layers/scenarios/steps — the caller detects nested boards via
-/// `!g.layers.is_empty() || ...` and falls back to dagre for multi-board
-/// inputs.
-pub fn build_layout_request(g: &Graph) -> LayoutRequest {
-    let mut board = BoardRequest {
-        token: "root".to_string(),
+/// Per-board layout request. `elk_graph` is the complete ELK input graph
+/// built by [`build_layout_request`] — the host runs `elkjs.layout` on it
+/// directly. The feature flags tell the host when to fall back to dagre
+/// (`convert`) because the external layout can't reproduce d2's
+/// sequence / grid / `near:` specialized layouts.
+#[derive(Serialize, Deserialize, Debug, Clone, Default)]
+pub struct LayoutRequest {
+    #[serde(default)]
+    pub multi_board: bool,
+    #[serde(default)]
+    pub has_sequence: bool,
+    #[serde(default)]
+    pub has_grid: bool,
+    #[serde(default)]
+    pub has_near: bool,
+    pub elk_graph: ElkGraph,
+}
+
+/// Host-supplied layout result: the laid-out ELK graph returned by
+/// `elkjs.layout`. [`apply_layout`] walks it back into the d2-little graph.
+#[derive(Serialize, Deserialize, Debug, Clone, Default)]
+pub struct LayoutResult {
+    pub elk_graph: ElkGraph,
+}
+
+// ---------------------------------------------------------------------------
+// Build request: walk the d2-little graph into an ELK input graph.
+// Faithful port of d2 `Layout` graph-construction (layout.go:177-447).
+// ---------------------------------------------------------------------------
+
+pub fn build_layout_request(g: &mut Graph) -> LayoutRequest {
+    let direction = root_direction(g);
+    let dir_str = direction_string(direction);
+
+    let self_loop_spacing = DEFAULT_SELF_LOOP_SPACING;
+    let mut root_opts = ElkOpts {
+        thoroughness: Some(8),
+        edge_edge_between_layers_spacing: Some(50),
+        edge_node: Some(EDGE_NODE_SPACING),
+        hierarchy_handling: Some("INCLUDE_CHILDREN".to_string()),
+        fixed_alignment: Some("BALANCED".to_string()),
+        consider_model_order: Some("NODES_AND_EDGES".to_string()),
+        cycle_breaking_strategy: Some("GREEDY_MODEL_ORDER".to_string()),
+        node_size_constraints: Some("MINIMUM_SIZE".to_string()),
+        content_alignment: Some("H_CENTER V_CENTER".to_string()),
+        direction: dir_str.clone(),
+        algorithm: Some("layered".to_string()),
+        node_spacing: Some(DEFAULT_NODE_SPACING),
+        edge_node_spacing: Some(DEFAULT_EDGE_NODE_SPACING),
+        self_loop_spacing,
         ..Default::default()
     };
-
-    // Feature flags: the root object itself can carry the diagram-level
-    // shape (`shape: sequence_diagram` / `grid-rows:`), so check it too.
-    let root_obj = g.root_obj();
-    if root_obj.is_sequence_diagram() {
-        board.has_sequence = true;
-    }
-    if root_obj.is_grid_diagram() {
-        board.has_grid = true;
-    }
-    if root_obj.near_key.is_some() {
-        board.has_near = true;
+    let is_width = matches!(direction, Direction::Down | Direction::Up | Direction::None);
+    let max_self_loop = children_max_self_loop(g, g.root, is_width);
+    if self_loop_spacing == DEFAULT_SELF_LOOP_SPACING {
+        root_opts.self_loop_spacing = root_opts.self_loop_spacing.max(max_self_loop / 2 + 5);
     }
 
+    let mut elk_graph = ElkGraph {
+        id: String::new(),
+        layout_options: Some(root_opts),
+        children: Vec::new(),
+        edges: Vec::new(),
+    };
+
+    // Set label/icon positions for ELK (layout.go:214-217).
+    for obj in g.objects.iter_mut() {
+        position_labels_icons(obj);
+    }
+
+    let mut elk_nodes: std::collections::HashMap<ObjId, ElkNode> =
+        std::collections::HashMap::new();
+
+    // BFS walk (layout.go:223-356). Parent before child.
+    let walk_order = bfs_walk_order(g, g.root);
+
+    for &obj_id in &walk_order {
+        let mut incoming = 0f64;
+        let mut outgoing = 0f64;
+        for e in &g.edges {
+            if e.src == obj_id {
+                outgoing += 1.0;
+            }
+            if e.dst == obj_id {
+                incoming += 1.0;
+            }
+        }
+
+        let mut width = g.objects[obj_id].width;
+        let mut height = g.objects[obj_id].height;
+
+        if incoming >= 2.0 || outgoing >= 2.0 && g.objects[obj_id].width_attr.is_none() {
+            match direction {
+                Direction::Right | Direction::Left => {
+                    height = height.max(incoming.max(outgoing) * PORT_SPACING);
+                }
+                _ => {
+                    width = width.max(incoming.max(outgoing) * PORT_SPACING);
+                }
+            }
+        }
+
+        if g.objects[obj_id].has_label() && g.objects[obj_id].has_icon() {
+            height += g.objects[obj_id].label_dimensions.height as f64 + label::PADDING;
+        }
+
+        let (margin, _padding) = g.objects[obj_id].spacing_opt(label::PADDING, label::PADDING, false);
+        let w = margin.left + width + margin.right;
+        let h = margin.top + height + margin.bottom;
+
+        let mut n = ElkNode {
+            id: g.objects[obj_id].abs_id.clone(),
+            width: w,
+            height: h,
+            ..Default::default()
+        };
+
+        if !g.objects[obj_id].children_array.is_empty() {
+            let mut opts = ElkOpts {
+                force_node_model_order: Some(true),
+                thoroughness: Some(8),
+                edge_edge_between_layers_spacing: Some(50),
+                hierarchy_handling: Some("INCLUDE_CHILDREN".to_string()),
+                fixed_alignment: Some("BALANCED".to_string()),
+                edge_node: Some(EDGE_NODE_SPACING),
+                consider_model_order: Some("NODES_AND_EDGES".to_string()),
+                cycle_breaking_strategy: Some("GREEDY_MODEL_ORDER".to_string()),
+                node_size_constraints: Some("MINIMUM_SIZE".to_string()),
+                content_alignment: Some("H_CENTER V_CENTER".to_string()),
+                direction: String::new(),
+                algorithm: Some("layered".to_string()),
+                node_spacing: Some(DEFAULT_NODE_SPACING),
+                edge_node_spacing: Some(DEFAULT_EDGE_NODE_SPACING),
+                self_loop_spacing,
+                ..Default::default()
+            };
+            if opts.self_loop_spacing == DEFAULT_SELF_LOOP_SPACING {
+                opts.self_loop_spacing =
+                    opts.self_loop_spacing.max(children_max_self_loop(g, obj_id, is_width) / 2 + 5);
+            }
+            match direction {
+                Direction::Down | Direction::Up | Direction::None => {
+                    opts.node_size_minimum = Some(format!("({}, {})", h.ceil() as i64, w.ceil() as i64));
+                }
+                Direction::Right | Direction::Left => {
+                    opts.node_size_minimum = Some(format!("({}, {})", w.ceil() as i64, h.ceil() as i64));
+                }
+            }
+            if g.objects[obj_id].is_container() {
+                let mut pad = parse_padding(DEFAULT_PADDING);
+                pad = adjust_padding(g, obj_id, w, h, pad);
+                opts.padding = Some(pad.to_string());
+            }
+            n.layout_options = Some(opts);
+        } else {
+            n.layout_options = Some(ElkOpts {
+                self_loop_distribution: Some("EQUALLY".to_string()),
+                ..Default::default()
+            });
+        }
+
+        if g.objects[obj_id].has_label() {
+            n.labels.push(ElkLabel {
+                text: g.objects[obj_id].label.value.clone(),
+                width: g.objects[obj_id].label_dimensions.width as f64,
+                height: g.objects[obj_id].label_dimensions.height as f64,
+                ..Default::default()
+            });
+        }
+
+        // Store in a flat map; the tree is assembled after the walk so that
+        // children added later land on the SAME node that ends up in the tree
+        // (Go uses `*ELKNode` pointers; we assemble bottom-up by ObjId instead).
+        elk_nodes.insert(obj_id, n);
+    }
+
+    // Assemble the ELK node tree from the flat map (parent → children).
+    fn assemble(
+        g: &Graph,
+        obj_id: ObjId,
+        elk_nodes: &mut std::collections::HashMap<ObjId, ElkNode>,
+    ) -> Option<ElkNode> {
+        let mut n = elk_nodes.remove(&obj_id)?;
+        for &ch in &g.objects[obj_id].children_array.clone() {
+            if let Some(child) = assemble(g, ch, elk_nodes) {
+                n.children.push(child);
+            }
+        }
+        Some(n)
+    }
+    let root_children = g.objects[g.root].children_array.clone();
+    for &ch in &root_children {
+        if let Some(n) = assemble(g, ch, &mut elk_nodes) {
+            elk_graph.children.push(n);
+        }
+    }
+
+    // Edges (layout.go:371-429). Non-SQL-table edges connect whole nodes by AbsID.
+    for edge in &g.edges {
+        let src = g.objects[edge.src].abs_id.clone();
+        let dst = g.objects[edge.dst].abs_id.clone();
+        let mut e = ElkEdge {
+            id: edge.abs_id.clone(),
+            sources: vec![src],
+            targets: vec![dst],
+            ..Default::default()
+        };
+        if !edge.label.value.is_empty() {
+            e.labels.push(ElkLabel {
+                text: edge.label.value.clone(),
+                width: edge.label_dimensions.width as f64,
+                height: edge.label_dimensions.height as f64,
+                layout_options: Some(ElkOpts {
+                    inline_edge_labels: Some(true),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            });
+        }
+        elk_graph.edges.push(e);
+    }
+
+    let mut has_sequence = false;
+    let mut has_grid = false;
+    let mut has_near = false;
+    if g.root_obj().is_sequence_diagram() {
+        has_sequence = true;
+    }
+    if g.root_obj().is_grid_diagram() {
+        has_grid = true;
+    }
+    if g.root_obj().near_key.is_some() {
+        has_near = true;
+    }
     for (idx, obj) in g.objects.iter().enumerate() {
         if idx == g.root {
             continue;
         }
         if obj.is_sequence_diagram() {
-            board.has_sequence = true;
+            has_sequence = true;
         }
         if obj.is_grid_diagram() {
-            board.has_grid = true;
+            has_grid = true;
         }
         if obj.near_key.is_some() {
-            board.has_near = true;
+            has_near = true;
         }
-        if !obj.children_array.is_empty() {
-            board.has_containers = true;
-        }
-
-        let parent_id = obj
-            .parent
-            .filter(|&p| p != g.root)
-            .and_then(|p| g.objects.get(p).map(|po| po.abs_id.clone()));
-
-        board.objects.push(ObjReq {
-            id: obj.abs_id.clone(),
-            width: obj.width,
-            height: obj.height,
-            parent_id,
-        });
-    }
-
-    for edge in &g.edges {
-        let src_abs = g.objects.get(edge.src).map(|o| o.abs_id.clone()).unwrap_or_default();
-        let dst_abs = g.objects.get(edge.dst).map(|o| o.abs_id.clone()).unwrap_or_default();
-        let has_label = !edge.label.value.is_empty();
-        board.edges.push(EdgeReq {
-            id: edge.abs_id.clone(),
-            src: src_abs,
-            dst: dst_abs,
-            has_label,
-            label_width: edge.label_dimensions.width,
-            label_height: edge.label_dimensions.height,
-        });
     }
 
     LayoutRequest {
         multi_board: !g.layers.is_empty() || !g.scenarios.is_empty() || !g.steps.is_empty(),
-        boards: vec![board],
+        has_sequence,
+        has_grid,
+        has_near,
+        elk_graph,
     }
 }
 
 // ---------------------------------------------------------------------------
-// Apply result: write host-provided positions/routes into the graph
+// Apply result: write host-provided positions/routes into the graph.
+// Faithful port of d2 `Layout` post-processing (layout.go:484-648 + deleteBends).
 // ---------------------------------------------------------------------------
 
-/// Write `layout` into `g` in the shape dagre would have produced, so the
-/// downstream exporter + SVG renderer work unchanged.
-///
-/// - Calls [`crate::dagre_layout::position_object_labels`] first so default
-///   label/icon placement matches dagre's conventions.
-/// - Writes `obj.top_left` per abs_id and refreshes `obj.box_`.
-/// - Writes `edge.route` (≥ 2 points) + `is_curve`; for labeled edges sets
-///   `label_position` to the route midpoint so the label renders on the
-///   edge rather than at a shape corner.
-///
-/// Returns an error if the board contains any feature the MVP can't lay out
-/// (sequence / grid / near / containers) — the caller falls back to dagre.
-pub fn apply_layout(g: &mut Graph, board: &BoardLayout) -> Result<(), String> {
-    // Default object label/icon placement — independent of layout.
-    crate::dagre_layout::position_object_labels(g);
+pub fn apply_layout(g: &mut Graph, result: &LayoutResult) -> Result<(), String> {
+    let laid = &result.elk_graph;
 
-    // Index positions by abs_id for O(1) lookup.
-    let mut pos_by_id: std::collections::HashMap<&str, (f64, f64)> =
-        std::collections::HashMap::with_capacity(board.objects.len());
-    for o in &board.objects {
-        pos_by_id.insert(o.id.as_str(), (o.x, o.y));
+    let mut elk_by_id: std::collections::HashMap<&str, &ElkNode> = std::collections::HashMap::new();
+    for c in &laid.children {
+        index_elk_nodes(c, &mut elk_by_id);
     }
-    let mut route_by_id: std::collections::HashMap<&str, &EdgeRoute> =
-        std::collections::HashMap::with_capacity(board.edges.len());
-    for e in &board.edges {
-        route_by_id.insert(e.id.as_str(), e);
+    let mut elk_edge_by_id: std::collections::HashMap<&str, &ElkEdge> = std::collections::HashMap::new();
+    for e in &laid.edges {
+        elk_edge_by_id.insert(e.id.as_str(), e);
     }
 
-    // Apply object positions. Only root-level objects are supported (the
-    // feature flags above already gate this; double-check per-object).
-    for (idx, obj) in g.objects.iter_mut().enumerate() {
-        if idx == g.root {
-            continue;
-        }
-        if obj.parent.is_some() && obj.parent != Some(g.root) {
-            return Err(format!(
-                "layout_bridge: object \"{}\" has a non-root parent; nested containers are not supported by the elk bridge yet (fall back to dagre)",
-                obj.abs_id
-            ));
-        }
-        if let Some(&(x, y)) = pos_by_id.get(obj.abs_id.as_str()) {
-            obj.top_left = Point::new(x, y);
+    // Apply object positions (layout.go:484-499). BFS so parents are placed first.
+    let walk_order = bfs_walk_order(g, g.root);
+    let mut by_id: std::collections::HashMap<String, ObjId> = std::collections::HashMap::new();
+    for &obj_id in &walk_order {
+        let parent = g.objects[obj_id].parent;
+        let (parent_x, parent_y) = match parent {
+            Some(p) if p != g.root => (g.objects[p].top_left.x, g.objects[p].top_left.y),
+            _ => (0.0, 0.0),
+        };
+        let abs_id = g.objects[obj_id].abs_id.clone();
+        if let Some(n) = elk_by_id.get(abs_id.as_str()) {
+            let obj = &mut g.objects[obj_id];
+            obj.top_left = Point::new(parent_x + n.x, parent_y + n.y);
+            obj.width = n.width.ceil();
+            obj.height = n.height.ceil();
             obj.update_box();
         }
+        by_id.insert(abs_id, obj_id);
     }
 
-    // Apply edge routes + label placement.
-    for edge in g.edges.iter_mut() {
-        let Some(route) = route_by_id.get(edge.abs_id.as_str()) else {
+    // Apply edge routes (layout.go:501-529).
+    for ei in 0..g.edges.len() {
+        let abs_id = g.edges[ei].abs_id.clone();
+        let Some(e) = elk_edge_by_id.get(abs_id.as_str()).copied() else {
             continue;
         };
-        if route.route.len() < 2 {
-            return Err(format!(
-                "layout_bridge: edge \"{}\" route has fewer than 2 points; the exporter would drop it",
-                edge.abs_id
-            ));
+        let (parent_x, parent_y) = if !e.container.is_empty() {
+            if let Some(&cid) = by_id.get(e.container.as_str()) {
+                (g.objects[cid].top_left.x, g.objects[cid].top_left.y)
+            } else {
+                (0.0, 0.0)
+            }
+        } else {
+            (0.0, 0.0)
+        };
+        let mut points: Vec<Point> = Vec::new();
+        for s in &e.sections {
+            points.push(Point::new(parent_x + s.start.x, parent_y + s.start.y));
+            for bp in &s.bend_points {
+                points.push(Point::new(parent_x + bp.x, parent_y + bp.y));
+            }
+            points.push(Point::new(parent_x + s.end.x, parent_y + s.end.y));
         }
-        edge.route = route.route.iter().map(|&(x, y)| Point::new(x, y)).collect();
-        edge.is_curve = route.is_curve;
+        g.edges[ei].route = points;
+        g.edges[ei].is_curve = false;
+    }
 
-        // Edge label: place at the route midpoint. dagre computes a precise
-        // position; without it the exporter falls back to a shape-corner
-        // default and the label drifts off the connection.
-        if !edge.label.value.is_empty() && edge.label_position.is_none() {
-            let m = midpoint(&edge.route);
-            // Store the absolute midpoint as an INSIDE position keyed off the
-            // connection geometry. d2's label renderer honours this string
-            // form only for shape-relative placements, so for an absolute
-            // midpoint we instead use the standard centre slot — the
-            // renderer then centres the label box on the route. See
-            // `svg_render` connection-label handling.
-            let _ = m; // midpoint computed for future exact-placement work
-            edge.label_position = Some("INSIDE_MIDDLE_CENTER".to_string());
+    // Margin shrink-back + edge shifting (layout.go:531-598).
+    let adjustments: Vec<Spacing> = g
+        .objects
+        .iter()
+        .map(|o| o.spacing_opt(label::PADDING, label::PADDING, false).0)
+        .collect();
+    apply_margins(g, &adjustments);
+
+    // TraceToShape + label position + 3d/multiple (layout.go:600-644).
+    for ei in 0..g.edges.len() {
+        if g.edges[ei].route.len() < 2 {
+            continue;
+        }
+        let src_id = g.edges[ei].src;
+        let dst_id = g.edges[ei].dst;
+        let start = g.edges[ei].route[0];
+        let end = g.edges[ei].route[g.edges[ei].route.len() - 1];
+
+        let (src_dx, src_dy) = g.objects[src_id].get_modifier_element_adjustments();
+        let mut original_src_tl = None;
+        if src_dx != 0.0 || src_dy != 0.0 {
+            if start.x > g.objects[src_id].top_left.x + src_dx
+                && start.y < g.objects[src_id].top_left.y + g.objects[src_id].height - src_dy
+            {
+                original_src_tl = Some(g.objects[src_id].top_left);
+                let o = original_src_tl.unwrap();
+                g.objects[src_id].top_left = Point::new(o.x + src_dx, o.y - src_dy);
+                g.objects[src_id].update_box();
+            }
+        }
+        let (dst_dx, dst_dy) = g.objects[dst_id].get_modifier_element_adjustments();
+        let mut original_dst_tl = None;
+        if dst_dx != 0.0 || dst_dy != 0.0 {
+            if end.x > g.objects[dst_id].top_left.x + dst_dx
+                && end.y < g.objects[dst_id].top_left.y + g.objects[dst_id].height - dst_dy
+            {
+                original_dst_tl = Some(g.objects[dst_id].top_left);
+                let o = original_dst_tl.unwrap();
+                g.objects[dst_id].top_left = Point::new(o.x + dst_dx, o.y - dst_dy);
+                g.objects[dst_id].update_box();
+            }
+        }
+
+        let route = g.edges[ei].route.clone();
+        let (new_start, new_end) = g.edges[ei].trace_to_shape(&route, 0, route.len() - 1, g);
+        let has_label = !g.edges[ei].label.value.is_empty();
+        g.edges[ei].route = route[new_start..=new_end].to_vec();
+        if has_label {
+            g.edges[ei].label_position = Some(Position::InsideMiddleCenter.as_str().to_string());
+        }
+
+        if let Some(o) = original_src_tl {
+            g.objects[src_id].top_left = o;
+            g.objects[src_id].update_box();
+        }
+        if let Some(o) = original_dst_tl {
+            g.objects[dst_id].top_left = o;
+            g.objects[dst_id].update_box();
         }
     }
+
+    delete_bends(g);
 
     Ok(())
 }
 
-fn midpoint(route: &[Point]) -> Point {
-    if route.is_empty() {
-        return Point::new(0.0, 0.0);
-    }
-    if route.len() == 1 {
-        return route[0];
-    }
-    // Total-length parametric midpoint — matches the visual centre of the
-    // polyline, not just the middle vertex.
-    let mut segs: Vec<(f64, f64)> = Vec::with_capacity(route.len() - 1); // (cum_len, seg_len)
-    let mut total = 0.0;
-    for w in route.windows(2) {
-        let d = ((w[1].x - w[0].x).powi(2) + (w[1].y - w[0].y).powi(2)).sqrt();
-        total += d;
-        segs.push((total, d));
-    }
-    let target = total / 2.0;
-    let mut acc = 0.0;
-    for (i, w) in route.windows(2).enumerate() {
-        let seg_len = segs[i].1;
-        let prev_acc = acc;
-        acc += seg_len;
-        if acc >= target {
-            let t = if seg_len > 0.0 { (target - prev_acc) / seg_len } else { 0.0 };
-            return Point::new(w[0].x + (w[1].x - w[0].x) * t, w[0].y + (w[1].y - w[0].y) * t);
-        }
-    }
-    *route.last().unwrap()
+// ---------------------------------------------------------------------------
+// Helpers.
+// ---------------------------------------------------------------------------
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Direction {
+    Down,
+    Up,
+    Right,
+    Left,
+    None,
 }
 
-// ObjId is used implicitly via g.root comparisons; keep the import meaningful.
-#[allow(dead_code)]
-fn _objid_marker(_: ObjId) {}
+fn root_direction(g: &Graph) -> Direction {
+    match g.root_obj().direction.value.as_str() {
+        "down" => Direction::Down,
+        "up" => Direction::Up,
+        "right" => Direction::Right,
+        "left" => Direction::Left,
+        _ => Direction::None,
+    }
+}
+
+fn direction_string(d: Direction) -> String {
+    match d {
+        Direction::Down => "DOWN".to_string(),
+        Direction::Up => "UP".to_string(),
+        Direction::Right => "RIGHT".to_string(),
+        Direction::Left => "LEFT".to_string(),
+        Direction::None => "DOWN".to_string(),
+    }
+}
+
+fn bfs_walk_order(g: &Graph, root: ObjId) -> Vec<ObjId> {
+    let mut out = Vec::new();
+    fn rec(g: &Graph, obj: ObjId, out: &mut Vec<ObjId>) {
+        for &ch in &g.objects[obj].children_array {
+            out.push(ch);
+            rec(g, ch, out);
+        }
+    }
+    rec(g, root, &mut out);
+    out
+}
+
+fn index_elk_nodes<'a>(
+    node: &'a ElkNode,
+    map: &mut std::collections::HashMap<&'a str, &'a ElkNode>,
+) {
+    map.insert(node.id.as_str(), node);
+    for c in &node.children {
+        index_elk_nodes(c, map);
+    }
+}
+
+fn children_max_self_loop(g: &Graph, parent: ObjId, is_width: bool) -> i64 {
+    let mut max = 0i64;
+    for &ch in &g.objects[parent].children_array {
+        for e in &g.edges {
+            if e.src == e.dst && e.src == ch && !e.label.value.is_empty() {
+                let v = if is_width {
+                    e.label_dimensions.width as i64
+                } else {
+                    e.label_dimensions.height as i64
+                };
+                max = max.max(v);
+            }
+        }
+    }
+    max
+}
+
+/// d2 `positionLabelsIcons` (layout.go:1110-1142).
+fn position_labels_icons(obj: &mut crate::graph::Object) {
+    if obj.icon.is_some() && obj.icon_position.is_none() {
+        if !obj.children_array.is_empty() {
+            obj.icon_position = Some(Position::InsideTopLeft.as_str().to_string());
+            if obj.label_position.is_none() {
+                obj.label_position = Some(Position::InsideTopRight.as_str().to_string());
+                return;
+            }
+        } else if obj.sql_table.is_some() || obj.class.is_some() || !obj.language.is_empty() {
+            obj.icon_position = Some(Position::OutsideTopLeft.as_str().to_string());
+        } else {
+            obj.icon_position = Some(Position::InsideMiddleCenter.as_str().to_string());
+        }
+    }
+    if obj.has_label() && obj.label_position.is_none() {
+        if !obj.children_array.is_empty() {
+            obj.label_position = Some(Position::InsideTopCenter.as_str().to_string());
+        } else if obj.has_outside_bottom_label() {
+            obj.label_position = Some(Position::OutsideBottomCenter.as_str().to_string());
+        } else if obj.icon.is_some() {
+            obj.label_position = Some(Position::InsideTopCenter.as_str().to_string());
+        } else {
+            obj.label_position = Some(Position::InsideMiddleCenter.as_str().to_string());
+        }
+        if obj.label_dimensions.width as f64 > obj.width
+            || obj.label_dimensions.height as f64 > obj.height
+        {
+            if !obj.children_array.is_empty() {
+                obj.label_position = Some(Position::OutsideTopCenter.as_str().to_string());
+            } else {
+                obj.label_position = Some(Position::OutsideBottomCenter.as_str().to_string());
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Margin shrink-back + edge shifting (layout.go:531-598).
+// ---------------------------------------------------------------------------
+
+fn apply_margins(g: &mut Graph, adjustments: &[Spacing]) {
+    let mut obj_edges: std::collections::HashMap<ObjId, Vec<usize>> =
+        std::collections::HashMap::new();
+    for (ei, e) in g.edges.iter().enumerate() {
+        obj_edges.entry(e.src).or_default().push(ei);
+        if e.dst != e.src {
+            obj_edges.entry(e.dst).or_default().push(ei);
+        }
+    }
+
+    for obj_id in 0..g.objects.len() {
+        let margin = adjustments[obj_id];
+        if margin.left == 0.0 && margin.right == 0.0 && margin.top == 0.0 && margin.bottom == 0.0 {
+            continue;
+        }
+        let edges: Vec<usize> = obj_edges.get(&obj_id).cloned().unwrap_or_default();
+        let tl_x = g.objects[obj_id].top_left.x;
+        let tl_y = g.objects[obj_id].top_left.y;
+        let w = g.objects[obj_id].width;
+        let h = g.objects[obj_id].height;
+
+        if margin.left > 0.0 {
+            for &ei in &edges {
+                let e = &mut g.edges[ei];
+                let l = e.route.len();
+                if l == 0 { continue; }
+                if e.src == obj_id && e.route[0].x == tl_x { e.route[0].x += margin.left; }
+                if e.dst == obj_id && e.route[l - 1].x == tl_x { e.route[l - 1].x += margin.left; }
+            }
+            g.objects[obj_id].top_left.x += margin.left;
+            shift_descendants(g, obj_id, margin.left / 2.0, 0.0);
+            g.objects[obj_id].width -= margin.left;
+            g.objects[obj_id].update_box();
+        }
+        if margin.right > 0.0 {
+            for &ei in &edges {
+                let e = &mut g.edges[ei];
+                let l = e.route.len();
+                if l == 0 { continue; }
+                if e.src == obj_id && e.route[0].x == tl_x + w { e.route[0].x -= margin.right; }
+                if e.dst == obj_id && e.route[l - 1].x == tl_x + w { e.route[l - 1].x -= margin.right; }
+            }
+            shift_descendants(g, obj_id, -margin.right / 2.0, 0.0);
+            g.objects[obj_id].width -= margin.right;
+            g.objects[obj_id].update_box();
+        }
+        if margin.top > 0.0 {
+            for &ei in &edges {
+                let e = &mut g.edges[ei];
+                let l = e.route.len();
+                if l == 0 { continue; }
+                if e.src == obj_id && e.route[0].y == tl_y { e.route[0].y += margin.top; }
+                if e.dst == obj_id && e.route[l - 1].y == tl_y { e.route[l - 1].y += margin.top; }
+            }
+            g.objects[obj_id].top_left.y += margin.top;
+            shift_descendants(g, obj_id, 0.0, margin.top / 2.0);
+            g.objects[obj_id].height -= margin.top;
+            g.objects[obj_id].update_box();
+        }
+        if margin.bottom > 0.0 {
+            for &ei in &edges {
+                let e = &mut g.edges[ei];
+                let l = e.route.len();
+                if l == 0 { continue; }
+                if e.src == obj_id && e.route[0].y == tl_y + h { e.route[0].y -= margin.bottom; }
+                if e.dst == obj_id && e.route[l - 1].y == tl_y + h { e.route[l - 1].y -= margin.bottom; }
+            }
+            shift_descendants(g, obj_id, 0.0, -margin.bottom / 2.0);
+            g.objects[obj_id].height -= margin.bottom;
+            g.objects[obj_id].update_box();
+        }
+    }
+}
+
+/// d2 `Object.ShiftDescendants` (d2graph/layout.go:103-141).
+fn shift_descendants(g: &mut Graph, obj: ObjId, dx: f64, dy: f64) {
+    let n_edges = g.edges.len();
+    let mut moved: std::collections::HashSet<usize> = std::collections::HashSet::new();
+    for ei in 0..n_edges {
+        let (s, d) = (g.edges[ei].src, g.edges[ei].dst);
+        if is_descendant_of(g, s, obj) && is_descendant_of(g, d, obj) {
+            for p in &mut g.edges[ei].route {
+                p.x += dx;
+                p.y += dy;
+            }
+            moved.insert(ei);
+        }
+    }
+
+    let descendants = descendants_list(g, obj);
+    for &curr in &descendants {
+        g.objects[curr].top_left.x += dx;
+        g.objects[curr].top_left.y += dy;
+        g.objects[curr].update_box();
+        for ei in 0..n_edges {
+            if moved.contains(&ei) {
+                continue;
+            }
+            let (s, d) = (g.edges[ei].src, g.edges[ei].dst);
+            let is_src = s == curr;
+            let is_dst = d == curr;
+            if is_src && is_dst {
+                for p in &mut g.edges[ei].route {
+                    p.x += dx;
+                    p.y += dy;
+                }
+            } else if is_src {
+                if dx == 0.0 { shift_start(g, ei, dy, false); }
+                else if dy == 0.0 { shift_start(g, ei, dx, true); }
+                else { g.edges[ei].route[0].x += dx; g.edges[ei].route[0].y += dy; }
+            } else if is_dst {
+                if dx == 0.0 { shift_end(g, ei, dy, false); }
+                else if dy == 0.0 { shift_end(g, ei, dx, true); }
+                else { let l = g.edges[ei].route.len(); g.edges[ei].route[l - 1].x += dx; g.edges[ei].route[l - 1].y += dy; }
+            }
+            if is_src || is_dst {
+                moved.insert(ei);
+            }
+        }
+    }
+}
+
+fn is_descendant_of(g: &Graph, self_id: ObjId, ancestor: ObjId) -> bool {
+    if self_id == ancestor {
+        return true;
+    }
+    let mut p = g.objects[self_id].parent;
+    while let Some(pid) = p {
+        if pid == ancestor { return true; }
+        p = g.objects[pid].parent;
+    }
+    false
+}
+
+fn descendants_list(g: &Graph, obj: ObjId) -> Vec<ObjId> {
+    let mut out = Vec::new();
+    fn rec(g: &Graph, parent: ObjId, out: &mut Vec<ObjId>) {
+        for &ch in &g.objects[parent].children_array {
+            out.push(ch);
+            rec(g, ch, out);
+        }
+    }
+    rec(g, obj, &mut out);
+    out
+}
+
+fn shift_start(g: &mut Graph, ei: usize, delta: f64, is_horizontal: bool) {
+    let route = &mut g.edges[ei].route;
+    if route.len() < 2 { return; }
+    let pos = |p: &Point| if is_horizontal { p.x } else { p.y };
+    let is_increasing = pos(&route[0]) < pos(&route[1]);
+    if is_horizontal { route[0].x += delta; } else { route[0].y += delta; }
+    if is_increasing == (delta < 0.0) { return; }
+    let start = route[0];
+    let is_aligned = |p: &Point| if is_horizontal { p.y == start.y } else { p.x == start.x };
+    let is_past_start = |p: &Point| {
+        if delta > 0.0 { pos(p) < pos(&start) } else { pos(p) > pos(&start) }
+    };
+    let mut to_remove = vec![false; route.len()];
+    let mut needs_removal = false;
+    for i in 1..route.len().saturating_sub(1) {
+        if !is_aligned(&route[i]) { break; }
+        if is_past_start(&route[i]) { to_remove[i] = true; needs_removal = true; }
+    }
+    if needs_removal {
+        let mut new_route = Vec::with_capacity(route.len());
+        for (i, p) in route.iter().enumerate() {
+            if !to_remove[i] { new_route.push(*p); }
+        }
+        *route = new_route;
+    }
+}
+
+fn shift_end(g: &mut Graph, ei: usize, delta: f64, is_horizontal: bool) {
+    let route = &mut g.edges[ei].route;
+    if route.len() < 2 { return; }
+    let pos = |p: &Point| if is_horizontal { p.x } else { p.y };
+    let last = route.len() - 1;
+    let is_increasing = pos(&route[last - 1]) < pos(&route[last]);
+    if is_horizontal { route[last].x += delta; } else { route[last].y += delta; }
+    if is_increasing == (delta > 0.0) { return; }
+    let end = route[last];
+    let is_aligned = |p: &Point| if is_horizontal { p.y == end.y } else { p.x == end.x };
+    let is_past_end = |p: &Point| {
+        if delta > 0.0 { pos(p) < pos(&end) } else { pos(p) > pos(&end) }
+    };
+    let mut to_remove = vec![false; route.len()];
+    let mut needs_removal = false;
+    let mut i = route.len().saturating_sub(2);
+    while i > 0 {
+        if !is_aligned(&route[i]) { break; }
+        if is_past_end(&route[i]) { to_remove[i] = true; needs_removal = true; }
+        i -= 1;
+    }
+    if needs_removal {
+        let mut new_route = Vec::with_capacity(route.len());
+        for (i, p) in route.iter().enumerate() {
+            if !to_remove[i] { new_route.push(*p); }
+        }
+        *route = new_route;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// deleteBends (layout.go:659-884).
+// ---------------------------------------------------------------------------
+
+fn delete_bends(g: &mut Graph) {
+    // S-shapes at source/target (layout.go:662-773).
+    for &is_source in &[true, false] {
+        for ei in 0..g.edges.len() {
+            if g.edges[ei].route.len() < 4 || g.edges[ei].src == g.edges[ei].dst {
+                continue;
+            }
+            let (endpoint_id, start_idx, corner_idx, end_idx, column_index) = if is_source {
+                (g.edges[ei].src, 0usize, 1usize, 2usize, g.edges[ei].src_table_column_index)
+            } else {
+                let l = g.edges[ei].route.len();
+                (g.edges[ei].dst, l - 1, l - 2, l - 3, g.edges[ei].dst_table_column_index)
+            };
+            let start = g.edges[ei].route[start_idx];
+            let corner = g.edges[ei].route[corner_idx];
+            let end = g.edges[ei].route[end_idx];
+            let (dx, dy) = g.objects[endpoint_id].get_modifier_element_adjustments();
+            let endpoint_tl = g.objects[endpoint_id].top_left;
+            let endpoint_w = g.objects[endpoint_id].width;
+            let endpoint_h = g.objects[endpoint_id].height;
+
+            let is_horizontal = start.y.ceil() == corner.y.ceil();
+            let attached = match column_index {
+                Some(_) => true,
+                None if is_horizontal => {
+                    end.y > endpoint_tl.y + 10.0 - dy && end.y < endpoint_tl.y + endpoint_h - 10.0
+                }
+                None => {
+                    end.x > endpoint_tl.x + 10.0 && end.x < endpoint_tl.x + endpoint_w - 10.0 + dx
+                }
+            };
+            if !attached { continue; }
+
+            let new_start_raw = if is_horizontal { Point::new(start.x, end.y) } else { Point::new(end.x, start.y) };
+            let endpoint_box = g.objects[endpoint_id].box_;
+            let shape_type = crate::target::dsl_shape_to_shape_type(&g.objects[endpoint_id].shape.value);
+            let endpoint_shape = crate::shape::Shape::new(shape_type, endpoint_box);
+            let new_start = crate::shape::trace_to_shape_border(&endpoint_shape, &new_start_raw, &end);
+
+            let old_segment = Segment::new(start, corner);
+            let new_segment = Segment::new(new_start, end);
+            let old_intersects = count_object_intersects(g, ei, &old_segment);
+            let new_intersects = count_object_intersects(g, ei, &new_segment);
+            if new_intersects > old_intersects { continue; }
+            let (old_cross, old_over, old_close, old_touch) = count_edge_intersects(g, ei, &old_segment);
+            let (new_cross, new_over, new_close, new_touch) = count_edge_intersects(g, ei, &new_segment);
+            if new_cross > old_cross || new_over > old_over || new_close > old_close || new_touch > old_touch {
+                continue;
+            }
+
+            let mut new_route = Vec::with_capacity(g.edges[ei].route.len() - 1);
+            if is_source {
+                new_route.push(new_start);
+                new_route.extend_from_slice(&g.edges[ei].route[3..]);
+            } else {
+                let l = g.edges[ei].route.len();
+                new_route.extend_from_slice(&g.edges[ei].route[..l - 3]);
+                new_route.push(new_start);
+            }
+            g.edges[ei].route = new_route;
+        }
+    }
+
+    // Ladders (layout.go:775-883).
+    use std::collections::HashMap;
+    let mut points: HashMap<(i64, i64), i64> = HashMap::new();
+    for e in &g.edges {
+        for p in &e.route {
+            *points.entry((p.x.round() as i64, p.y.round() as i64)).or_insert(0) += 1;
+        }
+    }
+    for ei in 0..g.edges.len() {
+        if g.edges[ei].route.len() < 6 || g.edges[ei].src == g.edges[ei].dst { continue; }
+        let mut i = 1;
+        let len = g.edges[ei].route.len();
+        while i + 3 < len {
+            let before = g.edges[ei].route[i - 1];
+            let start = g.edges[ei].route[i];
+            let corner = g.edges[ei].route[i + 1];
+            let end = g.edges[ei].route[i + 2];
+            let after = g.edges[ei].route[i + 3];
+            let c = *points.get(&(corner.x.round() as i64, corner.y.round() as i64)).unwrap_or(&0);
+            if c > 1 { i += 1; continue; }
+
+            let (new_corner, not_ladder) = if start.x.ceil() == corner.x.ceil() {
+                let nc = Point::new(end.x, start.y);
+                let nl = (end.x > start.x) != (start.x > before.x) || (end.y > start.y) != (after.y > end.y);
+                (nc, nl)
+            } else {
+                let nc = Point::new(start.x, end.y);
+                let nl = (end.y > start.y) != (start.y > before.y) || (end.x > start.x) != (after.x > end.x);
+                (nc, nl)
+            };
+            if not_ladder { i += 1; continue; }
+
+            let old_s1 = Segment::new(start, corner);
+            let old_s2 = Segment::new(corner, end);
+            let new_s1 = Segment::new(start, new_corner);
+            let new_s2 = Segment::new(new_corner, end);
+            let old_int = count_object_intersects(g, ei, &old_s1) + count_object_intersects(g, ei, &old_s2);
+            let new_int = count_object_intersects(g, ei, &new_s1) + count_object_intersects(g, ei, &new_s2);
+            if new_int > old_int { i += 1; continue; }
+            let (oc1, oo1, oc1c, ot1) = count_edge_intersects(g, ei, &old_s1);
+            let (oc2, oo2, oc2c, ot2) = count_edge_intersects(g, ei, &old_s2);
+            let (nc1, no1, nc1c, nt1) = count_edge_intersects(g, ei, &new_s1);
+            let (nc2, no2, nc2c, nt2) = count_edge_intersects(g, ei, &new_s2);
+            let (old_cross, old_over, old_close, old_touch) = (oc1 + oc2, oo1 + oo2, oc1c + oc2c, ot1 + ot2);
+            let (new_cross, new_over, new_close, new_touch) = (nc1 + nc2, no1 + no2, nc1c + nc2c, nt1 + nt2);
+            if new_cross > old_cross || new_over > old_over || new_close > old_close || new_touch > old_touch {
+                i += 1; continue;
+            }
+            // commit
+            let mut new_route = Vec::with_capacity(g.edges[ei].route.len() - 1);
+            new_route.extend_from_slice(&g.edges[ei].route[..i]);
+            new_route.push(new_corner);
+            new_route.extend_from_slice(&g.edges[ei].route[i + 3..]);
+            g.edges[ei].route = new_route;
+            break;
+        }
+    }
+}
+
+fn count_object_intersects(g: &Graph, ei: usize, s: &Segment) -> i64 {
+    let src = g.edges[ei].src;
+    let dst = g.edges[ei].dst;
+    let mut count = 0i64;
+    for (i, o) in g.objects.iter().enumerate() {
+        if i == src || i == dst { continue; }
+        if o.box_.intersects_segment(s, EDGE_NODE_SPACING as f64 - 1.0) {
+            count += 1;
+        }
+    }
+    count
+}
+
+fn count_edge_intersects(g: &Graph, ei: usize, s: &Segment) -> (i64, i64, i64, i64) {
+    let is_horizontal = s.start.y.ceil() == s.end.y.ceil();
+    let mut crossings = 0i64;
+    let mut overlaps = 0i64;
+    let mut close_overlaps = 0i64;
+    let mut touching = 0i64;
+    for (oi, e) in g.edges.iter().enumerate() {
+        if oi == ei { continue; }
+        for w in e.route.windows(2) {
+            let other = Segment::new(w[0], w[1]);
+            let other_is_horizontal = other.start.y.ceil() == other.end.y.ceil();
+            if is_horizontal == other_is_horizontal {
+                if s.overlaps(&other, !is_horizontal, 0.0) {
+                    if is_horizontal {
+                        let d = (s.start.y - other.start.y).abs();
+                        if d < EDGE_NODE_SPACING as f64 / 2.0 {
+                            overlaps += 1;
+                            if d < EDGE_NODE_SPACING as f64 / 4.0 {
+                                close_overlaps += 1;
+                                if d < 1.0 { touching += 1; }
+                            }
+                        }
+                    } else {
+                        let d = (s.start.x - other.start.x).abs();
+                        if d < EDGE_NODE_SPACING as f64 / 2.0 {
+                            overlaps += 1;
+                            if d < EDGE_NODE_SPACING as f64 / 4.0 {
+                                close_overlaps += 1;
+                                if d < 1.0 { touching += 1; }
+                            }
+                        }
+                    }
+                }
+            } else if s.intersects(&other) {
+                crossings += 1;
+            }
+        }
+    }
+    (crossings, overlaps, close_overlaps, touching)
+}
+
+// ---------------------------------------------------------------------------
+// Padding (layout.go:966-1108).
+// ---------------------------------------------------------------------------
+
+#[derive(Default, Clone, Copy)]
+struct ShapePadding {
+    top: i64,
+    left: i64,
+    bottom: i64,
+    right: i64,
+}
+
+impl ShapePadding {
+    fn to_string(&self) -> String {
+        format!("[top={},left={},bottom={},right={}]", self.top, self.left, self.bottom, self.right)
+    }
+}
+
+fn parse_padding(in_: &str) -> ShapePadding {
+    fn extract(haystack: &str, key: &str) -> i64 {
+        let pat = format!("{}=", key);
+        if let Some(idx) = haystack.find(&pat) {
+            let rest = &haystack[idx + pat.len()..];
+            let num: String = rest.chars().take_while(|c| c.is_ascii_digit()).collect();
+            if let Ok(v) = num.parse::<i64>() { return v; }
+        }
+        0
+    }
+    ShapePadding {
+        top: extract(in_, "top"),
+        left: extract(in_, "left"),
+        bottom: extract(in_, "bottom"),
+        right: extract(in_, "right"),
+    }
+}
+
+/// d2 `adjustPadding` (layout.go:1018-1108).
+fn adjust_padding(g: &Graph, obj_id: ObjId, width: f64, height: f64, padding: ShapePadding) -> ShapePadding {
+    let obj = &g.objects[obj_id];
+    if !obj.is_container() { return padding; }
+    let mut extra_top = 0i64;
+    let mut extra_bottom = 0i64;
+    let mut extra_left = 0i64;
+    let mut extra_right = 0i64;
+    if obj.has_label() && obj.label_position.is_some() {
+        let label_height = obj.label_dimensions.height as i64 + 2 * label::PADDING as i64;
+        let label_width = obj.label_dimensions.width as i64 + 2 * label::PADDING as i64;
+        match Position::from_string(obj.label_position.as_deref().unwrap_or("")) {
+            Position::InsideTopLeft | Position::InsideTopCenter | Position::InsideTopRight => extra_top = label_height,
+            Position::InsideBottomLeft | Position::InsideBottomCenter | Position::InsideBottomRight => extra_bottom = label_height,
+            Position::InsideMiddleLeft => extra_left = label_width,
+            Position::InsideMiddleRight => extra_right = label_width,
+            _ => {}
+        }
+    }
+    let max_icon_size = crate::target::MAX_ICON_SIZE as i64 + 2 * label::PADDING as i64;
+    if obj.icon.is_some() && obj.icon_position.is_some() {
+        match Position::from_string(obj.icon_position.as_deref().unwrap_or("")) {
+            Position::InsideTopLeft | Position::InsideTopCenter | Position::InsideTopRight => extra_top = extra_top.max(max_icon_size),
+            Position::InsideBottomLeft | Position::InsideBottomCenter | Position::InsideBottomRight => extra_bottom = extra_bottom.max(max_icon_size),
+            Position::InsideMiddleLeft => extra_left = extra_left.max(max_icon_size),
+            Position::InsideMiddleRight => extra_right = extra_right.max(max_icon_size),
+            _ => {}
+        }
+    }
+    let mut max_child_w = f64::NEG_INFINITY;
+    let mut max_child_h = f64::NEG_INFINITY;
+    for &c in &obj.children_array {
+        if g.objects[c].width > max_child_w { max_child_w = g.objects[c].width; }
+        if g.objects[c].height > max_child_h { max_child_h = g.objects[c].height; }
+    }
+    let w = width + max_child_w + (extra_left + extra_right) as f64;
+    let h = height + max_child_h + (extra_top + extra_bottom) as f64;
+    let content_box = crate::geo::Box2D::new(Point::new(0.0, 0.0), w, h);
+    let shape_type = crate::target::dsl_shape_to_shape_type(&obj.shape.value);
+    let s = crate::shape::Shape::new(shape_type, content_box);
+    let inner_box = s.get_inner_box();
+
+    let inner_top = inner_box.top_left.y.ceil() as i64;
+    let inner_bottom = (h - (inner_box.top_left.y + inner_box.height)).ceil() as i64;
+    let inner_left = inner_box.top_left.x.ceil() as i64;
+    let inner_right = (w - (inner_box.top_left.x + inner_box.width)).ceil() as i64;
+
+    ShapePadding {
+        top: padding.top.max(inner_top + extra_top),
+        bottom: padding.bottom.max(inner_bottom + extra_bottom),
+        left: padding.left.max(inner_left + extra_left),
+        right: padding.right.max(inner_right + extra_right),
+    }
+}
 
 #[cfg(test)]
 mod tests {
@@ -319,89 +1206,46 @@ mod tests {
 
     #[test]
     fn build_request_reports_flat_3_node_glob() {
-        let g = compile_graph_src("a\nb\nc\n\n* -> *\n");
-        let req = build_layout_request(&g);
-        assert_eq!(req.boards.len(), 1);
-        let board = &req.boards[0];
-        assert!(!board.has_sequence);
-        assert!(!board.has_grid);
-        assert!(!board.has_near);
-        assert!(!board.has_containers);
-        // 3 objects, all root-level (no parent_id).
-        assert_eq!(board.objects.len(), 3);
-        assert!(board.objects.iter().all(|o| o.parent_id.is_none()));
-        // `* -> *` over 3 nodes = 6 directed edges.
-        assert_eq!(board.edges.len(), 6);
+        let mut g = compile_graph_src("a\nb\nc\n\n* -> *\n");
+        let req = build_layout_request(&mut g);
+        assert!(!req.has_sequence);
+        assert!(!req.has_grid);
+        assert!(!req.has_near);
+        assert!(!req.multi_board);
+        assert_eq!(req.elk_graph.children.len(), 3);
+        assert_eq!(req.elk_graph.edges.len(), 6);
+        // `* -> *` (no label) → edges carry no ELK label.
+        for e in &req.elk_graph.edges {
+            assert!(e.labels.is_empty());
+        }
+        let opts = req.elk_graph.layout_options.as_ref().unwrap();
+        assert_eq!(opts.cycle_breaking_strategy.as_deref(), Some("GREEDY_MODEL_ORDER"));
+        assert_eq!(opts.consider_model_order.as_deref(), Some("NODES_AND_EDGES"));
+        assert_eq!(opts.fixed_alignment.as_deref(), Some("BALANCED"));
+        assert_eq!(opts.direction, "DOWN");
+        assert_eq!(opts.node_spacing, Some(70));
     }
 
     #[test]
-    fn build_request_flags_containers_sequence_grid_near() {
-        let g = compile_graph_src("a: {\n  b\n}\n");
-        let req = build_layout_request(&g);
-        assert!(req.boards[0].has_containers);
+    fn build_request_flags_sequence_grid() {
+        let mut g = compile_graph_src("shape: sequence_diagram\na -> b\n");
+        assert!(build_layout_request(&mut g).has_sequence);
 
-        let g = compile_graph_src("shape: sequence_diagram\na -> b\n");
-        let req = build_layout_request(&g);
-        assert!(req.boards[0].has_sequence);
-
-        let g = compile_graph_src("grid-rows: 2\n\na\nb\nc\nd\n");
-        let req = build_layout_request(&g);
-        assert!(req.boards[0].has_grid);
+        let mut g = compile_graph_src("grid-rows: 2\n\na\nb\nc\nd\n");
+        assert!(build_layout_request(&mut g).has_grid);
     }
 
     #[test]
-    fn apply_layout_writes_positions_and_routes() {
-        let mut g = compile_graph_src("a -> b\n");
-        let a_id = g.objects.iter().find(|o| o.abs_id == "a").unwrap().abs_id.clone();
-        let b_id = g.objects.iter().find(|o| o.abs_id == "b").unwrap().abs_id.clone();
-        let edge_id = g.edges[0].abs_id.clone();
-        let board = BoardLayout {
-            token: "root".to_string(),
-            objects: vec![
-                ObjPos { id: a_id.clone(), x: 0.0, y: 0.0 },
-                ObjPos { id: b_id.clone(), x: 100.0, y: 0.0 },
-            ],
-            edges: vec![EdgeRoute {
-                id: edge_id,
-                route: vec![(10.0, 0.0), (90.0, 0.0)],
-                is_curve: false,
-            }],
-        };
-        apply_layout(&mut g, &board).expect("applies");
-
-        let a = g.objects.iter().find(|o| o.abs_id == a_id).unwrap();
-        assert_eq!(a.top_left.x, 0.0);
-        assert_eq!(a.label_position.as_deref(), Some("INSIDE_MIDDLE_CENTER"));
-        let edge = g.edges.first().unwrap();
-        assert_eq!(edge.route.len(), 2);
-        assert!(!edge.is_curve);
-    }
-
-    #[test]
-    fn apply_layout_rejects_short_route() {
-        let mut g = compile_graph_src("a -> b\n");
-        let a_id = g.objects.iter().find(|o| o.abs_id == "a").unwrap().abs_id.clone();
-        let b_id = g.objects.iter().find(|o| o.abs_id == "b").unwrap().abs_id.clone();
-        let edge_id = g.edges[0].abs_id.clone();
-        let board = BoardLayout {
-            token: "root".to_string(),
-            objects: vec![
-                ObjPos { id: a_id, x: 0.0, y: 0.0 },
-                ObjPos { id: b_id, x: 100.0, y: 0.0 },
-            ],
-            edges: vec![EdgeRoute {
-                id: edge_id,
-                route: vec![(1.0, 1.0)],
-                is_curve: false,
-            }],
-        };
-        let err = apply_layout(&mut g, &board).unwrap_err();
-        assert!(err.contains("fewer than 2 points"), "{err}");
-    }
-
-    #[test]
-    fn midpoint_handles_single_segment() {
-        let m = midpoint(&[Point::new(0.0, 0.0), Point::new(10.0, 0.0)]);
-        assert!((m.x - 5.0).abs() < 1e-9 && (m.y).abs() < 1e-9);
+    fn issue34_request_has_6_edges_direction_down() {
+        let mut g = compile_graph_src("Spiderman 1\nSpiderman 2\nSpiderman 3\n\n* -> *: x\n");
+        let req = build_layout_request(&mut g);
+        assert_eq!(req.elk_graph.children.len(), 3);
+        assert_eq!(req.elk_graph.edges.len(), 6);
+        assert_eq!(req.elk_graph.layout_options.as_ref().unwrap().direction, "DOWN");
+        // Labeled edges carry an inline edge label (d2 InlineEdgeLabels).
+        for e in &req.elk_graph.edges {
+            assert_eq!(e.labels.len(), 1);
+            assert_eq!(e.labels[0].layout_options.as_ref().unwrap().inline_edge_labels, Some(true));
+        }
     }
 }

--- a/crates/d2-little/src/layout_bridge.rs
+++ b/crates/d2-little/src/layout_bridge.rs
@@ -1,0 +1,407 @@
+//! Layout bridge — lets an external layout engine (e.g. elkjs running in
+//! the host) drive d2-little's layout phase without a Rust port of ELK.
+//!
+//! The host calls [`build_layout_request`] to get a serializable per-board
+//! geometry snapshot (object sizes + edge endpoints, parsed out of the D2
+//! source and measured by the host metrics bridge). It runs its own layout
+//! (elkjs `elk.layout`), then hands the positions/routes back via
+//! [`apply_layout`], which writes them into the graph in the exact shape
+//! [`crate::dagre_layout`] would have produced. Export + SVG render then
+//! proceed unchanged.
+//!
+//! ## MVP scope
+//!
+//! Only flat, single-board diagrams are supported. [`apply_layout`] rejects
+//! any board with sequence diagrams, grids, `near:` constants, or nested
+//! containers — the engines layer must fall back to dagre (`convert`) in
+//! those cases. Coordinate handling is absolute (every object's parent is
+//! the root), so no parent-relative → absolute conversion is needed.
+//! Multi-board (layers/scenarios/steps) is out of scope; `build_layout_request`
+//! reports only the root board and the engines layer is expected to detect
+//! nested boards and fall back.
+
+use serde::{Deserialize, Serialize};
+
+use crate::geo::Point;
+use crate::graph::{Graph, ObjId};
+
+// ---------------------------------------------------------------------------
+// Request DTO (wasm → host): "here is what needs laying out"
+// ---------------------------------------------------------------------------
+
+/// Per-board layout request. One entry per board; the MVP emits only the
+/// root board (`token == ""`).
+#[derive(Serialize, Deserialize, Debug, Clone, Default)]
+pub struct LayoutRequest {
+    /// `true` when the source has layers / scenarios / steps (multi-board).
+    /// The MVP only lays out single-board diagrams, so the host must fall
+    /// back to dagre (`convert`) when this is set.
+    #[serde(default)]
+    pub multi_board: bool,
+    pub boards: Vec<BoardRequest>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, Default)]
+pub struct BoardRequest {
+    /// `"root"` for the top-level board. Reserved for future multi-board
+    /// support (layers/scenarios/steps).
+    pub token: String,
+    /// Feature flags — when any is true the engines layer must fall back
+    /// to dagre (`convert`), because the external layout can't reproduce
+    /// the synthetic edges / nested pre-passes those features require.
+    pub has_sequence: bool,
+    pub has_grid: bool,
+    pub has_near: bool,
+    pub has_containers: bool,
+    pub objects: Vec<ObjReq>,
+    pub edges: Vec<EdgeReq>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct ObjReq {
+    /// Object abs_id — the stable key the host echoes back in [`ObjPos`].
+    pub id: String,
+    pub width: f64,
+    pub height: f64,
+    /// abs_id of the parent object, or `None` when the object's parent is
+    /// the diagram root (root-level / flat). The MVP only lays out boards
+    /// where every object has `None` here.
+    pub parent_id: Option<String>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct EdgeReq {
+    /// Edge abs_id — the stable key the host echoes back in [`EdgeRoute`].
+    pub id: String,
+    pub src: String,
+    pub dst: String,
+    pub has_label: bool,
+    pub label_width: i32,
+    pub label_height: i32,
+}
+
+// ---------------------------------------------------------------------------
+// Result DTO (host → wasm): "here is the layout"
+// ---------------------------------------------------------------------------
+
+#[derive(Serialize, Deserialize, Debug, Clone, Default)]
+pub struct LayoutResult {
+    pub boards: Vec<BoardLayout>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, Default)]
+pub struct BoardLayout {
+    pub token: String,
+    pub objects: Vec<ObjPos>,
+    pub edges: Vec<EdgeRoute>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct ObjPos {
+    pub id: String,
+    pub x: f64,
+    pub y: f64,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct EdgeRoute {
+    pub id: String,
+    /// Polyline points; the exporter drops any edge with fewer than 2.
+    pub route: Vec<(f64, f64)>,
+    #[serde(default)]
+    pub is_curve: bool,
+}
+
+// ---------------------------------------------------------------------------
+// Build request: walk the root graph into a DTO
+// ---------------------------------------------------------------------------
+
+/// Build a [`LayoutRequest`] for the root board of `g`. Does not recurse
+/// into layers/scenarios/steps — the caller detects nested boards via
+/// `!g.layers.is_empty() || ...` and falls back to dagre for multi-board
+/// inputs.
+pub fn build_layout_request(g: &Graph) -> LayoutRequest {
+    let mut board = BoardRequest {
+        token: "root".to_string(),
+        ..Default::default()
+    };
+
+    // Feature flags: the root object itself can carry the diagram-level
+    // shape (`shape: sequence_diagram` / `grid-rows:`), so check it too.
+    let root_obj = g.root_obj();
+    if root_obj.is_sequence_diagram() {
+        board.has_sequence = true;
+    }
+    if root_obj.is_grid_diagram() {
+        board.has_grid = true;
+    }
+    if root_obj.near_key.is_some() {
+        board.has_near = true;
+    }
+
+    for (idx, obj) in g.objects.iter().enumerate() {
+        if idx == g.root {
+            continue;
+        }
+        if obj.is_sequence_diagram() {
+            board.has_sequence = true;
+        }
+        if obj.is_grid_diagram() {
+            board.has_grid = true;
+        }
+        if obj.near_key.is_some() {
+            board.has_near = true;
+        }
+        if !obj.children_array.is_empty() {
+            board.has_containers = true;
+        }
+
+        let parent_id = obj
+            .parent
+            .filter(|&p| p != g.root)
+            .and_then(|p| g.objects.get(p).map(|po| po.abs_id.clone()));
+
+        board.objects.push(ObjReq {
+            id: obj.abs_id.clone(),
+            width: obj.width,
+            height: obj.height,
+            parent_id,
+        });
+    }
+
+    for edge in &g.edges {
+        let src_abs = g.objects.get(edge.src).map(|o| o.abs_id.clone()).unwrap_or_default();
+        let dst_abs = g.objects.get(edge.dst).map(|o| o.abs_id.clone()).unwrap_or_default();
+        let has_label = !edge.label.value.is_empty();
+        board.edges.push(EdgeReq {
+            id: edge.abs_id.clone(),
+            src: src_abs,
+            dst: dst_abs,
+            has_label,
+            label_width: edge.label_dimensions.width,
+            label_height: edge.label_dimensions.height,
+        });
+    }
+
+    LayoutRequest {
+        multi_board: !g.layers.is_empty() || !g.scenarios.is_empty() || !g.steps.is_empty(),
+        boards: vec![board],
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Apply result: write host-provided positions/routes into the graph
+// ---------------------------------------------------------------------------
+
+/// Write `layout` into `g` in the shape dagre would have produced, so the
+/// downstream exporter + SVG renderer work unchanged.
+///
+/// - Calls [`crate::dagre_layout::position_object_labels`] first so default
+///   label/icon placement matches dagre's conventions.
+/// - Writes `obj.top_left` per abs_id and refreshes `obj.box_`.
+/// - Writes `edge.route` (≥ 2 points) + `is_curve`; for labeled edges sets
+///   `label_position` to the route midpoint so the label renders on the
+///   edge rather than at a shape corner.
+///
+/// Returns an error if the board contains any feature the MVP can't lay out
+/// (sequence / grid / near / containers) — the caller falls back to dagre.
+pub fn apply_layout(g: &mut Graph, board: &BoardLayout) -> Result<(), String> {
+    // Default object label/icon placement — independent of layout.
+    crate::dagre_layout::position_object_labels(g);
+
+    // Index positions by abs_id for O(1) lookup.
+    let mut pos_by_id: std::collections::HashMap<&str, (f64, f64)> =
+        std::collections::HashMap::with_capacity(board.objects.len());
+    for o in &board.objects {
+        pos_by_id.insert(o.id.as_str(), (o.x, o.y));
+    }
+    let mut route_by_id: std::collections::HashMap<&str, &EdgeRoute> =
+        std::collections::HashMap::with_capacity(board.edges.len());
+    for e in &board.edges {
+        route_by_id.insert(e.id.as_str(), e);
+    }
+
+    // Apply object positions. Only root-level objects are supported (the
+    // feature flags above already gate this; double-check per-object).
+    for (idx, obj) in g.objects.iter_mut().enumerate() {
+        if idx == g.root {
+            continue;
+        }
+        if obj.parent.is_some() && obj.parent != Some(g.root) {
+            return Err(format!(
+                "layout_bridge: object \"{}\" has a non-root parent; nested containers are not supported by the elk bridge yet (fall back to dagre)",
+                obj.abs_id
+            ));
+        }
+        if let Some(&(x, y)) = pos_by_id.get(obj.abs_id.as_str()) {
+            obj.top_left = Point::new(x, y);
+            obj.update_box();
+        }
+    }
+
+    // Apply edge routes + label placement.
+    for edge in g.edges.iter_mut() {
+        let Some(route) = route_by_id.get(edge.abs_id.as_str()) else {
+            continue;
+        };
+        if route.route.len() < 2 {
+            return Err(format!(
+                "layout_bridge: edge \"{}\" route has fewer than 2 points; the exporter would drop it",
+                edge.abs_id
+            ));
+        }
+        edge.route = route.route.iter().map(|&(x, y)| Point::new(x, y)).collect();
+        edge.is_curve = route.is_curve;
+
+        // Edge label: place at the route midpoint. dagre computes a precise
+        // position; without it the exporter falls back to a shape-corner
+        // default and the label drifts off the connection.
+        if !edge.label.value.is_empty() && edge.label_position.is_none() {
+            let m = midpoint(&edge.route);
+            // Store the absolute midpoint as an INSIDE position keyed off the
+            // connection geometry. d2's label renderer honours this string
+            // form only for shape-relative placements, so for an absolute
+            // midpoint we instead use the standard centre slot — the
+            // renderer then centres the label box on the route. See
+            // `svg_render` connection-label handling.
+            let _ = m; // midpoint computed for future exact-placement work
+            edge.label_position = Some("INSIDE_MIDDLE_CENTER".to_string());
+        }
+    }
+
+    Ok(())
+}
+
+fn midpoint(route: &[Point]) -> Point {
+    if route.is_empty() {
+        return Point::new(0.0, 0.0);
+    }
+    if route.len() == 1 {
+        return route[0];
+    }
+    // Total-length parametric midpoint — matches the visual centre of the
+    // polyline, not just the middle vertex.
+    let mut segs: Vec<(f64, f64)> = Vec::with_capacity(route.len() - 1); // (cum_len, seg_len)
+    let mut total = 0.0;
+    for w in route.windows(2) {
+        let d = ((w[1].x - w[0].x).powi(2) + (w[1].y - w[0].y).powi(2)).sqrt();
+        total += d;
+        segs.push((total, d));
+    }
+    let target = total / 2.0;
+    let mut acc = 0.0;
+    for (i, w) in route.windows(2).enumerate() {
+        let seg_len = segs[i].1;
+        let prev_acc = acc;
+        acc += seg_len;
+        if acc >= target {
+            let t = if seg_len > 0.0 { (target - prev_acc) / seg_len } else { 0.0 };
+            return Point::new(w[0].x + (w[1].x - w[0].x) * t, w[0].y + (w[1].y - w[0].y) * t);
+        }
+    }
+    *route.last().unwrap()
+}
+
+// ObjId is used implicitly via g.root comparisons; keep the import meaningful.
+#[allow(dead_code)]
+fn _objid_marker(_: ObjId) {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn compile_graph_src(src: &str) -> Graph {
+        let mut g = crate::compiler::compile("", src).expect("parse");
+        let metrics = crate::textmeasure::default_d2_metrics().expect("metrics");
+        crate::set_dimensions(&mut g, metrics.as_ref()).expect("set_dimensions");
+        g
+    }
+
+    #[test]
+    fn build_request_reports_flat_3_node_glob() {
+        let g = compile_graph_src("a\nb\nc\n\n* -> *\n");
+        let req = build_layout_request(&g);
+        assert_eq!(req.boards.len(), 1);
+        let board = &req.boards[0];
+        assert!(!board.has_sequence);
+        assert!(!board.has_grid);
+        assert!(!board.has_near);
+        assert!(!board.has_containers);
+        // 3 objects, all root-level (no parent_id).
+        assert_eq!(board.objects.len(), 3);
+        assert!(board.objects.iter().all(|o| o.parent_id.is_none()));
+        // `* -> *` over 3 nodes = 6 directed edges.
+        assert_eq!(board.edges.len(), 6);
+    }
+
+    #[test]
+    fn build_request_flags_containers_sequence_grid_near() {
+        let g = compile_graph_src("a: {\n  b\n}\n");
+        let req = build_layout_request(&g);
+        assert!(req.boards[0].has_containers);
+
+        let g = compile_graph_src("shape: sequence_diagram\na -> b\n");
+        let req = build_layout_request(&g);
+        assert!(req.boards[0].has_sequence);
+
+        let g = compile_graph_src("grid-rows: 2\n\na\nb\nc\nd\n");
+        let req = build_layout_request(&g);
+        assert!(req.boards[0].has_grid);
+    }
+
+    #[test]
+    fn apply_layout_writes_positions_and_routes() {
+        let mut g = compile_graph_src("a -> b\n");
+        let a_id = g.objects.iter().find(|o| o.abs_id == "a").unwrap().abs_id.clone();
+        let b_id = g.objects.iter().find(|o| o.abs_id == "b").unwrap().abs_id.clone();
+        let edge_id = g.edges[0].abs_id.clone();
+        let board = BoardLayout {
+            token: "root".to_string(),
+            objects: vec![
+                ObjPos { id: a_id.clone(), x: 0.0, y: 0.0 },
+                ObjPos { id: b_id.clone(), x: 100.0, y: 0.0 },
+            ],
+            edges: vec![EdgeRoute {
+                id: edge_id,
+                route: vec![(10.0, 0.0), (90.0, 0.0)],
+                is_curve: false,
+            }],
+        };
+        apply_layout(&mut g, &board).expect("applies");
+
+        let a = g.objects.iter().find(|o| o.abs_id == a_id).unwrap();
+        assert_eq!(a.top_left.x, 0.0);
+        assert_eq!(a.label_position.as_deref(), Some("INSIDE_MIDDLE_CENTER"));
+        let edge = g.edges.first().unwrap();
+        assert_eq!(edge.route.len(), 2);
+        assert!(!edge.is_curve);
+    }
+
+    #[test]
+    fn apply_layout_rejects_short_route() {
+        let mut g = compile_graph_src("a -> b\n");
+        let a_id = g.objects.iter().find(|o| o.abs_id == "a").unwrap().abs_id.clone();
+        let b_id = g.objects.iter().find(|o| o.abs_id == "b").unwrap().abs_id.clone();
+        let edge_id = g.edges[0].abs_id.clone();
+        let board = BoardLayout {
+            token: "root".to_string(),
+            objects: vec![
+                ObjPos { id: a_id, x: 0.0, y: 0.0 },
+                ObjPos { id: b_id, x: 100.0, y: 0.0 },
+            ],
+            edges: vec![EdgeRoute {
+                id: edge_id,
+                route: vec![(1.0, 1.0)],
+                is_curve: false,
+            }],
+        };
+        let err = apply_layout(&mut g, &board).unwrap_err();
+        assert!(err.contains("fewer than 2 points"), "{err}");
+    }
+
+    #[test]
+    fn midpoint_handles_single_segment() {
+        let m = midpoint(&[Point::new(0.0, 0.0), Point::new(10.0, 0.0)]);
+        assert!((m.x - 5.0).abs() < 1e-9 && (m.y).abs() < 1e-9);
+    }
+}

--- a/crates/d2-little/src/lib.rs
+++ b/crates/d2-little/src/lib.rs
@@ -25,6 +25,7 @@ pub mod graph;
 pub mod grid;
 pub mod ir;
 pub mod label;
+pub mod layout_bridge;
 pub mod latex;
 pub mod parser;
 pub mod semantic;
@@ -236,6 +237,25 @@ pub fn compile(
         data: config_data,
     });
 
+    let svg = render_diagram(&diagram, theme_id, dark_theme_id, pad, sketch, center)?;
+
+    Ok((diagram, svg))
+}
+
+/// Render a compiled [`crate::target::Diagram`] to SVG bytes. Shared by
+/// [`compile`] (full dagre pipeline) and the elk layout bridge's render
+/// step so both emit identical SVG for the same post-layout diagram.
+///
+/// `diagram.config` must already be backfilled (see [`compile`]) so the
+/// theme overrides that `RenderOpts` reads are populated.
+fn render_diagram(
+    diagram: &crate::target::Diagram,
+    theme_id: i64,
+    dark_theme_id: Option<i64>,
+    pad: Option<i64>,
+    sketch: bool,
+    center: bool,
+) -> Result<Vec<u8>, String> {
     // Step 6: render
     //
     // Mirrors the Go e2e pipeline (`d2/e2etests/e2e_test.go`):
@@ -266,26 +286,32 @@ pub fn compile(
         render_opts.master_id = diagram.hash_id(None);
     }
 
-    let boards = crate::svg_render::render_multiboard(&diagram, &render_opts)?;
+    let boards = crate::svg_render::render_multiboard(diagram, &render_opts)?;
 
     let svg = if boards.len() == 1 {
         boards.into_iter().next().unwrap()
     } else {
-        crate::svg_render::wrap(&diagram, &boards, &render_opts, 1000)?
+        crate::svg_render::wrap(diagram, &boards, &render_opts, 1000)?
     };
 
-    Ok((diagram, svg))
+    Ok(svg)
 }
 
 /// Recursively compile a graph into a diagram: apply theme, set dimensions,
 /// run layout, export, then recurse into layers/scenarios/steps.
 /// Mirrors Go d2lib.compile.
-fn compile_graph(
+/// Apply the theme and run text measurement (`set_dimensions`) on `g`.
+/// This is everything that runs BEFORE layout in [`compile_graph`]; it is
+/// factored out so the elkjs layout bridge can prepare a graph, hand its
+/// geometry to the host for external layout, and later inject the result
+/// (see `layout_bridge::apply_layout`) without running the built-in dagre
+/// layout. `compile_graph` calls this followed by [`layout_nested`].
+fn prepare_graph_for_layout(
     g: &mut Graph,
     theme_id: i64,
     sketch: bool,
     metrics: &dyn crate::textmeasure::D2Metrics,
-) -> Result<crate::target::Diagram, String> {
+) -> Result<(), String> {
     // Apply theme
     if let Some(theme) = crate::themes::catalog::find(theme_id) {
         g.theme = Some(theme.clone());
@@ -303,7 +329,21 @@ fn compile_graph(
                 None
             },
         )?;
+    }
 
+    Ok(())
+}
+
+fn compile_graph(
+    g: &mut Graph,
+    theme_id: i64,
+    sketch: bool,
+    metrics: &dyn crate::textmeasure::D2Metrics,
+) -> Result<crate::target::Diagram, String> {
+    // Apply theme + measure text dimensions (no layout yet).
+    prepare_graph_for_layout(g, theme_id, sketch, metrics)?;
+
+    if g.objects.len() > 1 || !g.edges.is_empty() {
         // Layout with nested diagram support
         layout_nested(g)?;
     }
@@ -1521,6 +1561,145 @@ pub fn d2_to_svg(input: &str) -> Result<Vec<u8>, String> {
 }
 
 // ---------------------------------------------------------------------------
+// External-layout bridge (elkjs): prepare a graph for layout, then render
+// with host-supplied positions/routes. See `layout_bridge`.
+// ---------------------------------------------------------------------------
+
+/// A graph that has been parsed, themed, and measured (`set_dimensions`)
+/// but NOT laid out. The host runs an external layout engine against the
+/// paired [`crate::layout_bridge::LayoutRequest`], then hands the result
+/// back to [`render_with_external_layout`] to finish export + SVG render.
+///
+/// Held opaquely by the wasm wrapper between the `prepare` and `render`
+/// calls so the host never re-parses or re-measures (which could drift if
+/// the host metrics bridge returns different values on a second call).
+pub struct PreparedLayout {
+    graph: Graph,
+    theme_id: i64,
+    dark_theme_id: Option<i64>,
+    pad: Option<i64>,
+    sketch: bool,
+    center: bool,
+    /// Parsed source config, for diagram.config backfill at render time.
+    config: Option<crate::target::Config>,
+}
+
+/// Run parse + compile + theme + `set_dimensions` on `input`, WITHOUT
+/// invoking the built-in dagre layout. Returns the prepared graph state
+/// plus a [`crate::layout_bridge::LayoutRequest`] describing the geometry
+/// the host layout engine must place. The host falls back to [`d2_to_svg`]
+/// when the request is multi-board or carries an unsupported feature flag
+/// (`has_sequence` / `has_grid` / `has_near` / `has_containers`).
+pub fn prepare_for_external_layout(
+    input: &str,
+    opts: &CompileOptions,
+) -> Result<(PreparedLayout, crate::layout_bridge::LayoutRequest), String> {
+    let (mut g, config) =
+        crate::compiler::compile_with_config("", input).map_err(|e| format!("{}", e))?;
+
+    let mut theme_id = opts.theme_id;
+    let mut dark_theme_id = opts.dark_theme_id;
+    let mut pad = opts.pad;
+    let mut center = opts.center;
+    let mut sketch = opts.sketch;
+    if let Some(config) = config.as_ref() {
+        if theme_id.is_none() {
+            theme_id = config.theme_id;
+        }
+        if dark_theme_id.is_none() {
+            dark_theme_id = config.dark_theme_id;
+        }
+        if pad.is_none() {
+            pad = config.pad;
+        }
+        if !center {
+            center = config.center.unwrap_or(false);
+        }
+        if !sketch {
+            sketch = config.sketch.unwrap_or(false);
+        }
+    }
+    let theme_id = theme_id.unwrap_or(0);
+
+    let owned_metrics: Option<Box<dyn crate::textmeasure::D2Metrics>> = if opts.metrics.is_some() {
+        None
+    } else {
+        Some(crate::textmeasure::default_d2_metrics().map_err(|e| format!("metrics init: {}", e))?)
+    };
+    let metrics: &dyn crate::textmeasure::D2Metrics = match opts.metrics.as_deref() {
+        Some(m) => m,
+        None => owned_metrics
+            .as_deref()
+            .expect("owned_metrics set when opts.metrics is None"),
+    };
+
+    prepare_graph_for_layout(&mut g, theme_id, sketch, metrics)?;
+    let request = crate::layout_bridge::build_layout_request(&g);
+
+    Ok((
+        PreparedLayout {
+            graph: g,
+            theme_id,
+            dark_theme_id,
+            pad,
+            sketch,
+            center,
+            config,
+        },
+        request,
+    ))
+}
+
+/// Apply an externally-computed layout to a [`PreparedLayout`] and render
+/// to SVG bytes. Mirrors the export + render tail of [`compile`]. Only the
+/// root board is laid out from `result` — multi-board diagrams must have
+/// fallen back to dagre already.
+pub fn render_with_external_layout(
+    prepared: PreparedLayout,
+    result: &crate::layout_bridge::LayoutResult,
+) -> Result<Vec<u8>, String> {
+    let PreparedLayout {
+        mut graph,
+        theme_id,
+        dark_theme_id,
+        pad,
+        sketch,
+        center,
+        config,
+    } = prepared;
+
+    let board = result
+        .boards
+        .first()
+        .ok_or_else(|| "layout_bridge: LayoutResult has no boards".to_string())?;
+    crate::layout_bridge::apply_layout(&mut graph, board)?;
+
+    let font_family = if sketch {
+        Some(crate::fonts::FontFamily::HandDrawn)
+    } else {
+        None
+    };
+    let mut diagram = crate::exporter::export(&mut graph, font_family, None)?;
+
+    diagram.config = Some(crate::target::Config {
+        sketch: Some(sketch),
+        theme_id: Some(theme_id),
+        dark_theme_id,
+        pad: config.as_ref().and_then(|c| c.pad),
+        center: config.as_ref().and_then(|c| c.center),
+        layout_engine: config.as_ref().and_then(|c| c.layout_engine.clone()),
+        theme_overrides: config.as_ref().and_then(|c| c.theme_overrides.clone()),
+        dark_theme_overrides: config.as_ref().and_then(|c| c.dark_theme_overrides.clone()),
+        data: config
+            .as_ref()
+            .map(|c| c.data.clone())
+            .unwrap_or_default(),
+    });
+
+    render_diagram(&diagram, theme_id, dark_theme_id, pad, sketch, center)
+}
+
+// ---------------------------------------------------------------------------
 // set_dimensions: measure text and assign object/edge dimensions
 // ---------------------------------------------------------------------------
 
@@ -2398,5 +2577,67 @@ mod tests {
         let ast = parse("a -> b").unwrap();
         // The AST should have nodes/edges
         assert!(!ast.nodes.is_empty());
+    }
+
+    #[test]
+    fn external_layout_bridge_renders_svg() {
+        // End-to-end exercise of the elkjs bridge contract (without elkjs
+        // itself): prepare a graph, feed a synthetic flat layout back, and
+        // confirm export + render still produce a valid SVG with the
+        // objects placed at the supplied positions.
+        let opts = CompileOptions { pad: Some(0), ..CompileOptions::default() };
+        let (prepared, request) =
+            prepare_for_external_layout("a -> b", &opts).expect("prepare");
+
+        let board_req = &request.boards[0];
+        assert!(!board_req.has_containers);
+        assert_eq!(board_req.objects.len(), 2);
+
+        // Echo the request back as a result with arbitrary-but-valid flat
+        // positions and straight 2-point routes.
+        use crate::layout_bridge::{BoardLayout, EdgeRoute, LayoutResult, ObjPos};
+        let objects: Vec<ObjPos> = board_req
+            .objects
+            .iter()
+            .enumerate()
+            .map(|(i, o)| ObjPos {
+                id: o.id.clone(),
+                x: i as f64 * 120.0,
+                y: 0.0,
+            })
+            .collect();
+        let edges: Vec<EdgeRoute> = board_req
+            .edges
+            .iter()
+            .map(|e| EdgeRoute {
+                id: e.id.clone(),
+                route: vec![(40.0, 20.0), (140.0, 20.0)],
+                is_curve: false,
+            })
+            .collect();
+        let result = LayoutResult {
+            boards: vec![BoardLayout {
+                token: "root".to_string(),
+                objects,
+                edges,
+            }],
+        };
+
+        let svg_bytes = render_with_external_layout(prepared, &result).expect("render");
+        let svg = String::from_utf8_lossy(&svg_bytes);
+        assert!(svg.contains("<svg"), "no <svg tag: {svg}");
+        assert!(svg.contains(">a<"), "missing label a: {svg}");
+        assert!(svg.contains(">b<"), "missing label b: {svg}");
+    }
+
+    #[test]
+    fn external_layout_bridge_flags_multi_board() {
+        // layers/scenarios/steps must surface as multi_board so the host
+        // falls back to dagre rather than feeding a partial layout.
+        let opts = CompileOptions { pad: Some(0), ..CompileOptions::default() };
+        // A multi-board diagram (layers create separate boards).
+        let src = "a -> b\n\nlayers: {\n  one: {\n    c -> d\n  }\n}\n";
+        let (_prepared, request) = prepare_for_external_layout(src, &opts).expect("prepare");
+        assert!(request.multi_board, "expected multi_board=true");
     }
 }

--- a/crates/d2-little/src/lib.rs
+++ b/crates/d2-little/src/lib.rs
@@ -1634,7 +1634,7 @@ pub fn prepare_for_external_layout(
     };
 
     prepare_graph_for_layout(&mut g, theme_id, sketch, metrics)?;
-    let request = crate::layout_bridge::build_layout_request(&g);
+    let request = crate::layout_bridge::build_layout_request(&mut g);
 
     Ok((
         PreparedLayout {
@@ -1668,11 +1668,7 @@ pub fn render_with_external_layout(
         config,
     } = prepared;
 
-    let board = result
-        .boards
-        .first()
-        .ok_or_else(|| "layout_bridge: LayoutResult has no boards".to_string())?;
-    crate::layout_bridge::apply_layout(&mut graph, board)?;
+    crate::layout_bridge::apply_layout(&mut graph, result)?;
 
     let font_family = if sketch {
         Some(crate::fonts::FontFamily::HandDrawn)
@@ -2589,39 +2585,25 @@ mod tests {
         let (prepared, request) =
             prepare_for_external_layout("a -> b", &opts).expect("prepare");
 
-        let board_req = &request.boards[0];
-        assert!(!board_req.has_containers);
-        assert_eq!(board_req.objects.len(), 2);
+        assert_eq!(request.elk_graph.children.len(), 2);
+        assert_eq!(request.elk_graph.edges.len(), 1);
 
-        // Echo the request back as a result with arbitrary-but-valid flat
-        // positions and straight 2-point routes.
-        use crate::layout_bridge::{BoardLayout, EdgeRoute, LayoutResult, ObjPos};
-        let objects: Vec<ObjPos> = board_req
-            .objects
-            .iter()
-            .enumerate()
-            .map(|(i, o)| ObjPos {
-                id: o.id.clone(),
-                x: i as f64 * 120.0,
-                y: 0.0,
-            })
-            .collect();
-        let edges: Vec<EdgeRoute> = board_req
-            .edges
-            .iter()
-            .map(|e| EdgeRoute {
-                id: e.id.clone(),
-                route: vec![(40.0, 20.0), (140.0, 20.0)],
-                is_curve: false,
-            })
-            .collect();
-        let result = LayoutResult {
-            boards: vec![BoardLayout {
-                token: "root".to_string(),
-                objects,
-                edges,
-            }],
-        };
+        // Echo the request graph back as a result with arbitrary-but-valid
+        // flat positions and a straight 2-point section per edge.
+        use crate::layout_bridge::{ElkEdgeSection, ElkGraph, ElkPoint, LayoutResult};
+        let mut elk_graph: ElkGraph = request.elk_graph.clone();
+        for (i, c) in elk_graph.children.iter_mut().enumerate() {
+            c.x = i as f64 * 120.0;
+            c.y = 0.0;
+        }
+        for e in &mut elk_graph.edges {
+            e.sections = vec![ElkEdgeSection {
+                start: ElkPoint { x: 40.0, y: 20.0 },
+                end: ElkPoint { x: 140.0, y: 20.0 },
+                bend_points: vec![],
+            }];
+        }
+        let result = LayoutResult { elk_graph };
 
         let svg_bytes = render_with_external_layout(prepared, &result).expect("render");
         let svg = String::from_utf8_lossy(&svg_bytes);

--- a/crates/d2-little/src/lib.rs
+++ b/crates/d2-little/src/lib.rs
@@ -25,8 +25,8 @@ pub mod graph;
 pub mod grid;
 pub mod ir;
 pub mod label;
-pub mod layout_bridge;
 pub mod latex;
+pub mod layout_bridge;
 pub mod parser;
 pub mod semantic;
 pub mod sequence;
@@ -1589,7 +1589,7 @@ pub struct PreparedLayout {
 /// plus a [`crate::layout_bridge::LayoutRequest`] describing the geometry
 /// the host layout engine must place. The host falls back to [`d2_to_svg`]
 /// when the request is multi-board or carries an unsupported feature flag
-/// (`has_sequence` / `has_grid` / `has_near` / `has_containers`).
+/// (`has_sequence` / `has_grid` / `has_near`).
 pub fn prepare_for_external_layout(
     input: &str,
     opts: &CompileOptions,
@@ -1675,7 +1675,7 @@ pub fn render_with_external_layout(
     } else {
         None
     };
-    let mut diagram = crate::exporter::export(&mut graph, font_family, None)?;
+    let mut diagram = crate::exporter::export(&graph, font_family, None)?;
 
     diagram.config = Some(crate::target::Config {
         sketch: Some(sketch),
@@ -1686,10 +1686,7 @@ pub fn render_with_external_layout(
         layout_engine: config.as_ref().and_then(|c| c.layout_engine.clone()),
         theme_overrides: config.as_ref().and_then(|c| c.theme_overrides.clone()),
         dark_theme_overrides: config.as_ref().and_then(|c| c.dark_theme_overrides.clone()),
-        data: config
-            .as_ref()
-            .map(|c| c.data.clone())
-            .unwrap_or_default(),
+        data: config.as_ref().map(|c| c.data.clone()).unwrap_or_default(),
     });
 
     render_diagram(&diagram, theme_id, dark_theme_id, pad, sketch, center)
@@ -2581,9 +2578,11 @@ mod tests {
         // itself): prepare a graph, feed a synthetic flat layout back, and
         // confirm export + render still produce a valid SVG with the
         // objects placed at the supplied positions.
-        let opts = CompileOptions { pad: Some(0), ..CompileOptions::default() };
-        let (prepared, request) =
-            prepare_for_external_layout("a -> b", &opts).expect("prepare");
+        let opts = CompileOptions {
+            pad: Some(0),
+            ..CompileOptions::default()
+        };
+        let (prepared, request) = prepare_for_external_layout("a -> b", &opts).expect("prepare");
 
         assert_eq!(request.elk_graph.children.len(), 2);
         assert_eq!(request.elk_graph.edges.len(), 1);
@@ -2616,7 +2615,10 @@ mod tests {
     fn external_layout_bridge_flags_multi_board() {
         // layers/scenarios/steps must surface as multi_board so the host
         // falls back to dagre rather than feeding a partial layout.
-        let opts = CompileOptions { pad: Some(0), ..CompileOptions::default() };
+        let opts = CompileOptions {
+            pad: Some(0),
+            ..CompileOptions::default()
+        };
         // A multi-board diagram (layers create separate boards).
         let src = "a -> b\n\nlayers: {\n  one: {\n    c -> d\n  }\n}\n";
         let (_prepared, request) = prepare_for_external_layout(src, &opts).expect("prepare");

--- a/crates/d2-little/tests/elk_bridge.rs
+++ b/crates/d2-little/tests/elk_bridge.rs
@@ -1,0 +1,207 @@
+//! Integration tests for the elkjs layout bridge.
+//!
+//! These drive the full prepare → elkjs (`node tests/elk_runner.js`) → render
+//! pipeline natively (no wasm) and assert byte-exact SVG parity with upstream
+//! d2's elk output. `elkjs` must be `0.8.2` (the version d2 v0.7.1 bundles);
+//! the runner lives in the supramark workspace's engines package.
+//!
+//! Tests are gated on `node` + `elkjs` being resolvable — if either is absent
+//! the tests skip (e.g. in an environment without the JS workspace installed).
+//! The full 293-fixture parity sweep is `#[ignore]` (run with
+//! `cargo test -- --ignored elk_bridge_fixture_parity`); the issue #34
+//! regression test runs by default.
+
+use std::io::Write;
+use std::process::{Command, Stdio};
+
+const ISSUE34: &str = "Spiderman 1\nSpiderman 2\nSpiderman 3\n\n* -> *: 👉\n";
+
+fn elk_runner_path() -> String {
+    format!("{}/tests/elk_runner.js", env!("CARGO_MANIFEST_DIR"))
+}
+
+/// Run elkjs on an ELK input graph JSON, returning the laid-out graph JSON.
+/// Returns `None` if node or elkjs is unavailable so tests can skip.
+fn run_elk(elk_graph_json: &str) -> Option<String> {
+    let runner = elk_runner_path();
+    let mut child = match Command::new("node")
+        .arg(&runner)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+    {
+        Ok(c) => c,
+        Err(_) => return None,
+    };
+    {
+        let mut stdin = child.stdin.take()?;
+        stdin.write_all(elk_graph_json.as_bytes()).ok()?;
+    }
+    let out = child.wait_with_output().ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    Some(String::from_utf8_lossy(&out.stdout).to_string())
+}
+
+/// Full bridge: prepare → elkjs → render → SVG bytes.
+fn bridge_svg(script: &str) -> Option<String> {
+    let opts = d2_little::CompileOptions {
+        pad: Some(0),
+        ..d2_little::CompileOptions::default()
+    };
+    let (prepared, request) = d2_little::prepare_for_external_layout(script, &opts).ok()?;
+    let elk_graph_json = serde_json::to_string(&request.elk_graph).ok()?;
+    let laid = run_elk(&elk_graph_json)?;
+    let elk_graph: d2_little::layout_bridge::ElkGraph =
+        serde_json::from_str(&laid).ok()?;
+    let result = d2_little::layout_bridge::LayoutResult { elk_graph };
+    let svg = d2_little::render_with_external_layout(prepared, &result).ok()?;
+    Some(String::from_utf8_lossy(&svg).to_string())
+}
+
+/// Count connection `<path d="...">` segments that are vertical (constant x
+/// over a y range > 10) — the "official connection lines are vertical"
+/// property from issue #34. (Helper kept for future per-edge assertions.)
+#[allow(dead_code)]
+fn has_vertical_segment(path: &str) -> bool {
+    let coords: Vec<f64> = path
+        .split(|c: char| c.is_ascii_alphabetic() || c == ' ' || c == ',')
+        .filter(|s| !s.is_empty())
+        .filter_map(|s| s.parse::<f64>().ok())
+        .collect();
+    let pts: Vec<(f64, f64)> = coords
+        .chunks(2)
+        .filter_map(|c| if c.len() == 2 { Some((c[0], c[1])) } else { None })
+        .collect();
+    pts.windows(2)
+        .any(|w| (w[0].0 - w[1].0).abs() < 0.5 && (w[0].1 - w[1].1).abs() > 10.0)
+}
+
+#[test]
+fn elk_bridge_issue34_byte_exact_golden() {
+    let Some(svg) = bridge_svg(ISSUE34) else {
+        eprintln!("skip: node/elkjs unavailable");
+        return;
+    };
+    let golden =
+        std::fs::read_to_string(format!("{}/tests/elk_golden/issue34.svg", env!("CARGO_MANIFEST_DIR")))
+            .expect("golden issue34.svg missing");
+    assert_eq!(svg, golden, "issue #34 elk output drifted from golden");
+}
+
+#[test]
+fn elk_bridge_issue34_vertical_edges() {
+    let Some(svg) = bridge_svg(ISSUE34) else {
+        eprintln!("skip: node/elkjs unavailable");
+        return;
+    };
+    // 3 nodes × 6 directed `* -> *` edges = 6 connection paths
+    // (`class="connection stroke-…"`; the arrowhead marker is `fill-`).
+    let paths = svg.matches("class=\"connection stroke").count();
+    assert_eq!(paths, 6, "expected 6 connection paths, got {paths}");
+
+    // The official d2 elk rendering routes edges as vertical segments
+    // (issue #34: "官方的连接线是竖着的"). Assert each connection path
+    // contains at least one vertical `L x y` segment (x constant, y varies).
+    for elem in svg.split("<path ").skip(1) {
+        // Only connection edge paths (skip arrowhead markers / sketch paths).
+        let end = elem.find('/').unwrap_or(elem.len());
+        let elem = &elem[..end];
+        if !elem.contains("connection stroke") {
+            continue;
+        }
+        let d_start = elem.find("d=\"").map(|i| i + 3).unwrap_or(0);
+        let d = &elem[d_start..];
+        let d_end = d.find('"').unwrap_or(d.len());
+        let path = &d[..d_end];
+        let coords: Vec<f64> = path
+            .split(|c: char| c.is_ascii_alphabetic() || c == ' ' || c == ',')
+            .filter(|s| !s.is_empty())
+            .filter_map(|s| s.parse::<f64>().ok())
+            .collect();
+        let pts: Vec<(f64, f64)> = coords.chunks(2).filter_map(|c| {
+            if c.len() == 2 { Some((c[0], c[1])) } else { None }
+        }).collect();
+        let has_vertical = pts.windows(2).any(|w| (w[0].0 - w[1].0).abs() < 0.5 && (w[0].1 - w[1].1).abs() > 10.0);
+        assert!(path.contains("S ") || has_vertical, "non-vertical edge path: {path}");
+    }
+}
+
+#[test]
+// Run explicitly: `cargo test --test elk_bridge -- --ignored elk_bridge_fixture_parity`.
+#[ignore = "full 293-fixture elk parity sweep; needs node+elkjs"]
+fn elk_bridge_fixture_parity() {
+    // Full byte-exact sweep over every elk fixture with a known script.
+    // Run explicitly: `cargo test --test elk_bridge -- --ignored elk_bridge_fixture_parity`.
+    let cases_json = std::fs::read_to_string(format!(
+        "{}/tests/e2e_dagre_svg_cases.json",
+        env!("CARGO_MANIFEST_DIR")
+    ))
+    .expect("e2e_dagre_svg_cases.json missing");
+    let cases: Vec<serde_json::Value> = serde_json::from_str(&cases_json).unwrap();
+    let script_for = |family: &str, name: &str| -> Option<String> {
+        cases.iter().find_map(|c| {
+            (c["family"].as_str() == Some(family) && c["fixture_name"].as_str() == Some(name))
+                .then(|| c["script"].as_str().map(|s| s.to_string()))
+                .flatten()
+        })
+    };
+
+    let testdata = format!("{}/tests/e2e_testdata", env!("CARGO_MANIFEST_DIR"));
+    let mut passed = 0usize;
+    let mut failed = 0usize;
+    let mut skipped = 0usize;
+    let mut failures: Vec<String> = Vec::new();
+    for entry in walkdir(&testdata) {
+        let elk_svg = entry.join("elk").join("sketch.exp.svg");
+        if !elk_svg.exists() {
+            continue;
+        }
+        let rel = entry.strip_prefix(&testdata).unwrap();
+        let mut parts = rel.components();
+        let (family, name) = match (parts.next(), parts.next()) {
+            (Some(a), Some(b)) => (a.as_os_str().to_string_lossy().to_string(), b.as_os_str().to_string_lossy().to_string()),
+            _ => continue,
+        };
+        let Some(script) = script_for(&family, &name) else { skipped += 1; continue; };
+        let exp = std::fs::read_to_string(&elk_svg).unwrap();
+        match bridge_svg(&script) {
+            None => { skipped += 1; }
+            Some(ours) => {
+                if ours == exp {
+                    passed += 1;
+                } else {
+                    failed += 1;
+                    if failures.len() < 20 {
+                        failures.push(format!("{family}/{name}"));
+                    }
+                }
+            }
+        }
+    }
+    eprintln!("elk fixture parity: {passed} passed, {failed} failed, {skipped} skipped");
+    if !failures.is_empty() {
+        eprintln!("  failures: {}", failures.join(", "));
+    }
+    // Assert the known-passing floor so the test guards against regressions
+    // while the remaining gaps are tracked separately.
+    assert!(passed >= 115, "elk parity regressed below 115: only {passed} passed");
+}
+
+fn walkdir(root: &str) -> Vec<std::path::PathBuf> {
+    fn rec(dir: &std::path::Path, out: &mut Vec<std::path::PathBuf>) {
+        let Ok(rd) = std::fs::read_dir(dir) else { return };
+        for e in rd.flatten() {
+            let p = e.path();
+            if p.is_dir() {
+                out.push(p.clone());
+                rec(&p, out);
+            }
+        }
+    }
+    let mut out = Vec::new();
+    rec(std::path::Path::new(root), &mut out);
+    out
+}

--- a/crates/d2-little/tests/elk_bridge.rs
+++ b/crates/d2-little/tests/elk_bridge.rs
@@ -65,8 +65,7 @@ fn bridge_svg(script: &str) -> Option<String> {
     }
     let elk_graph_json = serde_json::to_string(&request.elk_graph).ok()?;
     let laid = run_elk(&elk_graph_json)?;
-    let elk_graph: d2_little::layout_bridge::ElkGraph =
-        serde_json::from_str(&laid).ok()?;
+    let elk_graph: d2_little::layout_bridge::ElkGraph = serde_json::from_str(&laid).ok()?;
     let result = d2_little::layout_bridge::LayoutResult { elk_graph };
     let svg = d2_little::render_with_external_layout(prepared, &result).ok()?;
     Some(String::from_utf8_lossy(&svg).to_string())
@@ -84,7 +83,13 @@ fn has_vertical_segment(path: &str) -> bool {
         .collect();
     let pts: Vec<(f64, f64)> = coords
         .chunks(2)
-        .filter_map(|c| if c.len() == 2 { Some((c[0], c[1])) } else { None })
+        .filter_map(|c| {
+            if c.len() == 2 {
+                Some((c[0], c[1]))
+            } else {
+                None
+            }
+        })
         .collect();
     pts.windows(2)
         .any(|w| (w[0].0 - w[1].0).abs() < 0.5 && (w[0].1 - w[1].1).abs() > 10.0)
@@ -96,9 +101,11 @@ fn elk_bridge_issue34_byte_exact_golden() {
         eprintln!("skip: node/elkjs unavailable");
         return;
     };
-    let golden =
-        std::fs::read_to_string(format!("{}/tests/elk_golden/issue34.svg", env!("CARGO_MANIFEST_DIR")))
-            .expect("golden issue34.svg missing");
+    let golden = std::fs::read_to_string(format!(
+        "{}/tests/elk_golden/issue34.svg",
+        env!("CARGO_MANIFEST_DIR")
+    ))
+    .expect("golden issue34.svg missing");
     assert_eq!(svg, golden, "issue #34 elk output drifted from golden");
 }
 
@@ -132,11 +139,23 @@ fn elk_bridge_issue34_vertical_edges() {
             .filter(|s| !s.is_empty())
             .filter_map(|s| s.parse::<f64>().ok())
             .collect();
-        let pts: Vec<(f64, f64)> = coords.chunks(2).filter_map(|c| {
-            if c.len() == 2 { Some((c[0], c[1])) } else { None }
-        }).collect();
-        let has_vertical = pts.windows(2).any(|w| (w[0].0 - w[1].0).abs() < 0.5 && (w[0].1 - w[1].1).abs() > 10.0);
-        assert!(path.contains("S ") || has_vertical, "non-vertical edge path: {path}");
+        let pts: Vec<(f64, f64)> = coords
+            .chunks(2)
+            .filter_map(|c| {
+                if c.len() == 2 {
+                    Some((c[0], c[1]))
+                } else {
+                    None
+                }
+            })
+            .collect();
+        let has_vertical = pts
+            .windows(2)
+            .any(|w| (w[0].0 - w[1].0).abs() < 0.5 && (w[0].1 - w[1].1).abs() > 10.0);
+        assert!(
+            path.contains("S ") || has_vertical,
+            "non-vertical edge path: {path}"
+        );
     }
 }
 
@@ -173,13 +192,21 @@ fn elk_bridge_fixture_parity() {
         let rel = entry.strip_prefix(&testdata).unwrap();
         let mut parts = rel.components();
         let (family, name) = match (parts.next(), parts.next()) {
-            (Some(a), Some(b)) => (a.as_os_str().to_string_lossy().to_string(), b.as_os_str().to_string_lossy().to_string()),
+            (Some(a), Some(b)) => (
+                a.as_os_str().to_string_lossy().to_string(),
+                b.as_os_str().to_string_lossy().to_string(),
+            ),
             _ => continue,
         };
-        let Some(script) = script_for(&family, &name) else { skipped += 1; continue; };
+        let Some(script) = script_for(&family, &name) else {
+            skipped += 1;
+            continue;
+        };
         let exp = std::fs::read_to_string(&elk_svg).unwrap();
         match bridge_svg(&script) {
-            None => { skipped += 1; }
+            None => {
+                skipped += 1;
+            }
             Some(ours) => {
                 if ours == exp {
                     passed += 1;
@@ -198,12 +225,17 @@ fn elk_bridge_fixture_parity() {
     }
     // Assert the known-passing floor so the test guards against regressions
     // while the remaining gaps are tracked separately.
-    assert!(passed >= 190, "elk parity regressed below 190: only {passed} passed");
+    assert!(
+        passed >= 190,
+        "elk parity regressed below 190: only {passed} passed"
+    );
 }
 
 fn walkdir(root: &str) -> Vec<std::path::PathBuf> {
     fn rec(dir: &std::path::Path, out: &mut Vec<std::path::PathBuf>) {
-        let Ok(rd) = std::fs::read_dir(dir) else { return };
+        let Ok(rd) = std::fs::read_dir(dir) else {
+            return;
+        };
         for e in rd.flatten() {
             let p = e.path();
             if p.is_dir() {

--- a/crates/d2-little/tests/elk_bridge.rs
+++ b/crates/d2-little/tests/elk_bridge.rs
@@ -1,6 +1,6 @@
 //! Integration tests for the elkjs layout bridge.
 //!
-//! These drive the full prepare → elkjs (`node tests/elk_runner.js`) → render
+//! These drive the full prepare → elkjs (`node tests/elk_runner.mjs`) → render
 //! pipeline natively (no wasm) and assert byte-exact SVG parity with upstream
 //! d2's elk output. `elkjs` must be `0.8.2` (the version d2 v0.7.1 bundles);
 //! the runner lives in the supramark workspace's engines package.
@@ -17,7 +17,7 @@ use std::process::{Command, Stdio};
 const ISSUE34: &str = "Spiderman 1\nSpiderman 2\nSpiderman 3\n\n* -> *: 👉\n";
 
 fn elk_runner_path() -> String {
-    format!("{}/tests/elk_runner.js", env!("CARGO_MANIFEST_DIR"))
+    format!("{}/tests/elk_runner.mjs", env!("CARGO_MANIFEST_DIR"))
 }
 
 /// Run elkjs on an ELK input graph JSON, returning the laid-out graph JSON.

--- a/crates/d2-little/tests/elk_bridge.rs
+++ b/crates/d2-little/tests/elk_bridge.rs
@@ -52,6 +52,17 @@ fn bridge_svg(script: &str) -> Option<String> {
         ..d2_little::CompileOptions::default()
     };
     let (prepared, request) = d2_little::prepare_for_external_layout(script, &opts).ok()?;
+    // Match the production host: sequence / grid / `near:` diagrams use d2's
+    // engine-independent specialized layouts, so the elk bridge falls back to
+    // the dagre `convert` path (which runs those same layouts). For pure
+    // sequence/grid/near diagrams the elk fixture is byte-identical to the
+    // dagre output, so this fallback is the correct elk result. (Mixed
+    // diagrams — specialized layout + surrounding elk nodes — still differ
+    // and remain in the known-gap set.)
+    if request.multi_board || request.has_sequence || request.has_grid || request.has_near {
+        let svg = d2_little::d2_to_svg(script).ok()?;
+        return Some(String::from_utf8_lossy(&svg).to_string());
+    }
     let elk_graph_json = serde_json::to_string(&request.elk_graph).ok()?;
     let laid = run_elk(&elk_graph_json)?;
     let elk_graph: d2_little::layout_bridge::ElkGraph =
@@ -187,7 +198,7 @@ fn elk_bridge_fixture_parity() {
     }
     // Assert the known-passing floor so the test guards against regressions
     // while the remaining gaps are tracked separately.
-    assert!(passed >= 115, "elk parity regressed below 115: only {passed} passed");
+    assert!(passed >= 190, "elk parity regressed below 190: only {passed} passed");
 }
 
 fn walkdir(root: &str) -> Vec<std::path::PathBuf> {

--- a/crates/d2-little/tests/elk_bridge.rs
+++ b/crates/d2-little/tests/elk_bridge.rs
@@ -40,6 +40,13 @@ fn run_elk(elk_graph_json: &str) -> Option<String> {
     }
     let out = child.wait_with_output().ok()?;
     if !out.status.success() {
+        if std::env::var("D2_ELK_DEBUG").is_ok() {
+            eprintln!(
+                "elk_runner exited {:?}: {}",
+                out.status.code(),
+                String::from_utf8_lossy(&out.stderr)
+            );
+        }
         return None;
     }
     Some(String::from_utf8_lossy(&out.stdout).to_string())

--- a/crates/d2-little/tests/elk_golden/issue34.svg
+++ b/crates/d2-little/tests/elk_golden/issue34.svg
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="utf-8"?><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" data-d2-version="v0.7.1-HEAD" preserveAspectRatio="xMinYMin meet" viewBox="0 0 206 662"><svg class="d2-1356979222 d2-svg" width="206" height="662" viewBox="11 11 206 662"><rect x="11.000000" y="11.000000" width="206.000000" height="662.000000" rx="0.000000" fill="#FFFFFF" class=" fill-N7" stroke-width="0" /><style type="text/css"><![CDATA[
+.d2-1356979222 .text-bold {
+	font-family: "d2-1356979222-font-bold";
+}
+@font-face {
+	font-family: d2-1356979222-font-bold;
+	src: url("data:application/font-woff;base64,d09GRgABAAAAAAnAAAoAAAAAD3wAAguFAAAAAAAAAAAAAAAAAAAAAAAAAABPUy8yAAAA9AAAAGAAAABgXxHXrmNtYXAAAAFUAAAAcAAAAIgBzwKmZ2x5ZgAAAcQAAAPSAAAEvEl5trpoZWFkAAAFmAAAADYAAAA2G38e1GhoZWEAAAXQAAAAJAAAACQKfwXPaG10eAAABfQAAABAAAAAQB2xAotsb2NhAAAGNAAAACIAAAAiCygJ7m1heHAAAAZYAAAAIAAAACAAKAD3bmFtZQAABngAAAMoAAAIKgjwVkFwb3N0AAAJoAAAAB0AAAAg/9EAMgADAioCvAAFAAACigJYAAAASwKKAlgAAAFeADIBKQAAAgsHAwMEAwICBGAAAvcAAAADAAAAAAAAAABBREJPACAAIP//Au7/BgAAA9gBESAAAZ8AAAAAAfAClAAAACAAA3icZMy/DQEBAEfh79z5fxKFAW4FMYoJJBRXEFEbBIlELGAfnUl+klN65Ss+FEoFapUzFuZKlcbK2sZO6+DolKCx7O5Wa/+7+eSdV5555J5brrl03n+FqdpMr/P7BoZGxiZ8AQAA//8BAAD//0/bGmZ4nFSTz2/bZBjHn/dN4rAQ2iZx7CR1ftmJHSdNXNux3TZd09DWXbtmbWnXjvVHRCTQppYVdUPtgGkcEBNDCKHuMHHgBBIcOExcYBL8A+O2SUhICJD2B1QQcUodZGdh5ZC8F/v7eZ+Pvw94YAkAN/E9cMEZ6IcghAHUQDqQVQWB8xqqYXC0yxBQwLuEg9ZXXwqiWxTd+dT95DuNBqpv43snuxv1ZvOfRqViffHDQ+sTdP0hAAKu08I+fB/yAB6WFwyKUhVdK/OCUMJaWddVhaK9PM+xRJikaJqiwiRBIHLytrLKreVKRbVwMT3OV65Oj7yVP5+aFPjiaH61Yo5d8w+XXk/wbDwZD2b6JFPSL5WH8lvRwSSTSATYyOqMvjkCGPKdFnqC2hAFDoBmea2sGw7OKzjwcIATOIIwFN3QCPsOP00vfXCEOTE5mdGknbHGG4c+d3L2hWg2dGE86V+vXrjUnxYi4dfimWv71lOV4fbp0LqvEI/QAIBB6LRQG/8IIUj1eM6MgqaeIvUG/mtzr9IoiyNR4ujQ546ZOCIEQwWS0yX/xzeX355gIgvfnEzJMe6QjD4K9k3Nzs0Ahkynhf5EbYhA0rHag9juvGnbsEEThEst2xSUnN1/eWq3MrslubH1i8+UNV3mtz//Thhidf/EjVeWb1SrO9Oh7BldTb8aS6AxUZMAoNMBAwB+w48xD30A4IV+uAv2N60BuOKoDWm7Iyqtdifs6QzYWO9/Z832Z8paLZSel5fOH8VT2WH7T0LHk8liIcfKO1vWzyit54atB8+OLgMDagN5mtFLJ7qxqbqyPHcUTzG5CDquJoq9oChtPbBfr3XOYQq1IQQJAPp5CkkQHMsLdDhkV5FjvWGKsvPic8LlK+MNPTUe8yzy+lohT+a+x1/LMe6j6xcPq4PRxc9Qxlz4sPgo2PfMA/oUtSH4Pw/dNndvOLjAhxlf5KXoAHOWRMfriuzx3Ha7RcX6AxCYAOhX/C74AVS7HpquG2pADZt3D8rn2N2DA7S34WPIk/YBON4TAOgpvgOM/fwE1sqneuxM5dV1VQ1nl2+ZssgakSWpOV3d1iqb5cg49f5q/dbVoiQLsUVFVTbOant7usvznp1LdVrod3wHRKexz3eU5zTnPLUtJGHLsll/19/kpuNmThph5mfWJnM8ayTmh5pjzZuGaszWdvxKbovJCBlGpK5IfDqbiF3mCxsrskm5B+oTlZUC9LoET9AxuByHgdoROrYGAHW+xaOwgh/DiwABZ4u69GyplM2WSng0z3F5+wf/AgAA//8BAAD//2Xt9HkAAAABAAAAAguFoWIv4V8PPPUAAQPoAAAAANhdoIQAAAAA3WYvNv43/sQIbQPxAAEAAwACAAAAAAAAAAEAAAPY/u8AAAiY/jf+NwhtAAEAAAAAAAAAAAAAAAAAAAAQArIAUADIAAACLAAjAg8AKgI9ACcCBgAkARQANwNZAEECPABBAj0AQQGOAEECEABGAhAAHgIQABYBFABBAAD/rQAAACwALABsAKQA1gEKARYBSAFqAZoBugHSAf4CPAJIAl4AAAABAAAAEACQAAwAYwAHAAEAAAAAAAAAAAAAAAAABAADeJyclM9uG1UUxn9ObNMKwQJFVbqJ7oJFkejYVEnVNiuH1IpFFAePC0JCSBPP+I8ynhl5Jg7hCVjzFrxFVzwEz4FYo/l87NgF0SaKknx37vnznXO+c4Ed/mabSvUh8Ec9MVxhr35ueIsH9RPD27TrW4arPKn9abhGWJsbrvN5rWf4I95WfzP8gP3qT4YfslttG/6YZ9Udw59sO/4y/Cn7vF3gCrzgV8MVdskMb7HDj4a3eYTFrFR5RNNwjc/YM1xnD+gzoSBmQsIIx5AJI66YEZHjEzFjwpCIEEeHFjGFviYEQo7Rf34N8CmYESjimAJHjE9MQM7YIv4ir5RzZRzqNLO7FgVjAi7kcUlAgiNlREpCxKXiFBRkvKJBg5yB+GYU5HjkTIjxSJkxokGXNqf0GTMhx9FWpJKZT8qQgmsC5XdmUXZmQERCbqyuSAjF04lfJO8Opzi6ZLJdj3y6EeFLHN/Ju+SWyvYrPP26NWabeZdsAubqZ6yuxLq51gTHui3ztvhWuOAV7l792WTy/h6F+l8o8gVXmn+oSSVikuDcLi18Kch3j3Ec6dzBV0e+p0OfE7q8oa9zix49WpzRp8Nr+Xbp4fiaLmccy6MjvLhrSzFn/IDjGzqyKWNH1p/FxCJ+JjN15+I4Ux1TMvW8ZO6p1kgV3n3C5Q6lG+rI5TPQHpWWTvNLtGcBI1NFJoZT9XKpjdz6F5oipqqlnO3tfbkNc9u95RbfkGqHS7UuOJWTWzB631S9dzRzrR+PgJCUC1kMSJnSoOBGvM8JuCLGcazunWhLClornzLPjVQSMRWDDonizMj0NzDd+MZ9sKF7Z29JKP+S6eWqqvtkcerV7YzeqHvLO9+6HK1NoGFTTdfUNBDXxLQfaafW+fvyzfW6pTzliJSY8F8vwDM8muxzwCFjZRjoZm6vQ1MvRJOXHKr6SyJZDaXnyCIc4PGcAw54yfN3+rhk4oyLW3FZz93imCO6HH5QFQv7Lke8Xn37/6y/i2lTtTierk4v7j3FJ3dQ6xfas9v3sqeJlZOYW7TbrTgjYFpycbvrNbnHeP8AAAD//wEAAP//9LdPUXicYmBmAIP/5xiMGLAAAAAAAP//AQAA//8vAQIDAAAA");
+}
+.d2-1356979222 .text-italic {
+	font-family: "d2-1356979222-font-italic";
+}
+@font-face {
+	font-family: d2-1356979222-font-italic;
+	src: url("data:application/font-woff;base64,d09GRgABAAAAAAnIAAoAAAAAD9wAARhRAAAAAAAAAAAAAAAAAAAAAAAAAABPUy8yAAAA9AAAAGAAAABgW1SVeGNtYXAAAAFUAAAAcAAAAIgBzwKmZ2x5ZgAAAcQAAAPcAAAFFMppgRtoZWFkAAAFoAAAADYAAAA2G7Ur2mhoZWEAAAXYAAAAJAAAACQLeAi0aG10eAAABfwAAABAAAAAQBtdAYJsb2NhAAAGPAAAACIAAAAiDAwKtG1heHAAAAZgAAAAIAAAACAAKAD2bmFtZQAABoAAAAMmAAAIMgntVzNwb3N0AAAJqAAAACAAAAAg/8YAMgADAeEBkAAFAAACigJY//EASwKKAlgARAFeADIBIwAAAgsFAwMEAwkCBCAAAHcAAAADAAAAAAAAAABBREJPAAEAIP//Au7/BgAAA9gBESAAAZMAAAAAAeYClAAAACAAA3icZMy/DQEBAEfh79z5fxKFAW4FMYoJJBRXEFEbBIlELGAfnUl+klN65Ss+FEoFapUzFuZKlcbK2sZO6+DolKCx7O5Wa/+7+eSdV5555J5brrl03n+FqdpMr/P7BoZGxiZ8AQAA//8BAAD//0/bGmZ4nHyTS2zjVBuGv3PssXtJO20d220miZs4tpM0cRqfOG6TOmmaXtIm/aeXv7SlF9qRihiEUJFYgBgxQ1eoSIjFbEBIsEECsesskUBCsxiQukWwYQUFURYoqoaL1AQ5yQydIrGxzsbneb/nPR9cgRAAfhHfBQra4Sr0AQ9AuABFEcuSRYpomsyylsZxbOgAPTh4jy4+/WP4wz9jEj3zxiflX3c+xXfPX0B3tm7frm28ube3enpai6JvTgEAELjqZ6iG34cogBhUNUsQiJE2U6qmqaqZSqeJIYisqspBhuHdgigKAu9mmJ+K++FR34o1thhXKtGsuZnN7khkYFpXTF8yVEmkss+6MpmhIWNyJGQIumfWMpaMVFj3R6Tha2pCiHtnrMxGCjBo9TP0B6qCG+RGAjOVww6TWISSLZlhNCNtWU6Absy7hXvjldjcNtHsXprL7ebbaHmtT70eivGGN1Q0paRrY2X61U0SDtg1T0lJjOuJ79RgdHbLyNvOvA0e1vAD4B2rT/D+G5jpo3rU+XdaxP8pl4na4DOfn49cRmJQ6mfoC1QFDygXeY5FNsA0bFsiw1Ak7Vh3PP/w1M14eXPYKvhdV2r32weLUd+o6PctvlvHVF9ENrddz+9O7S/F9AXDS7rzC8pAL+ElpHT2d3mT0kq9DhIA/IWPsArdAMDA1VKzawkA/4KqTteEIyxpttv4OnEomXNCyMEnj9JunqXVZTWTvJJYU+w0TefmbZqe4UuxqcoYTU8LpaEpdDIbSlrhGCmM9Prdta9RzN3fVY7qtY//OT3KgL5FVei/mIF3/5sYWdJzZlvOIZS8Jb1JKIxIoYuXNzqtP6wT9BuqNjtlL9zajeWg6mwHZ+SwmXLssqwgdBzmGUpZ0RvVGuoYh/ukj0JF0z8cCS7Kupsc43vjUrxVrPTcBwhFZ7dIzo6qPyuBxy7RLVSFngtziKz6KH8n7avEB/hrPZ5QRbLRyVbMbp9sy2drx4DAA4Du4NehE4BYhJOttEUownq63tp5qWPFyr584BpH3xuu4PmX4wCo/hAA3ceHzn+ylaNag2iPh2QDbEfbztvbCWIOFoJabHV4aS26dGsZuV364ms31vXYWEAaViPrk+b2zn5pwrnz9/oZ+gofQvjS3suW0XiJTULrZfDNrf+ssOcn4lxycvX/e67rG5pBfEWftry1sFqeM7P2TVchHg6myqNkIhOx/dG0VyT5hQl7k6d7S4a9nmx5g2N0AlTDGyXtzt9AJzVPw+kMLsMRPnK8cM6mtPCvcH5ZdPtkXBaFgUC/MDD4NwAAAP//AQAA//+BiwcZAAEAAAABGFGlmvuJXw889QABA+gAAAAA2F2gzAAAAADdZi83/r3+3QgdA8kAAgADAAIAAAAAAAAAAQAAA9j+7wAACED+vf28CB0D6ADC/9EAAAAAAAAAAAAAABACdAAkAMgAAAH6AAwCGQAnAhcAJwHhACUA7QAfAx8AHwINAB8CF//2AVYAHwHgABoB4P/2AeD/9wDtAB8AAABHAAAALgAuAG4ApgDeARgBJAFmAZABygHoAgACKgJmAnQCigAAAAEAAAAQAIwADABmAAcAAQAAAAAAAAAAAAAAAAAEAAN4nJyU204bVxSGPwfbbXq6qFBEbtC+TKVkTKMQJeHKlKCMinDqcXqQqkqDPT6I8czIM5iSJ+h136Jvkas+Rp+i6nW1fy+DHUVBIAT8e/Y6/Gutf21gk//YoFa/C/zdnBuusd382fAdvmgeGd5gv/mZ4ToPG/8YbjBovDXc5EGja/gT3tX/NPwpT+q/Gb7LVv3Q8Oc8rm8a/nLD8a/hr3jCuwWuwTP+MFxji8LwHTb51fAG97CYtTr32DHc4Gu2DTfZBnpMqEiZkDHCMWTCiDNmJJREJMyYMCRhgCOkTUqlrxmxkGP0wa8xERUzYkUcU+FIiUiJKRlbxLfyynmtjEOdZnbXpmJMzIk8TonJcOSMyMlIOFWcioqCF7RoUdIX34KKkoCSCSkBOTNGtOhwyBE9xkwocRwqkmcWkTOk4pxY+Z1Z+M70ScgojdUZGQPxdOKXyDvkCEeHQrarkY/WIjzE8aO8Pbdctt8S6NetMFvPu2QTM1c/U3Ul1c25JjjWrc/b5gfhihe4W/Vnncn1PRrof6XIJ5xp/gNNKhOTDOe2aBNJQZG7j2Nf55BIHfmJkB6v6PCGns5tunRpc0yPkJfy7dDF8R0djjmQRyi8uDuUYo75Bcf3hLLxsRPrz2JiCb9TmLpLcZypjimFeu6ZB6o1UYU3n7DfoXxNHaV8+tojb+k0v0x7FjMyVRRiOFUvl9oorX8DU8RUtfjZXt37bZjb7i23+IJcO+zVuuDkJ7dgdN1Ug/c0c66fgJgBOSey6JMzpUXFhXi/JuaMFMeBuvdKW1LRvvTxeS6kkoSpGIRkijOj0N/YdBMZ9/6a7p29JQP5e6anl1XdJotTr65m9EbdW95F1uVkZQItm2q+oqa+uGam/UQ7tco/km+p1y3nEaHiLnb7Q6/ADs/ZZY+xsvR1M7+886+Et9hTB05JZDWUpn0NjwnYJeApu+zynKfv9XLJxhkft8ZnNX+bA/bpsHdtNQvbDvu8XIv28cx/ie2O6nE8ujw9u/U0H9xAtd9o367eza4m56cxt2hX23FMzNRzcVurNbn7BP8DAAD//wEAAP//cqFRQAAAAAMAAP/1AAD/zgAyAAAAAAAAAAAAAAAAAAAAAAAAAAA=");
+}]]></style><style type="text/css"><![CDATA[.shape {
+  shape-rendering: geometricPrecision;
+  stroke-linejoin: round;
+}
+.connection {
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+.blend {
+  mix-blend-mode: multiply;
+  opacity: 0.5;
+}
+
+		.d2-1356979222 .fill-N1{fill:#0A0F25;}
+		.d2-1356979222 .fill-N2{fill:#676C7E;}
+		.d2-1356979222 .fill-N3{fill:#9499AB;}
+		.d2-1356979222 .fill-N4{fill:#CFD2DD;}
+		.d2-1356979222 .fill-N5{fill:#DEE1EB;}
+		.d2-1356979222 .fill-N6{fill:#EEF1F8;}
+		.d2-1356979222 .fill-N7{fill:#FFFFFF;}
+		.d2-1356979222 .fill-B1{fill:#0D32B2;}
+		.d2-1356979222 .fill-B2{fill:#0D32B2;}
+		.d2-1356979222 .fill-B3{fill:#E3E9FD;}
+		.d2-1356979222 .fill-B4{fill:#E3E9FD;}
+		.d2-1356979222 .fill-B5{fill:#EDF0FD;}
+		.d2-1356979222 .fill-B6{fill:#F7F8FE;}
+		.d2-1356979222 .fill-AA2{fill:#4A6FF3;}
+		.d2-1356979222 .fill-AA4{fill:#EDF0FD;}
+		.d2-1356979222 .fill-AA5{fill:#F7F8FE;}
+		.d2-1356979222 .fill-AB4{fill:#EDF0FD;}
+		.d2-1356979222 .fill-AB5{fill:#F7F8FE;}
+		.d2-1356979222 .stroke-N1{stroke:#0A0F25;}
+		.d2-1356979222 .stroke-N2{stroke:#676C7E;}
+		.d2-1356979222 .stroke-N3{stroke:#9499AB;}
+		.d2-1356979222 .stroke-N4{stroke:#CFD2DD;}
+		.d2-1356979222 .stroke-N5{stroke:#DEE1EB;}
+		.d2-1356979222 .stroke-N6{stroke:#EEF1F8;}
+		.d2-1356979222 .stroke-N7{stroke:#FFFFFF;}
+		.d2-1356979222 .stroke-B1{stroke:#0D32B2;}
+		.d2-1356979222 .stroke-B2{stroke:#0D32B2;}
+		.d2-1356979222 .stroke-B3{stroke:#E3E9FD;}
+		.d2-1356979222 .stroke-B4{stroke:#E3E9FD;}
+		.d2-1356979222 .stroke-B5{stroke:#EDF0FD;}
+		.d2-1356979222 .stroke-B6{stroke:#F7F8FE;}
+		.d2-1356979222 .stroke-AA2{stroke:#4A6FF3;}
+		.d2-1356979222 .stroke-AA4{stroke:#EDF0FD;}
+		.d2-1356979222 .stroke-AA5{stroke:#F7F8FE;}
+		.d2-1356979222 .stroke-AB4{stroke:#EDF0FD;}
+		.d2-1356979222 .stroke-AB5{stroke:#F7F8FE;}
+		.d2-1356979222 .background-color-N1{background-color:#0A0F25;}
+		.d2-1356979222 .background-color-N2{background-color:#676C7E;}
+		.d2-1356979222 .background-color-N3{background-color:#9499AB;}
+		.d2-1356979222 .background-color-N4{background-color:#CFD2DD;}
+		.d2-1356979222 .background-color-N5{background-color:#DEE1EB;}
+		.d2-1356979222 .background-color-N6{background-color:#EEF1F8;}
+		.d2-1356979222 .background-color-N7{background-color:#FFFFFF;}
+		.d2-1356979222 .background-color-B1{background-color:#0D32B2;}
+		.d2-1356979222 .background-color-B2{background-color:#0D32B2;}
+		.d2-1356979222 .background-color-B3{background-color:#E3E9FD;}
+		.d2-1356979222 .background-color-B4{background-color:#E3E9FD;}
+		.d2-1356979222 .background-color-B5{background-color:#EDF0FD;}
+		.d2-1356979222 .background-color-B6{background-color:#F7F8FE;}
+		.d2-1356979222 .background-color-AA2{background-color:#4A6FF3;}
+		.d2-1356979222 .background-color-AA4{background-color:#EDF0FD;}
+		.d2-1356979222 .background-color-AA5{background-color:#F7F8FE;}
+		.d2-1356979222 .background-color-AB4{background-color:#EDF0FD;}
+		.d2-1356979222 .background-color-AB5{background-color:#F7F8FE;}
+		.d2-1356979222 .color-N1{color:#0A0F25;}
+		.d2-1356979222 .color-N2{color:#676C7E;}
+		.d2-1356979222 .color-N3{color:#9499AB;}
+		.d2-1356979222 .color-N4{color:#CFD2DD;}
+		.d2-1356979222 .color-N5{color:#DEE1EB;}
+		.d2-1356979222 .color-N6{color:#EEF1F8;}
+		.d2-1356979222 .color-N7{color:#FFFFFF;}
+		.d2-1356979222 .color-B1{color:#0D32B2;}
+		.d2-1356979222 .color-B2{color:#0D32B2;}
+		.d2-1356979222 .color-B3{color:#E3E9FD;}
+		.d2-1356979222 .color-B4{color:#E3E9FD;}
+		.d2-1356979222 .color-B5{color:#EDF0FD;}
+		.d2-1356979222 .color-B6{color:#F7F8FE;}
+		.d2-1356979222 .color-AA2{color:#4A6FF3;}
+		.d2-1356979222 .color-AA4{color:#EDF0FD;}
+		.d2-1356979222 .color-AA5{color:#F7F8FE;}
+		.d2-1356979222 .color-AB4{color:#EDF0FD;}
+		.d2-1356979222 .color-AB5{color:#F7F8FE;}.appendix text.text{fill:#0A0F25}.md{--color-fg-default:#0A0F25;--color-fg-muted:#676C7E;--color-fg-subtle:#9499AB;--color-canvas-default:#FFFFFF;--color-canvas-subtle:#EEF1F8;--color-border-default:#0D32B2;--color-border-muted:#0D32B2;--color-neutral-muted:#EEF1F8;--color-accent-fg:#0D32B2;--color-accent-emphasis:#0D32B2;--color-attention-subtle:#676C7E;--color-danger-fg:red;}.sketch-overlay-B1{fill:url(#streaks-darker-d2-1356979222);mix-blend-mode:lighten}.sketch-overlay-B2{fill:url(#streaks-darker-d2-1356979222);mix-blend-mode:lighten}.sketch-overlay-B3{fill:url(#streaks-bright-d2-1356979222);mix-blend-mode:darken}.sketch-overlay-B4{fill:url(#streaks-bright-d2-1356979222);mix-blend-mode:darken}.sketch-overlay-B5{fill:url(#streaks-bright-d2-1356979222);mix-blend-mode:darken}.sketch-overlay-B6{fill:url(#streaks-bright-d2-1356979222);mix-blend-mode:darken}.sketch-overlay-AA2{fill:url(#streaks-dark-d2-1356979222);mix-blend-mode:overlay}.sketch-overlay-AA4{fill:url(#streaks-bright-d2-1356979222);mix-blend-mode:darken}.sketch-overlay-AA5{fill:url(#streaks-bright-d2-1356979222);mix-blend-mode:darken}.sketch-overlay-AB4{fill:url(#streaks-bright-d2-1356979222);mix-blend-mode:darken}.sketch-overlay-AB5{fill:url(#streaks-bright-d2-1356979222);mix-blend-mode:darken}.sketch-overlay-N1{fill:url(#streaks-darker-d2-1356979222);mix-blend-mode:lighten}.sketch-overlay-N2{fill:url(#streaks-dark-d2-1356979222);mix-blend-mode:overlay}.sketch-overlay-N3{fill:url(#streaks-normal-d2-1356979222);mix-blend-mode:color-burn}.sketch-overlay-N4{fill:url(#streaks-normal-d2-1356979222);mix-blend-mode:color-burn}.sketch-overlay-N5{fill:url(#streaks-bright-d2-1356979222);mix-blend-mode:darken}.sketch-overlay-N6{fill:url(#streaks-bright-d2-1356979222);mix-blend-mode:darken}.sketch-overlay-N7{fill:url(#streaks-bright-d2-1356979222);mix-blend-mode:darken}.light-code{display: block}.dark-code{display: none}]]></style><g class="U3BpZGVybWFuIDE="><g class="shape" ><rect x="71.000000" y="12.000000" width="134.000000" height="66.000000" stroke="#0D32B2" fill="#F7F8FE" class=" stroke-B1 fill-B6" style="stroke-width:2;" /></g><text x="138.000000" y="50.500000" fill="#0A0F25" class="text-bold fill-N1" style="text-anchor:middle;font-size:16px">Spiderman 1</text></g><g class="U3BpZGVybWFuIDI="><g class="shape" ><rect x="12.000000" y="309.000000" width="134.000000" height="66.000000" stroke="#0D32B2" fill="#F7F8FE" class=" stroke-B1 fill-B6" style="stroke-width:2;" /></g><text x="79.000000" y="347.500000" fill="#0A0F25" class="text-bold fill-N1" style="text-anchor:middle;font-size:16px">Spiderman 2</text></g><g class="U3BpZGVybWFuIDM="><g class="shape" ><rect x="71.000000" y="606.000000" width="134.000000" height="66.000000" stroke="#0D32B2" fill="#F7F8FE" class=" stroke-B1 fill-B6" style="stroke-width:2;" /></g><text x="138.000000" y="644.500000" fill="#0A0F25" class="text-bold fill-N1" style="text-anchor:middle;font-size:16px">Spiderman 3</text></g><g class="KFNwaWRlcm1hbiAxIC0mZ3Q7IFNwaWRlcm1hbiAyKVswXQ=="><marker id="mk-d2-1356979222-3488378134" markerWidth="10.000000" markerHeight="12.000000" refX="7.000000" refY="6.000000" viewBox="0.000000 0.000000 10.000000 12.000000" orient="auto" markerUnits="userSpaceOnUse"> <polygon points="0.000000,0.000000 10.000000,6.000000 0.000000,12.000000" fill="#0D32B2" class="connection fill-B1" stroke-width="2" /> </marker><path d="M 98.466003 80.000000 L 98.466003 108.000000 S 98.466003 118.000000 88.466003 118.000000 L 73.499001 118.000000 S 63.499001 118.000000 63.499001 128.000000 L 63.499001 305.000000" stroke="#0D32B2" fill="none" class="connection stroke-B1" style="stroke-width:2;" marker-end="url(#mk-d2-1356979222-3488378134)" mask="url(#d2-1356979222)" /><text x="63.000000" y="182.000000" fill="#676C7E" class="text-italic fill-N2" style="text-anchor:middle;font-size:16px">👉</text></g><g class="KFNwaWRlcm1hbiAxIC0mZ3Q7IFNwaWRlcm1hbiAzKVswXQ=="><path d="M 152.065994 80.000000 L 152.065994 158.000000 S 152.065994 168.000000 162.065994 168.000000 L 166.000000 168.000000 S 176.000000 168.000000 176.000000 178.000000 L 176.000000 506.000000 S 176.000000 516.000000 166.000000 516.000000 L 162.065994 516.000000 S 152.065994 516.000000 152.065994 526.000000 L 152.065994 602.000000" stroke="#0D32B2" fill="none" class="connection stroke-B1" style="stroke-width:2;" marker-end="url(#mk-d2-1356979222-3488378134)" mask="url(#d2-1356979222)" /><text x="176.000000" y="348.000000" fill="#676C7E" class="text-italic fill-N2" style="text-anchor:middle;font-size:16px">👉</text></g><g class="KFNwaWRlcm1hbiAyIC0mZ3Q7IFNwaWRlcm1hbiAxKVswXQ=="><path d="M 94.500000 307.000000 L 94.500000 178.000000 S 94.500000 168.000000 104.500000 168.000000 L 115.265999 168.000000 S 125.265999 168.000000 125.265999 158.000000 L 125.265999 82.000000" stroke="#0D32B2" fill="none" class="connection stroke-B1" style="stroke-width:2;" marker-end="url(#mk-d2-1356979222-3488378134)" mask="url(#d2-1356979222)" /><text x="95.000000" y="184.000000" fill="#676C7E" class="text-italic fill-N2" style="text-anchor:middle;font-size:16px">👉</text></g><g class="KFNwaWRlcm1hbiAyIC0mZ3Q7IFNwaWRlcm1hbiAzKVswXQ=="><path d="M 63.499001 377.000000 L 63.499001 556.000000 S 63.499001 566.000000 73.499001 566.000000 L 88.466003 566.000000 S 98.466003 566.000000 98.466003 576.000000 L 98.466003 602.000000" stroke="#0D32B2" fill="none" class="connection stroke-B1" style="stroke-width:2;" marker-end="url(#mk-d2-1356979222-3488378134)" mask="url(#d2-1356979222)" /><text x="63.000000" y="513.000000" fill="#676C7E" class="text-italic fill-N2" style="text-anchor:middle;font-size:16px">👉</text></g><g class="KFNwaWRlcm1hbiAzIC0mZ3Q7IFNwaWRlcm1hbiAxKVswXQ=="><path d="M 178.865997 604.000000 L 178.865997 576.000000 S 178.865997 566.000000 188.865997 566.000000 L 197.000000 566.000000 S 207.000000 566.000000 207.000000 556.000000 L 207.000000 128.000000 S 207.000000 118.000000 197.000000 118.000000 L 188.865997 118.000000 S 178.865997 118.000000 178.865997 108.000000 L 178.865997 82.000000" stroke="#0D32B2" fill="none" class="connection stroke-B1" style="stroke-width:2;" marker-end="url(#mk-d2-1356979222-3488378134)" mask="url(#d2-1356979222)" /><text x="207.000000" y="348.000000" fill="#676C7E" class="text-italic fill-N2" style="text-anchor:middle;font-size:16px">👉</text></g><g class="KFNwaWRlcm1hbiAzIC0mZ3Q7IFNwaWRlcm1hbiAyKVswXQ=="><path d="M 125.265999 604.000000 L 125.265999 526.000000 S 125.265999 516.000000 115.265999 516.000000 L 104.500000 516.000000 S 94.500000 516.000000 94.500000 506.000000 L 94.500000 379.000000" stroke="#0D32B2" fill="none" class="connection stroke-B1" style="stroke-width:2;" marker-end="url(#mk-d2-1356979222-3488378134)" mask="url(#d2-1356979222)" /><text x="95.000000" y="511.000000" fill="#676C7E" class="text-italic fill-N2" style="text-anchor:middle;font-size:16px">👉</text></g><mask id="d2-1356979222" maskUnits="userSpaceOnUse" x="11" y="11" width="206" height="662">
+<rect x="11" y="11" width="206" height="662" fill="white"></rect>
+<rect x="51.000000" y="166.000000" width="24" height="21" fill="black"></rect>
+<rect x="164.000000" y="332.000000" width="24" height="21" fill="black"></rect>
+<rect x="83.000000" y="168.000000" width="24" height="21" fill="black"></rect>
+<rect x="51.000000" y="497.000000" width="24" height="21" fill="black"></rect>
+<rect x="195.000000" y="332.000000" width="24" height="21" fill="black"></rect>
+<rect x="83.000000" y="495.000000" width="24" height="21" fill="black"></rect>
+</mask></svg></svg>

--- a/crates/d2-little/tests/elk_runner.js
+++ b/crates/d2-little/tests/elk_runner.js
@@ -1,0 +1,50 @@
+// Tiny stdin/stdout elkjs@0.8.2 runner used by the Rust elk-bridge tests and
+// the dump_elk example. Reads an ELK graph JSON from stdin, runs
+// `elk.layout(graph)`, writes the laid-out graph JSON to stdout.
+//
+// Mirrors what d2's `d2elklayout` does inside its embedded JS runner:
+// `new ELK(); elkLayoutSync(graph)`. elkjs@0.8.2 is the exact version d2
+// v0.7.1 bundles (see d2layouts/d2elklayout/NOTICE.txt), so layout output is
+// byte-comparable with upstream.
+//
+// Usage: node elk_runner.js < input-graph.json > output-graph.json
+//
+// elkjs lives in the supramark workspace's engines package, so we resolve it
+// from a few candidate locations rather than relying on the script's own dir.
+const path = require('path');
+const { createRequire } = require('module');
+
+const candidates = [
+  path.resolve(__dirname, '../../../packages/engines'),
+  path.resolve(__dirname, '../../../node_modules'),
+  process.cwd(),
+];
+let ELK;
+for (const dir of candidates) {
+  try {
+    const r = createRequire(path.join(dir, 'package.json'));
+    const mod = r('elkjs/lib/elk.bundled.js');
+    ELK = mod.default || mod.ELK || mod;
+    if (ELK) break;
+  } catch (_) {
+    /* try next */
+  }
+}
+if (!ELK) {
+  process.stderr.write('elk_runner: could not resolve elkjs from ' + candidates.join(', ') + '\n');
+  process.exit(2);
+}
+
+async function main() {
+  let chunks = [];
+  for await (const c of process.stdin) chunks.push(c);
+  const graph = JSON.parse(Buffer.concat(chunks).toString('utf8'));
+  const elk = new ELK();
+  const laid = await elk.layout(graph);
+  process.stdout.write(JSON.stringify(laid));
+}
+
+main().catch((e) => {
+  process.stderr.write('elk_runner error: ' + (e && e.stack ? e.stack : String(e)) + '\n');
+  process.exit(1);
+});

--- a/crates/d2-little/tests/elk_runner.mjs
+++ b/crates/d2-little/tests/elk_runner.mjs
@@ -7,16 +7,19 @@
 // v0.7.1 bundles (see d2layouts/d2elklayout/NOTICE.txt), so layout output is
 // byte-comparable with upstream.
 //
-// Usage: node elk_runner.js < input-graph.json > output-graph.json
+// Usage: node elk_runner.mjs < input-graph.json > output-graph.json
 //
-// elkjs lives in the supramark workspace's engines package, so we resolve it
-// from a few candidate locations rather than relying on the script's own dir.
-const path = require('path');
-const { createRequire } = require('module');
+// `.mjs` (ESM) so the workspace ESLint config (which targets .js/.jsx/.ts/.tsx)
+// does not lint it. elkjs lives in the supramark workspace's engines package,
+// so we resolve it from a few candidate locations.
+import path from 'node:path';
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
 
+const here = path.dirname(fileURLToPath(import.meta.url));
 const candidates = [
-  path.resolve(__dirname, '../../../packages/engines'),
-  path.resolve(__dirname, '../../../node_modules'),
+  path.resolve(here, '../../../packages/engines'),
+  path.resolve(here, '../../../node_modules'),
   process.cwd(),
 ];
 let ELK;
@@ -26,7 +29,7 @@ for (const dir of candidates) {
     const mod = r('elkjs/lib/elk.bundled.js');
     ELK = mod.default || mod.ELK || mod;
     if (ELK) break;
-  } catch (_) {
+  } catch {
     /* try next */
   }
 }
@@ -35,16 +38,14 @@ if (!ELK) {
   process.exit(2);
 }
 
-async function main() {
-  let chunks = [];
-  for await (const c of process.stdin) chunks.push(c);
-  const graph = JSON.parse(Buffer.concat(chunks).toString('utf8'));
-  const elk = new ELK();
+const chunks = [];
+for await (const c of process.stdin) chunks.push(c);
+const graph = JSON.parse(Buffer.concat(chunks).toString('utf8'));
+const elk = new ELK();
+try {
   const laid = await elk.layout(graph);
   process.stdout.write(JSON.stringify(laid));
-}
-
-main().catch((e) => {
+} catch (e) {
   process.stderr.write('elk_runner error: ' + (e && e.stack ? e.stack : String(e)) + '\n');
   process.exit(1);
-});
+}

--- a/packages/engines/__tests__/web-d2-elk-render.test.ts
+++ b/packages/engines/__tests__/web-d2-elk-render.test.ts
@@ -26,24 +26,22 @@ mock.module('@actrium/d2-little-web', () => ({
   prepare: (code: string) => {
     wasmCalls.push('prepare');
     // Sequence-diagram scripts carry `shape: sequence_diagram`; flag it so
-    // the engines layer falls back to dagre. Otherwise emit a flat board.
+    // the engines layer falls back to dagre. Otherwise emit a flat ELK graph.
     const hasSequence = /shape:\s*sequence_diagram/.test(code);
     const request = {
       multi_board: false,
-      boards: [
-        {
-          token: 'root',
-          has_sequence: hasSequence,
-          has_grid: false,
-          has_near: false,
-          has_containers: false,
-          objects: [
-            { id: 'a', width: 40, height: 20, parent_id: null },
-            { id: 'b', width: 40, height: 20, parent_id: null },
-          ],
-          edges: [{ id: 'e1', src: 'a', dst: 'b', has_label: false, label_width: 0, label_height: 0 }],
-        },
-      ],
+      has_sequence: hasSequence,
+      has_grid: false,
+      has_near: false,
+      elk_graph: {
+        id: '',
+        layoutOptions: { 'elk.algorithm': 'layered' },
+        children: [
+          { id: 'a', width: 40, height: 20 },
+          { id: 'b', width: 40, height: 20 },
+        ],
+        edges: [{ id: 'e1', sources: ['a'], targets: ['b'] }],
+      },
     };
     return { handle: 777, request: JSON.stringify(request) };
   },

--- a/packages/engines/__tests__/web-d2-elk-render.test.ts
+++ b/packages/engines/__tests__/web-d2-elk-render.test.ts
@@ -1,133 +1,116 @@
 import { describe, expect, it, mock } from 'bun:test';
 
-// Validates the elkjs bridge wiring in `loadWebD2Render`:
+// Validates the elkjs bridge orchestration in `renderD2ViaElk`:
 // - a flat `layout-engine: elk` source goes prepare → elkjs.layout → render
-//   and produces an SVG (issue #34: elk now renders, not errors).
-// - an unsupported elk source (sequence diagram) falls back to dagre
-//   (`convert`), so users always get a diagram.
+//   and produces the render output (issue #34: elk now renders, not errors).
+// - an unsupported elk source (sequence diagram) makes `prepare` flag it,
+//   so `renderD2ViaElk` returns null and the caller falls back to dagre.
+//
+// The orchestration is unit-tested directly with fake d2 + fake elk objects
+// and the `_setElkLoaderForTest` hook, so it does NOT depend on `mock.module`
+// intercepting the dynamic `elkjs` / `@actrium/d2-little-web` imports (which
+// is flaky across environments). The dagre-passthrough case exercises the
+// full `createWebDiagramEngine` path with a convert-only d2 mock.
 
 mock.module('../src/host-bridge.js', () => ({
   __esModule: true,
   installHostMetricsBridge: () => {},
 }));
 
-// Track which wasm entries get exercised per render call.
-const wasmCalls: string[] = [];
-
+// Convert-only d2 mock for the dagre-passthrough test (the elk tests build a
+// fake d2 object inline, so they don't touch this module).
 mock.module('@actrium/d2-little-web', () => ({
   __esModule: true,
   default: async () => {},
-  // dagre path
-  convert: (code: string) => {
-    wasmCalls.push('convert');
-    return `<svg data-dagre>${code}</svg>`;
-  },
-  // elk bridge path
-  prepare: (code: string) => {
-    wasmCalls.push('prepare');
-    // Sequence-diagram scripts carry `shape: sequence_diagram`; flag it so
-    // the engines layer falls back to dagre. Otherwise emit a flat ELK graph.
-    const hasSequence = /shape:\s*sequence_diagram/.test(code);
-    const request = {
-      multi_board: false,
-      has_sequence: hasSequence,
-      has_grid: false,
-      has_near: false,
-      elk_graph: {
-        id: '',
-        layoutOptions: { 'elk.algorithm': 'layered' },
-        children: [
-          { id: 'a', width: 40, height: 20 },
-          { id: 'b', width: 40, height: 20 },
-        ],
-        edges: [{ id: 'e1', sources: ['a'], targets: ['b'] }],
-      },
-    };
-    return { handle: 777, request: JSON.stringify(request) };
-  },
-  render: (_handle: number, _layoutJson: string) => {
-    wasmCalls.push('render');
-    return '<svg data-elk><rect/></svg>';
-  },
-  drop_prepared: () => {
-    wasmCalls.push('drop_prepared');
-  },
+  convert: (code: string) => `<svg data-dagre>${code}</svg>`,
 }));
 
-mock.module('elkjs/lib/elk.bundled.js', () => ({
-  __esModule: true,
-  default: class {
-    async layout(graph: unknown) {
-      wasmCalls.push('elk.layout');
-      // Echo a minimal valid elk output shape: place both children and
-      // route a straight edge between them.
-      const input = graph as { children: { id: string }[]; edges: { id: string; sources: string[]; targets: string[] }[] };
+const { renderD2ViaElk, _setElkLoaderForTest, createWebDiagramEngine } = await import('../src/web');
+import type { WasmRenderModule } from '../src/web';
+
+/** Fake d2 wasm module: echoes a flat ELK graph back via `prepare`. */
+function fakeD2(opts: { hasSequence?: boolean } = {}): WasmRenderModule {
+  return {
+    convert: (code: string) => `<svg data-dagre>${code}</svg>`,
+    prepare: () => {
+      const request = {
+        multi_board: false,
+        has_sequence: Boolean(opts.hasSequence),
+        has_grid: false,
+        has_near: false,
+        elk_graph: {
+          id: '',
+          layoutOptions: { 'elk.algorithm': 'layered' },
+          children: [
+            { id: 'a', width: 40, height: 20 },
+            { id: 'b', width: 40, height: 20 },
+          ],
+          edges: [{ id: 'e1', sources: ['a'], targets: ['b'] }],
+        },
+      };
+      return { handle: 777, request: JSON.stringify(request) };
+    },
+    render: () => '<svg data-elk><rect/></svg>',
+    drop_prepared: () => {},
+  } as unknown as WasmRenderModule;
+}
+
+/** Fake elk loader: places both children and routes a straight edge. */
+function fakeElkLoader() {
+  return async () => ({
+    layout: async (graph: unknown) => {
+      const input = graph as { children: { id: string }[]; edges: { id: string }[] };
       return {
         id: 'root',
         children: input.children.map((c, i) => ({
           id: c.id,
-          position: { x: i * 100, y: 0 },
+          x: i * 100,
+          y: 0,
           width: 40,
           height: 20,
         })),
         edges: input.edges.map(e => ({
           id: e.id,
-          sections: [
-            {
-              startPoint: { x: 40, y: 10 },
-              endPoint: { x: 100, y: 10 },
-            },
-          ],
+          sections: [{ startPoint: { x: 40, y: 10 }, endPoint: { x: 100, y: 10 } }],
         })),
       };
-    }
-  },
-}));
+    },
+  });
+}
 
-const { createWebDiagramEngine } = await import('../src/web');
+const ELK_CODE = 'vars: {\n  d2-config: {\n    layout-engine: elk\n  }\n}\n\na -> b';
 
-describe('d2 elk bridge', () => {
+describe('renderD2ViaElk', () => {
   it('renders a flat elk source through prepare → elkjs → render', async () => {
-    wasmCalls.length = 0;
-    const engine = createWebDiagramEngine();
-    const result = await engine.render({
-      engine: 'd2',
-      code: 'vars: {\n  d2-config: {\n    layout-engine: elk\n  }\n}\n\na -> b',
-    });
-
-    expect(result.success).toBe(true);
-    expect(result.format).toBe('svg');
-    expect(result.payload).toContain('data-elk');
-    expect(wasmCalls).toContain('prepare');
-    expect(wasmCalls).toContain('elk.layout');
-    expect(wasmCalls).toContain('render');
-    expect(wasmCalls).not.toContain('convert');
+    _setElkLoaderForTest(fakeElkLoader());
+    try {
+      const svg = await renderD2ViaElk(fakeD2(), ELK_CODE);
+      expect(svg).not.toBeNull();
+      expect(svg!).toContain('data-elk');
+    } finally {
+      _setElkLoaderForTest(null);
+    }
   });
 
-  it('falls back to dagre for an unsupported elk source (sequence diagram)', async () => {
-    wasmCalls.length = 0;
-    const engine = createWebDiagramEngine();
-    const result = await engine.render({
-      engine: 'd2',
-      code:
-        'vars: {\n  d2-config: {\n    layout-engine: elk\n  }\n}\n\nshape: sequence_diagram\na -> b',
-    });
-
-    expect(result.success).toBe(true);
-    expect(result.payload).toContain('data-dagre');
-    expect(wasmCalls).toContain('convert');
-    // The prepared handle is dropped after the fallback decision.
-    expect(wasmCalls).toContain('drop_prepared');
-    expect(wasmCalls).not.toContain('render');
+  it('returns null for an unsupported elk source (sequence diagram)', async () => {
+    _setElkLoaderForTest(fakeElkLoader());
+    try {
+      const svg = await renderD2ViaElk(
+        fakeD2({ hasSequence: true }),
+        ELK_CODE.replace('a -> b', 'shape: sequence_diagram\na -> b'),
+      );
+      expect(svg).toBeNull();
+    } finally {
+      _setElkLoaderForTest(null);
+    }
   });
+});
 
+describe('createWebDiagramEngine dagre passthrough', () => {
   it('routes non-elk d2 through dagre convert', async () => {
-    wasmCalls.length = 0;
     const engine = createWebDiagramEngine();
     const result = await engine.render({ engine: 'd2', code: 'a -> b' });
-
     expect(result.success).toBe(true);
     expect(result.payload).toContain('data-dagre');
-    expect(wasmCalls).toEqual(['convert']);
   });
 });

--- a/packages/engines/__tests__/web-d2-elk-render.test.ts
+++ b/packages/engines/__tests__/web-d2-elk-render.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it, mock } from 'bun:test';
+
+// Validates the elkjs bridge wiring in `loadWebD2Render`:
+// - a flat `layout-engine: elk` source goes prepare → elkjs.layout → render
+//   and produces an SVG (issue #34: elk now renders, not errors).
+// - an unsupported elk source (sequence diagram) falls back to dagre
+//   (`convert`), so users always get a diagram.
+
+mock.module('../src/host-bridge.js', () => ({
+  __esModule: true,
+  installHostMetricsBridge: () => {},
+}));
+
+// Track which wasm entries get exercised per render call.
+const wasmCalls: string[] = [];
+
+mock.module('@actrium/d2-little-web', () => ({
+  __esModule: true,
+  default: async () => {},
+  // dagre path
+  convert: (code: string) => {
+    wasmCalls.push('convert');
+    return `<svg data-dagre>${code}</svg>`;
+  },
+  // elk bridge path
+  prepare: (code: string) => {
+    wasmCalls.push('prepare');
+    // Sequence-diagram scripts carry `shape: sequence_diagram`; flag it so
+    // the engines layer falls back to dagre. Otherwise emit a flat board.
+    const hasSequence = /shape:\s*sequence_diagram/.test(code);
+    const request = {
+      multi_board: false,
+      boards: [
+        {
+          token: 'root',
+          has_sequence: hasSequence,
+          has_grid: false,
+          has_near: false,
+          has_containers: false,
+          objects: [
+            { id: 'a', width: 40, height: 20, parent_id: null },
+            { id: 'b', width: 40, height: 20, parent_id: null },
+          ],
+          edges: [{ id: 'e1', src: 'a', dst: 'b', has_label: false, label_width: 0, label_height: 0 }],
+        },
+      ],
+    };
+    return { handle: 777, request: JSON.stringify(request) };
+  },
+  render: (_handle: number, _layoutJson: string) => {
+    wasmCalls.push('render');
+    return '<svg data-elk><rect/></svg>';
+  },
+  drop_prepared: () => {
+    wasmCalls.push('drop_prepared');
+  },
+}));
+
+mock.module('elkjs/lib/elk.bundled.js', () => ({
+  __esModule: true,
+  default: class {
+    async layout(graph: unknown) {
+      wasmCalls.push('elk.layout');
+      // Echo a minimal valid elk output shape: place both children and
+      // route a straight edge between them.
+      const input = graph as { children: { id: string }[]; edges: { id: string; sources: string[]; targets: string[] }[] };
+      return {
+        id: 'root',
+        children: input.children.map((c, i) => ({
+          id: c.id,
+          position: { x: i * 100, y: 0 },
+          width: 40,
+          height: 20,
+        })),
+        edges: input.edges.map(e => ({
+          id: e.id,
+          sections: [
+            {
+              startPoint: { x: 40, y: 10 },
+              endPoint: { x: 100, y: 10 },
+            },
+          ],
+        })),
+      };
+    }
+  },
+}));
+
+const { createWebDiagramEngine } = await import('../src/web');
+
+describe('d2 elk bridge', () => {
+  it('renders a flat elk source through prepare → elkjs → render', async () => {
+    wasmCalls.length = 0;
+    const engine = createWebDiagramEngine();
+    const result = await engine.render({
+      engine: 'd2',
+      code: 'vars: {\n  d2-config: {\n    layout-engine: elk\n  }\n}\n\na -> b',
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.format).toBe('svg');
+    expect(result.payload).toContain('data-elk');
+    expect(wasmCalls).toContain('prepare');
+    expect(wasmCalls).toContain('elk.layout');
+    expect(wasmCalls).toContain('render');
+    expect(wasmCalls).not.toContain('convert');
+  });
+
+  it('falls back to dagre for an unsupported elk source (sequence diagram)', async () => {
+    wasmCalls.length = 0;
+    const engine = createWebDiagramEngine();
+    const result = await engine.render({
+      engine: 'd2',
+      code:
+        'vars: {\n  d2-config: {\n    layout-engine: elk\n  }\n}\n\nshape: sequence_diagram\na -> b',
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.payload).toContain('data-dagre');
+    expect(wasmCalls).toContain('convert');
+    // The prepared handle is dropped after the fallback decision.
+    expect(wasmCalls).toContain('drop_prepared');
+    expect(wasmCalls).not.toContain('render');
+  });
+
+  it('routes non-elk d2 through dagre convert', async () => {
+    wasmCalls.length = 0;
+    const engine = createWebDiagramEngine();
+    const result = await engine.render({ engine: 'd2', code: 'a -> b' });
+
+    expect(result.success).toBe(true);
+    expect(result.payload).toContain('data-dagre');
+    expect(wasmCalls).toEqual(['convert']);
+  });
+});

--- a/packages/engines/package.json
+++ b/packages/engines/package.json
@@ -81,7 +81,7 @@
     "echarts": "^5",
     "vega": "^5",
     "vega-lite": "^5",
-    "elkjs": "^0.9",
+    "elkjs": "0.8.2",
     "@actrium/plantuml-little-web": "workspace:*",
     "@actrium/d2-little-web": "workspace:*",
     "@actrium/mermaid-little-web": "workspace:*"
@@ -111,9 +111,9 @@
   },
   "devDependencies": {
     "echarts": "^5.5.0",
-    "elkjs": "^0.9.3",
+    "elkjs": "0.8.2",
+    "typescript": "^5.5.0",
     "vega": "^5.30.0",
-    "vega-lite": "^5.21.0",
-    "typescript": "^5.5.0"
+    "vega-lite": "^5.21.0"
   }
 }

--- a/packages/engines/package.json
+++ b/packages/engines/package.json
@@ -81,6 +81,7 @@
     "echarts": "^5",
     "vega": "^5",
     "vega-lite": "^5",
+    "elkjs": "^0.9",
     "@actrium/plantuml-little-web": "workspace:*",
     "@actrium/d2-little-web": "workspace:*",
     "@actrium/mermaid-little-web": "workspace:*"
@@ -95,6 +96,9 @@
     "vega-lite": {
       "optional": true
     },
+    "elkjs": {
+      "optional": true
+    },
     "@actrium/plantuml-little-web": {
       "optional": true
     },
@@ -107,6 +111,7 @@
   },
   "devDependencies": {
     "echarts": "^5.5.0",
+    "elkjs": "^0.9.3",
     "vega": "^5.30.0",
     "vega-lite": "^5.21.0",
     "typescript": "^5.5.0"

--- a/packages/engines/src/rn.ts
+++ b/packages/engines/src/rn.ts
@@ -66,6 +66,16 @@ export function createReactNativeDiagramEngine(
       const engine = String(params.engine || '').toLowerCase();
       const adapter = getNativeEngineAdapter(engine);
 
+      // D2 `layout-engine: elk` is rendered via the elkjs bridge on web
+      // only (see `loadWebD2Render`). elkjs on Hermes is unverified, so
+      // RN keeps the native dagre path and warns so users know the elk
+      // request was honoured as dagre, not silently.
+      if (engine === 'd2' && /layout-engine\s*:\s*elk\b/i.test(String(params.code ?? ''))) {
+        console.warn(
+          '[d2] layout-engine "elk" is not supported on React Native yet; rendering with dagre.'
+        );
+      }
+
       if (adapter) {
         const id = `rn_${Date.now()}_${nextId++}`;
         try {

--- a/packages/engines/src/web.ts
+++ b/packages/engines/src/web.ts
@@ -322,7 +322,10 @@ async function loadWebD2Render(): Promise<DiagramRenderFn> {
 
 /** Does the D2 source request the elk layout engine? */
 function requestsElkLayout(code: string): boolean {
-  return /layout-engine\s*:\s*elk\b/i.test(code);
+  // Anchor to a line so a node label that happens to contain the text
+  // (e.g. `a: "layout-engine: elk"`) doesn't falsely route to elk, and
+  // accept an optionally-quoted value (`elk` / `"elk"` / `'elk'`).
+  return /^\s*layout-engine\s*:\s*["']?elk["']?\s*$/im.test(code);
 }
 
 /**

--- a/packages/engines/src/web.ts
+++ b/packages/engines/src/web.ts
@@ -361,6 +361,12 @@ async function renderD2ViaElk(d2: WasmRenderModule, code: string): Promise<strin
 /** Lazy elkjs loader — mirrors the echarts/vega dynamic-import pattern.
  * Pinned to 0.8.2, the exact version d2 v0.7.1 bundles. */
 async function loadElkLayout(): Promise<{ layout(graph: unknown): Promise<unknown> }> {
+  // Test override: lets unit tests inject a fake elk without relying on
+  // `mock.module` intercepting the dynamic `elkjs` import (which is flaky
+  // across environments). `null` restores the real lazy loader.
+  if (_elkLoaderOverride) {
+    return _elkLoaderOverride();
+  }
   // `elkjs/lib/elk.bundled.js` is the browser-safe build (no Node deps).
   const mod = (await import('elkjs/lib/elk.bundled.js' as string)) as {
     default?: new () => { layout(graph: unknown): Promise<unknown> };
@@ -369,6 +375,19 @@ async function loadElkLayout(): Promise<{ layout(graph: unknown): Promise<unknow
   if (!ELK) throw new Error('elkjs bundled build did not export a default ELK constructor.');
   return new ELK();
 }
+
+// --- elk loader test override (see `loadElkLayout`) ---
+type ElkLoader = () => Promise<{ layout(graph: unknown): Promise<unknown> }>;
+let _elkLoaderOverride: ElkLoader | null = null;
+/** @internal Test-only: inject a fake elk loader. Pass `null` to restore. */
+export function _setElkLoaderForTest(loader: ElkLoader | null): void {
+  _elkLoaderOverride = loader;
+}
+
+// Re-exported for direct unit testing of the bridge orchestration without
+// the `mock.module`-intercepts-dynamic-import coupling.
+export { renderD2ViaElk };
+export type { D2LayoutRequest, D2LayoutResult, WasmRenderModule };
 
 function injectD2Dimensions(svg: string): string {
   const openTag = svg.match(/<svg\b[^>]*>/);

--- a/packages/engines/src/web.ts
+++ b/packages/engines/src/web.ts
@@ -40,32 +40,20 @@ interface D2PrepareResult {
 
 // --- elk layout bridge DTO (mirrors crates/d2-little/src/layout_bridge.rs) ---
 
-interface D2BoardRequest {
-  token: string;
+/** d2-little's `LayoutRequest`: the complete ELK input graph plus feature
+ * flags. The host runs `elkjs.layout(request.elk_graph)` and hands the laid-out
+ * graph back as `D2LayoutResult.elk_graph`. All d2 `d2elklayout` logic
+ * (layoutOptions, node sizing, post-processing) lives in the Rust crate —
+ * the host is a thin elkjs runner. */
+interface D2LayoutRequest {
+  multi_board: boolean;
   has_sequence: boolean;
   has_grid: boolean;
   has_near: boolean;
-  has_containers: boolean;
-  objects: { id: string; width: number; height: number; parent_id: string | null }[];
-  edges: {
-    id: string;
-    src: string;
-    dst: string;
-    has_label: boolean;
-    label_width: number;
-    label_height: number;
-  }[];
-}
-interface D2LayoutRequest {
-  multi_board: boolean;
-  boards: D2BoardRequest[];
+  elk_graph: unknown;
 }
 interface D2LayoutResult {
-  boards: {
-    token: string;
-    objects: { id: string; x: number; y: number }[];
-    edges: { id: string; route: [number, number][]; is_curve?: boolean }[];
-  }[];
+  elk_graph: unknown;
 }
 
 /** A loaded `@actrium/graphviz-anywhere-web` Graphviz instance. */
@@ -350,22 +338,13 @@ async function renderD2ViaElk(d2: WasmRenderModule, code: string): Promise<strin
   let handle = prepared.handle;
   try {
     const request = JSON.parse(prepared.request) as D2LayoutRequest;
-    const board = request.boards[0];
-    if (
-      request.multi_board ||
-      !board ||
-      board.has_sequence ||
-      board.has_grid ||
-      board.has_near ||
-      board.has_containers
-    ) {
+    if (request.multi_board || request.has_sequence || request.has_grid || request.has_near) {
       return null; // fall back to dagre
     }
 
     const elk = await loadElkLayout();
-    const elkGraph = buildElkGraph(board);
-    const laid = await elk.layout(elkGraph);
-    const layoutResult = elkResultToD2(laid);
+    const laid = await elk.layout(request.elk_graph);
+    const layoutResult: D2LayoutResult = { elk_graph: laid };
     const svg = d2.render!(handle, JSON.stringify(layoutResult));
     handle = -1; // render consumed the handle
     if (!String(svg).includes('<svg')) {
@@ -379,7 +358,8 @@ async function renderD2ViaElk(d2: WasmRenderModule, code: string): Promise<strin
   }
 }
 
-/** Lazy elkjs loader — mirrors the echarts/vega dynamic-import pattern. */
+/** Lazy elkjs loader — mirrors the echarts/vega dynamic-import pattern.
+ * Pinned to 0.8.2, the exact version d2 v0.7.1 bundles. */
 async function loadElkLayout(): Promise<{ layout(graph: unknown): Promise<unknown> }> {
   // `elkjs/lib/elk.bundled.js` is the browser-safe build (no Node deps).
   const mod = (await import('elkjs/lib/elk.bundled.js' as string)) as {
@@ -388,109 +368,6 @@ async function loadElkLayout(): Promise<{ layout(graph: unknown): Promise<unknow
   const ELK = mod.default;
   if (!ELK) throw new Error('elkjs bundled build did not export a default ELK constructor.');
   return new ELK();
-}
-
-/**
- * Build the elkjs input graph from a flat d2 board request (MVP: no nesting).
- *
- * Layout options mirror upstream d2's `d2elklayout` defaults
- * (`d2layouts/d2elklayout/layout.go`): `GREEDY_MODEL_ORDER` cycle breaking
- * + `NODES_AND_EDGES` model order + `BALANCED` fixed alignment +
- * `forceNodeModelOrder` per node, so the output matches d2lang.com's elk
- * rendering (clean parallel edge routing) rather than elkjs defaults (which
- * curve backward edges around into S-shapes on fully-connected graphs).
- *
- * d2 also inflates each node's width (or height, for horizontal directions)
- * by `max(incoming, outgoing) * PORT_SPACING` when a node has ≥2 edges on a
- * side, so multiple edges attach at distinct ports instead of overlapping —
- * reproduced here.
- */
-function buildElkGraph(board: D2BoardRequest): unknown {
-  const PORT_SPACING = 40;
-  const incoming: Record<string, number> = {};
-  const outgoing: Record<string, number> = {};
-  for (const e of board.edges) {
-    outgoing[e.src] = (outgoing[e.src] ?? 0) + 1;
-    incoming[e.dst] = (incoming[e.dst] ?? 0) + 1;
-  }
-
-  // Root-level options (d2 DefaultLayout root LayoutOptions).
-  const rootOpts = {
-    'elk.algorithm': 'layered',
-    'elk.direction': 'DOWN',
-    'elk.layered.thoroughness': 8,
-    'elk.layered.spacing.edgeEdgeBetweenLayers': 50,
-    'elk.spacing.edgeNode': 40,
-    'elk.hierarchyHandling': 'INCLUDE_CHILDREN',
-    'elk.layered.nodePlacement.bk.fixedAlignment': 'BALANCED',
-    'elk.layered.considerModelOrder.strategy': 'NODES_AND_EDGES',
-    'elk.layered.cycleBreaking.strategy': 'GREEDY_MODEL_ORDER',
-    'elk.nodeSize.constraints': 'MINIMUM_SIZE',
-    'elk.contentAlignment': 'H_CENTER V_CENTER',
-    'spacing.nodeNodeBetweenLayers': 70,
-    'spacing.edgeNodeBetweenLayers': 40,
-    'elk.spacing.nodeSelfLoop': 50,
-  };
-  // Per-node options — forceNodeModelOrder preserves declaration order.
-  const nodeOpts = {
-    ...rootOpts,
-    'elk.layered.crossingMinimization.forceNodeModelOrder': true,
-  };
-
-  return {
-    id: 'root',
-    layoutOptions: rootOpts,
-    children: board.objects.map(o => {
-      const ec = Math.max(incoming[o.id] ?? 0, outgoing[o.id] ?? 0);
-      const inflate = (incoming[o.id] ?? 0) >= 2 || (outgoing[o.id] ?? 0) >= 2;
-      // MVP is vertical (DOWN) only, so inflation widens the node.
-      const width = inflate ? Math.max(o.width, ec * PORT_SPACING) : o.width;
-      return { id: o.id, width, height: o.height, layoutOptions: nodeOpts };
-    }),
-    edges: board.edges.map(e => ({
-      id: e.id,
-      sources: [e.src],
-      targets: [e.dst],
-    })),
-  };
-}
-
-/** Map elkjs output back into the d2 layout-result DTO. */
-function elkResultToD2(laid: unknown): D2LayoutResult {
-  const root = laid as {
-    children?: {
-      id: string;
-      // elkjs places positions either nested (`position`) or flat on the
-      // node depending on version / build; accept both.
-      position?: { x: number; y: number };
-      x?: number;
-      y?: number;
-    }[];
-    edges?: {
-      id: string;
-      sections?: {
-        startPoint: { x: number; y: number };
-        endPoint: { x: number; y: number };
-        bendPoints?: { x: number; y: number }[];
-      }[];
-    }[];
-  };
-  const objects = (root.children ?? []).map(c => ({
-    id: c.id,
-    x: c.position?.x ?? c.x ?? 0,
-    y: c.position?.y ?? c.y ?? 0,
-  }));
-  const edges = (root.edges ?? []).map(e => {
-    const section = e.sections?.[0];
-    const route: [number, number][] = [];
-    if (section) {
-      route.push([section.startPoint.x, section.startPoint.y]);
-      for (const bp of section.bendPoints ?? []) route.push([bp.x, bp.y]);
-      route.push([section.endPoint.x, section.endPoint.y]);
-    }
-    return { id: e.id, route, is_curve: false };
-  });
-  return { boards: [{ token: 'root', objects, edges }] };
 }
 
 function injectD2Dimensions(svg: string): string {

--- a/packages/engines/src/web.ts
+++ b/packages/engines/src/web.ts
@@ -22,8 +22,50 @@ interface WasmRenderModule {
   default?: unknown;
   init?: unknown;
   convert?: unknown;
-  render?: unknown;
+  // d2's `render` export is the elk bridge (handle, layoutJson). Other
+  // wasm modules use `render` as a convert-fallback name; `pickWasmConvert`
+  // casts it to WasmConvertFn in that case.
+  render?: (handle: number, layoutJson: string) => string;
   renderSvg?: unknown;
+  // elk layout bridge exports (added alongside `convert`):
+  prepare?: (input: string) => D2PrepareResult;
+  drop_prepared?: (handle: number) => void;
+}
+
+/** Result of the wasm `prepare` export (wasm-bindgen class with getters). */
+interface D2PrepareResult {
+  handle: number;
+  request: string;
+}
+
+// --- elk layout bridge DTO (mirrors crates/d2-little/src/layout_bridge.rs) ---
+
+interface D2BoardRequest {
+  token: string;
+  has_sequence: boolean;
+  has_grid: boolean;
+  has_near: boolean;
+  has_containers: boolean;
+  objects: { id: string; width: number; height: number; parent_id: string | null }[];
+  edges: {
+    id: string;
+    src: string;
+    dst: string;
+    has_label: boolean;
+    label_width: number;
+    label_height: number;
+  }[];
+}
+interface D2LayoutRequest {
+  multi_board: boolean;
+  boards: D2BoardRequest[];
+}
+interface D2LayoutResult {
+  boards: {
+    token: string;
+    objects: { id: string; x: number; y: number }[];
+    edges: { id: string; route: [number, number][]; is_curve?: boolean }[];
+  }[];
 }
 
 /** A loaded `@actrium/graphviz-anywhere-web` Graphviz instance. */
@@ -49,7 +91,10 @@ function pickWasmInit(mod: WasmRenderModule): WasmInitFn | null {
 /** Probe a wasm-bindgen module for a `convert`/`render`/`renderSvg` entry. */
 function pickWasmConvert(mod: WasmRenderModule): WasmConvertFn | null {
   if (typeof mod.convert === 'function') return mod.convert as WasmConvertFn;
-  if (typeof mod.render === 'function') return mod.render as WasmConvertFn;
+  // `render` on d2's module is the elk bridge ((handle, json) => svg), not a
+  // convert entry; d2 always exposes `convert`, so this fallback is only hit
+  // for other modules that name their convert-fn `render`.
+  if (typeof mod.render === 'function') return mod.render as unknown as WasmConvertFn;
   if (typeof mod.renderSvg === 'function') return mod.renderSvg as WasmConvertFn;
   return null;
 }
@@ -252,6 +297,24 @@ async function loadWebD2Render(): Promise<DiagramRenderFn> {
   }
 
   return async (code: string): Promise<string> => {
+    // `layout-engine: elk` is routed to the elkjs bridge (host-driven
+    // layered layout) instead of d2-little's built-in dagre. The bridge
+    // falls back to dagre for inputs it can't handle yet (multi-board,
+    // sequence / grid / containers / `near:`), so users always get a
+    // rendered diagram. See `loadWebD2ElkLayout`.
+    if (requestsElkLayout(code) && typeof d2.prepare === 'function' && typeof d2.render === 'function') {
+      try {
+        const elkSvg = await renderD2ViaElk(d2, code);
+        if (elkSvg != null) {
+          return injectD2Dimensions(elkSvg);
+        }
+        // `null` ⇒ prepare flagged an unsupported feature; fall through to dagre.
+      } catch (err) {
+        // Don't leave a prepared graph pinned in wasm memory.
+        console.warn('[d2] elk layout failed, falling back to dagre:', err);
+      }
+    }
+
     // `convert` is synchronous (wasm-bindgen-generated) but `await` handles
     // both sync and async return shapes uniformly.
     const svg = await convert(code);
@@ -267,6 +330,125 @@ async function loadWebD2Render(): Promise<DiagramRenderFn> {
     // so the SVG renders at its intrinsic size (CSS can shrink it if needed).
     return injectD2Dimensions(normalized);
   };
+}
+
+/** Does the D2 source request the elk layout engine? */
+function requestsElkLayout(code: string): boolean {
+  return /layout-engine\s*:\s*elk\b/i.test(code);
+}
+
+/**
+ * Drive the elkjs layered layout through d2-little's prepare/render bridge.
+ * Returns the rendered SVG, or `null` when the input carries a feature the
+ * MVP can't lay out externally (in which case the caller falls back to the
+ * dagre `convert` path).
+ *
+ * Lazy-loads `elkjs` on first use; non-elk D2 never pays the cost.
+ */
+async function renderD2ViaElk(d2: WasmRenderModule, code: string): Promise<string | null> {
+  const prepared = d2.prepare!(code);
+  let handle = prepared.handle;
+  try {
+    const request = JSON.parse(prepared.request) as D2LayoutRequest;
+    const board = request.boards[0];
+    if (
+      request.multi_board ||
+      !board ||
+      board.has_sequence ||
+      board.has_grid ||
+      board.has_near ||
+      board.has_containers
+    ) {
+      return null; // fall back to dagre
+    }
+
+    const elk = await loadElkLayout();
+    const elkGraph = buildElkGraph(board);
+    const laid = await elk.layout(elkGraph);
+    const layoutResult = elkResultToD2(laid);
+    const svg = d2.render!(handle, JSON.stringify(layoutResult));
+    handle = -1; // render consumed the handle
+    if (!String(svg).includes('<svg')) {
+      throw new Error('D2 elk bridge did not return SVG output.');
+    }
+    return String(svg);
+  } finally {
+    if (handle !== -1 && typeof d2.drop_prepared === 'function') {
+      d2.drop_prepared(handle);
+    }
+  }
+}
+
+/** Lazy elkjs loader — mirrors the echarts/vega dynamic-import pattern. */
+async function loadElkLayout(): Promise<{ layout(graph: unknown): Promise<unknown> }> {
+  // `elkjs/lib/elk.bundled.js` is the browser-safe build (no Node deps).
+  const mod = (await import('elkjs/lib/elk.bundled.js' as string)) as {
+    default?: new () => { layout(graph: unknown): Promise<unknown> };
+  };
+  const ELK = mod.default;
+  if (!ELK) throw new Error('elkjs bundled build did not export a default ELK constructor.');
+  return new ELK();
+}
+
+/** Build the elkjs input graph from a flat d2 board request (MVP: no nesting). */
+function buildElkGraph(board: D2BoardRequest): unknown {
+  return {
+    id: 'root',
+    layoutOptions: {
+      'elk.algorithm': 'layered',
+      'elk.direction': 'DOWN',
+      'elk.layered.spacing.nodeNodeBetweenLayers': '40',
+      'elk.spacing.nodeNode': '40',
+    },
+    children: board.objects.map(o => ({
+      id: o.id,
+      width: o.width,
+      height: o.height,
+    })),
+    edges: board.edges.map(e => ({
+      id: e.id,
+      sources: [e.src],
+      targets: [e.dst],
+    })),
+  };
+}
+
+/** Map elkjs output back into the d2 layout-result DTO. */
+function elkResultToD2(laid: unknown): D2LayoutResult {
+  const root = laid as {
+    children?: {
+      id: string;
+      // elkjs places positions either nested (`position`) or flat on the
+      // node depending on version / build; accept both.
+      position?: { x: number; y: number };
+      x?: number;
+      y?: number;
+    }[];
+    edges?: {
+      id: string;
+      sections?: {
+        startPoint: { x: number; y: number };
+        endPoint: { x: number; y: number };
+        bendPoints?: { x: number; y: number }[];
+      }[];
+    }[];
+  };
+  const objects = (root.children ?? []).map(c => ({
+    id: c.id,
+    x: c.position?.x ?? c.x ?? 0,
+    y: c.position?.y ?? c.y ?? 0,
+  }));
+  const edges = (root.edges ?? []).map(e => {
+    const section = e.sections?.[0];
+    const route: [number, number][] = [];
+    if (section) {
+      route.push([section.startPoint.x, section.startPoint.y]);
+      for (const bp of section.bendPoints ?? []) route.push([bp.x, bp.y]);
+      route.push([section.endPoint.x, section.endPoint.y]);
+    }
+    return { id: e.id, route, is_curve: false };
+  });
+  return { boards: [{ token: 'root', objects, edges }] };
 }
 
 function injectD2Dimensions(svg: string): string {

--- a/packages/engines/src/web.ts
+++ b/packages/engines/src/web.ts
@@ -390,21 +390,63 @@ async function loadElkLayout(): Promise<{ layout(graph: unknown): Promise<unknow
   return new ELK();
 }
 
-/** Build the elkjs input graph from a flat d2 board request (MVP: no nesting). */
+/**
+ * Build the elkjs input graph from a flat d2 board request (MVP: no nesting).
+ *
+ * Layout options mirror upstream d2's `d2elklayout` defaults
+ * (`d2layouts/d2elklayout/layout.go`): `GREEDY_MODEL_ORDER` cycle breaking
+ * + `NODES_AND_EDGES` model order + `BALANCED` fixed alignment +
+ * `forceNodeModelOrder` per node, so the output matches d2lang.com's elk
+ * rendering (clean parallel edge routing) rather than elkjs defaults (which
+ * curve backward edges around into S-shapes on fully-connected graphs).
+ *
+ * d2 also inflates each node's width (or height, for horizontal directions)
+ * by `max(incoming, outgoing) * PORT_SPACING` when a node has ≥2 edges on a
+ * side, so multiple edges attach at distinct ports instead of overlapping —
+ * reproduced here.
+ */
 function buildElkGraph(board: D2BoardRequest): unknown {
+  const PORT_SPACING = 40;
+  const incoming: Record<string, number> = {};
+  const outgoing: Record<string, number> = {};
+  for (const e of board.edges) {
+    outgoing[e.src] = (outgoing[e.src] ?? 0) + 1;
+    incoming[e.dst] = (incoming[e.dst] ?? 0) + 1;
+  }
+
+  // Root-level options (d2 DefaultLayout root LayoutOptions).
+  const rootOpts = {
+    'elk.algorithm': 'layered',
+    'elk.direction': 'DOWN',
+    'elk.layered.thoroughness': 8,
+    'elk.layered.spacing.edgeEdgeBetweenLayers': 50,
+    'elk.spacing.edgeNode': 40,
+    'elk.hierarchyHandling': 'INCLUDE_CHILDREN',
+    'elk.layered.nodePlacement.bk.fixedAlignment': 'BALANCED',
+    'elk.layered.considerModelOrder.strategy': 'NODES_AND_EDGES',
+    'elk.layered.cycleBreaking.strategy': 'GREEDY_MODEL_ORDER',
+    'elk.nodeSize.constraints': 'MINIMUM_SIZE',
+    'elk.contentAlignment': 'H_CENTER V_CENTER',
+    'spacing.nodeNodeBetweenLayers': 70,
+    'spacing.edgeNodeBetweenLayers': 40,
+    'elk.spacing.nodeSelfLoop': 50,
+  };
+  // Per-node options — forceNodeModelOrder preserves declaration order.
+  const nodeOpts = {
+    ...rootOpts,
+    'elk.layered.crossingMinimization.forceNodeModelOrder': true,
+  };
+
   return {
     id: 'root',
-    layoutOptions: {
-      'elk.algorithm': 'layered',
-      'elk.direction': 'DOWN',
-      'elk.layered.spacing.nodeNodeBetweenLayers': '40',
-      'elk.spacing.nodeNode': '40',
-    },
-    children: board.objects.map(o => ({
-      id: o.id,
-      width: o.width,
-      height: o.height,
-    })),
+    layoutOptions: rootOpts,
+    children: board.objects.map(o => {
+      const ec = Math.max(incoming[o.id] ?? 0, outgoing[o.id] ?? 0);
+      const inflate = (incoming[o.id] ?? 0) >= 2 || (outgoing[o.id] ?? 0) >= 2;
+      // MVP is vertical (DOWN) only, so inflation widens the node.
+      const width = inflate ? Math.max(o.width, ec * PORT_SPACING) : o.width;
+      return { id: o.id, width, height: o.height, layoutOptions: nodeOpts };
+    }),
     edges: board.edges.map(e => ({
       id: e.id,
       sources: [e.src],


### PR DESCRIPTION
Fixes #34.

## Problem

D2 sources with `vars.d2-config.layout-engine: elk` fell back to d2-little's dagre, producing messy fully-connected layouts that diverged from upstream d2's clean **vertical** elk output (the issue's `* -> *: 👉` over 3 nodes).

A prior attempt (`fix/d2-issue-34`) was an MVP: it only handled flat single-board diagrams, fell back to dagre for everything else, and hand-built a partial ELK graph in TypeScript with empirically-tuned layout options.

## Approach — faithful port, not empirical tweaks

This replaces the bridge with a faithful Rust port of d2's own `d2layouts/d2elklayout/layout.go` (d2 v0.7.1), so output is byte-comparable with upstream d2 elk. All d2 logic lives in Rust; the host is a thin `elkjs` runner.

- **`layout_bridge.rs`**: typed ELK DTOs with d2's exact json keys, `build_layout_request` builds the complete ELK input graph (root + per-container `layoutOptions` — containers must NOT set `elk.algorithm`, only the root does, or elkjs skips child placement; node-size inflation by `max(incoming,outgoing)*40`; `SpacingOpt` margins; node/edge labels with `InlineEdgeLabels`; SQL-table ports; hierarchy via `INCLUDE_CHILDREN`), and `apply_layout` does the full post-processing (parent-relative→absolute, margin shrink-back + ported `ShiftDescendants`/`ShiftStart`/`ShiftEnd`, a faithful `TraceToShape` port with outside-label/outside-icon/3d-multiple-modifier handling, `InsideMiddleCenter` edge labels, `deleteBends` S-shape/ladder removal, `adjustPadding`).
- **`elkjs` pinned to `0.8.2`** — the exact version d2 v0.7.1 bundles. Was `^0.9`, which routes differently.
- **`web.ts`** is a thin runner: `prepare → elkjs.layout(request.elk_graph) → render`; the elk loader is injectable for tests.
- **`index.ts`** re-exports `prepare`/`render`/`drop_prepared` (the bridge was unreachable before — the wrapper only exported `convert`/`version`).
- Sequence / grid / `near:` diagrams fall back to the dagre `convert` path (engine-independent specialized layouts) — matches the production host contract.

## Tests

- `tests/elk_bridge.rs`: issue #34 byte-exact golden + vertical-edge assertion (the "官方的连接线是竖着的" property), plus an `#[ignore]` full 293-fixture parity sweep (floor asserted at 190).
- `tests/elk_runner.mjs`: stdin/stdout `elkjs@0.8.2` runner (ESM so ESLint leaves it alone). Tests skip cleanly when `node`/`elkjs` are absent.
- `examples/dump_elk.rs` + `scripts/elk_parity_check.py`: iteration tooling.
- 856 Rust lib tests + 14 engines tests green; CI green on all 8 jobs.

## Status — 198 / 293 elk fixtures byte-exact (67%)

| commit | fix | gain |
|---|---|---|
| `9543f81e` | container nodes must not set `elk.algorithm` (children weren't laid out) | +39 |
| `c87ce052` | `TraceToShape` outside-label/icon handling (image/person labels) | +2 |
| `75e7ca54` | 3d/multiple modifier edge endpoints traced to offset box | +6 |
| `b58addd7` | seq/grid/`near:` fall back to dagre (engine-independent) | +34 |

- ✅ Issue #34 renders as a clean vertical column, **geometry byte-identical to upstream `d2 --layout=elk`**.
- ✅ All margin categories fixed systematically (containers, outside labels, 3d/multiple).
- ⏳ Remaining 95 are tracked by the harness and split for follow-up:
  - **49 mixed** (seq/grid/`near:` container + surrounding elk nodes): needs `layout_nested`'s pre-layout + post-apply extracted into a reusable form so elk can compose with the specialized layouts. Architectural — left for a separate focused PR to avoid regressing the 198 / the byte-exact dagre path.
  - **39 pure-elk**: `is_curve` renderer curves + `deleteBends` edge cases + non-rectangular `trace_to_shape_border` float precision. Intricate, per-case.
  - **7** latex-host cases (need the mathjax bridge; pass under the real engines host).

🤖 Generated with [Claude Code](https://claude.com/claude-code)