### PR TITLE
fix: statically link graphviz on desktop

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,6 +179,64 @@ jobs:
             echo "::endgroup::"
           done
 
+  # Exercise the exact crates.io fallback used by downstream `cargo install`
+  # consumers. A library-only `cargo build` cannot detect a missing rpath or a
+  # loader selecting an ABI-incompatible same-named shared library, so this job
+  # builds and runs a final executable with a real DOT -> SVG render.
+  graphviz-release-runtime-smoke:
+    name: Graphviz release runtime (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-14, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install Linux static-link dependencies
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y g++ libexpat1-dev zlib1g-dev
+
+      - name: Test target and ABI mappings
+        shell: bash
+        run: cargo test -p graphviz-anywhere --test build_helpers_tests
+
+      - name: Build final executable from release asset
+        shell: bash
+        env:
+          GRAPHVIZ_ANYWHERE_ALLOW_DOWNLOAD: "1"
+          # PRs for the next crate version run before that tag exists. Use the
+          # latest published assets while exercising the current build script.
+          GRAPHVIZ_ANYWHERE_RELEASE_VERSION: "0.2.3"
+        run: cargo build --release -p graphviz-anywhere-example
+
+      - name: Run DOT-to-SVG smoke without loader overrides
+        shell: bash
+        run: |
+          if [ "$RUNNER_OS" = "Windows" ]; then
+            target/release/graphviz-anywhere-example.exe > graphviz-smoke.log
+          else
+            env -u LD_LIBRARY_PATH -u DYLD_LIBRARY_PATH \
+              target/release/graphviz-anywhere-example > graphviz-smoke.log
+          fi
+          grep -q "SVG output" graphviz-smoke.log
+
+      - name: Assert no Graphviz desktop runtime dependency
+        if: runner.os != 'Windows'
+        shell: bash
+        run: |
+          if [ "$RUNNER_OS" = "macOS" ]; then
+            ! otool -L target/release/graphviz-anywhere-example | grep -q libgraphviz_api
+          else
+            ! ldd target/release/graphviz-anywhere-example | grep -q libgraphviz_api
+          fi
+
   # plantuml-little's Rust tests (parser / layout / render unit tests) do not
   # run in the "Test & Build" job — that job only exercises the RN JS wrappers,
   # and `cargo test -p plantuml-little` needs the graphviz-anywhere native lib,
@@ -311,4 +369,3 @@ jobs:
         env:
           PLANTUML_LITTLE_TEST_BACKEND: wasm
         run: bash crates/plantuml-little/scripts/check_reference_failures.sh
-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,6 +185,11 @@ jobs:
   # builds and runs a final executable with a real DOT -> SVG render.
   graphviz-release-runtime-smoke:
     name: Graphviz release runtime (${{ matrix.os }})
+    env:
+      # PRs for the next crate version run before that tag exists. Use the
+      # latest published assets while exercising the current build script.
+      GRAPHVIZ_ANYWHERE_ALLOW_DOWNLOAD: "1"
+      GRAPHVIZ_ANYWHERE_RELEASE_VERSION: "0.2.3"
     strategy:
       fail-fast: false
       matrix:
@@ -209,11 +214,6 @@ jobs:
 
       - name: Build final executable from release asset
         shell: bash
-        env:
-          GRAPHVIZ_ANYWHERE_ALLOW_DOWNLOAD: "1"
-          # PRs for the next crate version run before that tag exists. Use the
-          # latest published assets while exercising the current build script.
-          GRAPHVIZ_ANYWHERE_RELEASE_VERSION: "0.2.3"
         run: cargo build --release -p graphviz-anywhere-example
 
       - name: Run DOT-to-SVG smoke without loader overrides

--- a/.github/workflows/graphviz-release.yml
+++ b/.github/workflows/graphviz-release.yml
@@ -1,4 +1,4 @@
-name: Build
+name: Graphviz Release
 
 on:
   push:
@@ -14,6 +14,10 @@ concurrency:
 permissions:
   contents: write
 
+defaults:
+  run:
+    working-directory: crates/graphviz-anywhere
+
 jobs:
   build-linux:
     strategy:
@@ -22,11 +26,8 @@ jobs:
           - arch: x86_64
             runs-on: ubuntu-latest
           - arch: aarch64
-            # TODO(infra): switch to ubuntu-24.04-arm once confirmed available in this org
-            runs-on: ubuntu-latest
-            continue-on-error: true
+            runs-on: ubuntu-22.04-arm
     runs-on: ${{ matrix.runs-on }}
-    continue-on-error: ${{ matrix.continue-on-error == true }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -34,14 +35,14 @@ jobs:
 
       - name: Resolve graphviz submodule pin
         id: gvpin
-        run: echo "sha=$(git rev-parse HEAD:graphviz)" >> "$GITHUB_OUTPUT"
+        run: echo "sha=$(git rev-parse HEAD:crates/graphviz-anywhere/graphviz)" >> "$GITHUB_OUTPUT"
 
       - name: Cache build output
         id: cache
         uses: actions/cache@v4
         with:
-          path: output/linux-${{ matrix.arch }}
-          key: gv-build-linux-${{ matrix.arch }}-${{ steps.gvpin.outputs.sha }}-${{ hashFiles('capi/**', 'scripts/build-linux.sh', 'scripts/common.sh') }}
+          path: crates/graphviz-anywhere/output/linux-${{ matrix.arch }}
+          key: gv-build-linux-${{ matrix.arch }}-${{ steps.gvpin.outputs.sha }}-${{ hashFiles('crates/graphviz-anywhere/capi/**', 'crates/graphviz-anywhere/scripts/build-linux.sh', 'crates/graphviz-anywhere/scripts/common.sh') }}
 
       - name: Install dependencies
         if: steps.cache.outputs.cache-hit != 'true'
@@ -78,21 +79,18 @@ jobs:
         run: |
           if [ "${{ matrix.arch }}" = "x86_64" ]; then
             RUST_TARGET="x86_64-unknown-linux-gnu"
-            GVA_DIR="${GITHUB_WORKSPACE}/output/linux-x86_64/lib"
-            rustup target add "$RUST_TARGET"
-            GRAPHVIZ_ANYWHERE_NO_DOWNLOAD=1 \
-            GRAPHVIZ_ANYWHERE_DIR="$GVA_DIR" \
-              cargo build --release --target "$RUST_TARGET" -p graphviz-anywhere
           else
-            # aarch64: runner is x86_64, use `cross` for docker-based cross-compile
             RUST_TARGET="aarch64-unknown-linux-gnu"
-            GVA_DIR="${GITHUB_WORKSPACE}/output/linux-aarch64/lib"
-            cargo install cross --quiet
-            rustup target add "$RUST_TARGET"
-            GRAPHVIZ_ANYWHERE_NO_DOWNLOAD=1 \
-            GRAPHVIZ_ANYWHERE_DIR="$GVA_DIR" \
-              cross build --release --target "$RUST_TARGET" -p graphviz-anywhere
           fi
+          GVA_DIR="${GITHUB_WORKSPACE}/crates/graphviz-anywhere/output/linux-${{ matrix.arch }}/lib"
+          rustup target add "$RUST_TARGET"
+          GRAPHVIZ_ANYWHERE_NO_DOWNLOAD=1 \
+          GRAPHVIZ_ANYWHERE_DIR="$GVA_DIR" \
+            cargo build --release --target "$RUST_TARGET" -p graphviz-anywhere-example
+          binary="target/$RUST_TARGET/release/graphviz-anywhere-example"
+          env -u LD_LIBRARY_PATH "$binary" > graphviz-smoke.log
+          grep -q "SVG output" graphviz-smoke.log
+          ! ldd "$binary" | grep -q libgraphviz_api
 
       - name: Package
         run: |
@@ -107,7 +105,7 @@ jobs:
       - uses: actions/upload-artifact@v7
         with:
           name: prebuilt-linux-${{ matrix.arch }}
-          path: packages/rust/prebuilt/
+          path: crates/graphviz-anywhere/packages/rust/prebuilt/
 
   build-macos:
     runs-on: macos-14
@@ -118,14 +116,14 @@ jobs:
 
       - name: Resolve graphviz submodule pin
         id: gvpin
-        run: echo "sha=$(git rev-parse HEAD:graphviz)" >> "$GITHUB_OUTPUT"
+        run: echo "sha=$(git rev-parse HEAD:crates/graphviz-anywhere/graphviz)" >> "$GITHUB_OUTPUT"
 
       - name: Cache build output
         id: cache
         uses: actions/cache@v4
         with:
-          path: output/macos-universal
-          key: gv-build-macos-universal-${{ steps.gvpin.outputs.sha }}-${{ hashFiles('capi/**', 'scripts/build-macos.sh', 'scripts/common.sh') }}
+          path: crates/graphviz-anywhere/output/macos-universal
+          key: gv-build-macos-universal-${{ steps.gvpin.outputs.sha }}-${{ hashFiles('crates/graphviz-anywhere/capi/**', 'crates/graphviz-anywhere/scripts/build-macos.sh', 'crates/graphviz-anywhere/scripts/common.sh') }}
 
       - name: Install dependencies
         if: steps.cache.outputs.cache-hit != 'true'
@@ -161,8 +159,12 @@ jobs:
           # Verify both Darwin targets against the universal library (host + cross)
           rustup target add aarch64-apple-darwin x86_64-apple-darwin
           for RUST_TARGET in aarch64-apple-darwin x86_64-apple-darwin; do
-            cargo build --release --target "$RUST_TARGET" -p graphviz-anywhere
+            cargo build --release --target "$RUST_TARGET" -p graphviz-anywhere-example
           done
+          binary="target/aarch64-apple-darwin/release/graphviz-anywhere-example"
+          env -u DYLD_LIBRARY_PATH "$binary" > graphviz-smoke.log
+          grep -q "SVG output" graphviz-smoke.log
+          ! otool -L "$binary" | grep -q libgraphviz_api
 
       - name: Package
         run: |
@@ -177,7 +179,7 @@ jobs:
       - uses: actions/upload-artifact@v7
         with:
           name: prebuilt-macos
-          path: packages/rust/prebuilt/
+          path: crates/graphviz-anywhere/packages/rust/prebuilt/
 
   build-ios:
     runs-on: macos-14
@@ -188,14 +190,14 @@ jobs:
 
       - name: Resolve graphviz submodule pin
         id: gvpin
-        run: echo "sha=$(git rev-parse HEAD:graphviz)" >> "$GITHUB_OUTPUT"
+        run: echo "sha=$(git rev-parse HEAD:crates/graphviz-anywhere/graphviz)" >> "$GITHUB_OUTPUT"
 
       - name: Cache build output
         id: cache
         uses: actions/cache@v4
         with:
-          path: output/ios
-          key: gv-build-ios-${{ steps.gvpin.outputs.sha }}-${{ hashFiles('capi/**', 'scripts/build-ios.sh', 'scripts/common.sh') }}
+          path: crates/graphviz-anywhere/output/ios
+          key: gv-build-ios-${{ steps.gvpin.outputs.sha }}-${{ hashFiles('crates/graphviz-anywhere/capi/**', 'crates/graphviz-anywhere/scripts/build-ios.sh', 'crates/graphviz-anywhere/scripts/common.sh') }}
 
       - name: Install dependencies
         if: steps.cache.outputs.cache-hit != 'true'
@@ -249,7 +251,7 @@ jobs:
               iphonesimulator-x86_64) RUST_TARGET=x86_64-apple-ios ;;
             esac
             GRAPHVIZ_ANYWHERE_NO_DOWNLOAD=1 \
-            GRAPHVIZ_ANYWHERE_DIR="${GITHUB_WORKSPACE}/output/ios/${slice}/lib" \
+            GRAPHVIZ_ANYWHERE_DIR="${GITHUB_WORKSPACE}/crates/graphviz-anywhere/output/ios/${slice}/lib" \
               cargo build --release --target "$RUST_TARGET" -p graphviz-anywhere
           done
 
@@ -285,14 +287,14 @@ jobs:
 
       - name: Resolve graphviz submodule pin
         id: gvpin
-        run: echo "sha=$(git rev-parse HEAD:graphviz)" >> "$GITHUB_OUTPUT"
+        run: echo "sha=$(git rev-parse HEAD:crates/graphviz-anywhere/graphviz)" >> "$GITHUB_OUTPUT"
 
       - name: Cache build output
         id: cache
         uses: actions/cache@v4
         with:
-          path: output/android/${{ matrix.abi }}
-          key: gv-build-android-${{ matrix.abi }}-${{ steps.gvpin.outputs.sha }}-${{ hashFiles('capi/**', 'scripts/build-android.sh', 'scripts/common.sh') }}
+          path: crates/graphviz-anywhere/output/android/${{ matrix.abi }}
+          key: gv-build-android-${{ matrix.abi }}-${{ steps.gvpin.outputs.sha }}-${{ hashFiles('crates/graphviz-anywhere/capi/**', 'crates/graphviz-anywhere/scripts/build-android.sh', 'crates/graphviz-anywhere/scripts/common.sh') }}
 
       - name: Install dependencies
         if: steps.cache.outputs.cache-hit != 'true'
@@ -321,7 +323,7 @@ jobs:
             x86_64)       RUST_TARGET=x86_64-linux-android ;;
             x86)          RUST_TARGET=i686-linux-android ;;
           esac
-          GVA_DIR="${GITHUB_WORKSPACE}/output/android/${{ matrix.abi }}/lib"
+          GVA_DIR="${GITHUB_WORKSPACE}/crates/graphviz-anywhere/output/android/${{ matrix.abi }}/lib"
           # cargo-ndk handles Android toolchain wiring; takes ABI names directly
           cargo install cargo-ndk --quiet
           rustup target add "$RUST_TARGET"
@@ -346,11 +348,8 @@ jobs:
           - arch: x86_64
             runs-on: windows-latest
           - arch: arm64
-            runs-on: windows-latest
-            # TODO(infra): verify Windows ARM64 cross-build (vcvarsall arm64)
-            continue-on-error: true
+            runs-on: windows-11-arm
     runs-on: ${{ matrix.runs-on }}
-    continue-on-error: ${{ matrix.continue-on-error == true }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -359,14 +358,14 @@ jobs:
       - name: Resolve graphviz submodule pin
         id: gvpin
         shell: bash
-        run: echo "sha=$(git rev-parse HEAD:graphviz)" >> "$GITHUB_OUTPUT"
+        run: echo "sha=$(git rev-parse HEAD:crates/graphviz-anywhere/graphviz)" >> "$GITHUB_OUTPUT"
 
       - name: Cache build output
         id: cache
         uses: actions/cache@v4
         with:
-          path: output/windows-${{ matrix.arch }}
-          key: gv-build-windows-${{ matrix.arch }}-${{ steps.gvpin.outputs.sha }}-${{ hashFiles('capi/**', 'scripts/build-windows.sh', 'scripts/common.sh') }}
+          path: crates/graphviz-anywhere/output/windows-${{ matrix.arch }}
+          key: gv-build-windows-${{ matrix.arch }}-${{ steps.gvpin.outputs.sha }}-${{ hashFiles('crates/graphviz-anywhere/capi/**', 'crates/graphviz-anywhere/scripts/build-windows.sh', 'crates/graphviz-anywhere/scripts/common.sh') }}
 
       - name: Install dependencies
         # choco.org serves 503 periodically; retry a few times before
@@ -389,12 +388,6 @@ jobs:
               exit 1
             }
           }
-
-      - name: Configure MSVC for ARM64 cross-compile
-        if: matrix.arch == 'arm64' && steps.cache.outputs.cache-hit != 'true'
-        shell: cmd
-        run: |
-          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64_arm64
 
       - name: Build
         if: steps.cache.outputs.cache-hit != 'true'
@@ -436,37 +429,44 @@ jobs:
           GRAPHVIZ_ANYWHERE_DIR: ${{ github.workspace }}/output/windows-x86_64/lib
         run: |
           rustup target add x86_64-pc-windows-msvc
-          cargo build --release --target x86_64-pc-windows-msvc -p graphviz-anywhere
+          cargo build --release --target x86_64-pc-windows-msvc -p graphviz-anywhere-example
+          target/x86_64-pc-windows-msvc/release/graphviz-anywhere-example.exe > graphviz-smoke.log
+          grep -q "SVG output" graphviz-smoke.log
 
       - name: Verify Rust crate cross-build (arm64)
-        # Windows arm64 cross-compile from x86_64 runner may not fully link;
-        # mirroring the continue-on-error of the existing arm64 native build leg.
         if: matrix.arch == 'arm64'
-        continue-on-error: true
         shell: bash
         env:
           GRAPHVIZ_ANYWHERE_NO_DOWNLOAD: "1"
           GRAPHVIZ_ANYWHERE_DIR: ${{ github.workspace }}/output/windows-arm64/lib
         run: |
           rustup target add aarch64-pc-windows-msvc
-          cargo build --release --target aarch64-pc-windows-msvc -p graphviz-anywhere
+          cargo build --release --target aarch64-pc-windows-msvc -p graphviz-anywhere-example
+          target/aarch64-pc-windows-msvc/release/graphviz-anywhere-example.exe > graphviz-smoke.log
+          grep -q "SVG output" graphviz-smoke.log
 
       - name: Package
         shell: bash
         run: |
-          cd output/windows-${{ matrix.arch }}
-          7z a "${GITHUB_WORKSPACE}/graphviz-native-windows-${{ matrix.arch }}.zip" .
+          stage="${RUNNER_TEMP}/graphviz-native-windows-${{ matrix.arch }}"
+          mkdir -p "$stage/lib" "$stage/include"
+          cp "output/windows-${{ matrix.arch }}/lib/graphviz_api_static.lib" \
+             "$stage/lib/graphviz_api.lib"
+          cp "output/windows-${{ matrix.arch }}/include/graphviz_api.h" \
+             "$stage/include/graphviz_api.h"
+          tar -czf "${GITHUB_WORKSPACE}/graphviz-native-windows-${{ matrix.arch }}.tar.gz" \
+              -C "$stage" .
 
       - uses: actions/upload-artifact@v7
         with:
           name: windows-${{ matrix.arch }}
-          path: graphviz-native-windows-${{ matrix.arch }}.zip
+          path: graphviz-native-windows-${{ matrix.arch }}.tar.gz
 
       - uses: actions/upload-artifact@v7
         if: matrix.arch == 'x86_64'
         with:
           name: prebuilt-windows
-          path: packages/rust/prebuilt/
+          path: crates/graphviz-anywhere/packages/rust/prebuilt/
 
   build-wasm:
     runs-on: ubuntu-latest
@@ -478,7 +478,7 @@ jobs:
 
       - name: Resolve graphviz submodule pin
         id: gvpin
-        run: echo "sha=$(git rev-parse HEAD:graphviz)" >> "$GITHUB_OUTPUT"
+        run: echo "sha=$(git rev-parse HEAD:crates/graphviz-anywhere/graphviz)" >> "$GITHUB_OUTPUT"
 
       - name: Cache wasm build output
         id: cache
@@ -488,7 +488,7 @@ jobs:
             packages/web/dist/viz.js
             packages/web/dist/viz.wasm
             packages/web/dist/viz.d.ts
-          key: gv-build-wasm-${{ steps.gvpin.outputs.sha }}-${{ hashFiles('capi/**', 'scripts/build-wasm.sh', 'scripts/common.sh') }}
+          key: gv-build-wasm-${{ steps.gvpin.outputs.sha }}-${{ hashFiles('crates/graphviz-anywhere/capi/**', 'crates/graphviz-anywhere/scripts/build-wasm.sh', 'crates/graphviz-anywhere/scripts/common.sh') }}
 
       - name: Install emscripten
         if: steps.cache.outputs.cache-hit != 'true'
@@ -524,75 +524,27 @@ jobs:
       - uses: actions/upload-artifact@v7
         with:
           name: wasm-dist
-          path: packages/web/dist/
+          path: crates/graphviz-anywhere/packages/web/dist/
 
-  publish-npm-cargo:
+  publish-cargo:
     # ONLY run on real v* tags. test* tags trigger CI matrix + GitHub
     # prerelease via the `release` job, but must NEVER publish to
-    # npm/crates.io — a duplicate version push to those registries is
-    # immutable and would burn the version number for the actual release.
+    # crates.io — a duplicate version push is immutable and would burn the
+    # version number for the actual release. npm packages have an independent
+    # version lifecycle and are deliberately not published from this workflow.
     if: startsWith(github.ref, 'refs/tags/v')
-    needs: [build-linux, build-macos, build-windows, build-wasm]
+    needs: [release]
     runs-on: ubuntu-latest
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v6
 
-      - name: Debug workspace
-        run: |
-          echo "Current dir: $(pwd)"
-          ls -la
-          [ -f package.json ] && echo "✓ package.json found" || echo "✗ package.json NOT found"
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '18'
-          registry-url: 'https://registry.npmjs.org'
-
-      - name: Download prebuilt artifacts
-        uses: actions/download-artifact@v8
-        with:
-          path: artifacts
-
-      - name: Restore prebuilt libraries
-        run: |
-          mkdir -p packages/rust/prebuilt/{macos,linux,windows}
-          mkdir -p packages/web/dist
-          # Best-effort copy; do not fail on missing files
-          cp -r artifacts/prebuilt-macos/* packages/rust/prebuilt/macos/ 2>/dev/null || true
-          cp -r artifacts/prebuilt-linux-x86_64/* packages/rust/prebuilt/linux/ 2>/dev/null || true
-          cp -r artifacts/prebuilt-windows/* packages/rust/prebuilt/windows/ 2>/dev/null || true
-          cp -r artifacts/wasm-dist/* packages/web/dist/ 2>/dev/null || true
-          echo "=== prebuilt libs ===" && find packages/rust/prebuilt -type f
-          echo "=== web/dist ===" && ls -la packages/web/dist/ || echo "⚠️  wasm-dist may not be available"
-
-      - name: Symlink wasm files for TypeScript compilation
-        run: |
-          mkdir -p output/wasm
-          ln -sf ../../packages/web/dist/viz.js output/wasm/viz.js || true
-          ln -sf ../../packages/web/dist/viz.wasm output/wasm/viz.wasm || true
-          ln -sf ../../packages/web/dist/viz.d.ts output/wasm/viz.d.ts || true
-
-      - name: Install dependencies
-        run: npm install
-
-      - name: Build packages
-        run: npm run build --workspaces
-
-      - name: Check npm package versions
-        run: npm run check:publish:npm
-
-      - name: Publish to npm
-        run: |
-          npm publish --workspace packages/web --access public --auth-type=legacy
-          npm publish --workspace packages/react-native --access public --auth-type=legacy
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NPM_CONFIG_OTP: ${{ secrets.NPM_OTP }}
-
       - uses: dtolnay/rust-toolchain@stable
-      - name: Publish to crates.io
-        run: cargo publish --manifest-path packages/rust/Cargo.toml --token ${{ secrets.CARGO_TOKEN }} --allow-dirty --no-verify
+      - name: Verify and publish to crates.io
+        env:
+          GRAPHVIZ_ANYWHERE_ALLOW_DOWNLOAD: "1"
+        run: |
+          cargo publish --manifest-path packages/rust/Cargo.toml --allow-dirty --dry-run
+          cargo publish --manifest-path packages/rust/Cargo.toml --token ${{ secrets.CARGO_TOKEN }} --allow-dirty
 
   release:
     # Run on real v* tags (full release) and test* tags (prerelease pipeline dry-run).
@@ -606,17 +558,15 @@ jobs:
       - build-windows
       - build-wasm
     runs-on: ubuntu-latest
-    continue-on-error: true
     steps:
       - uses: actions/download-artifact@v8
         with:
-          path: artifacts
+          path: crates/graphviz-anywhere/artifacts
 
       - name: Flatten release assets
         run: |
           mkdir -p release-assets
-          # Collect every .tar.gz and .zip from all artifact subdirs
-          find artifacts -name '*.tar.gz' -o -name '*.zip' | \
+          find artifacts -name '*.tar.gz' | \
             xargs -I{} cp {} release-assets/ || true
           echo "=== Release assets ==="
           ls -lh release-assets/
@@ -630,17 +580,17 @@ jobs:
           prerelease: ${{ startsWith(github.ref, 'refs/tags/test') }}
           generate_release_notes: true
           files: |
-            release-assets/graphviz-native-linux-x86_64.tar.gz
-            release-assets/graphviz-native-linux-aarch64.tar.gz
-            release-assets/graphviz-native-macos-universal.tar.gz
-            release-assets/graphviz-native-windows-x86_64.zip
-            release-assets/graphviz-native-windows-arm64.zip
-            release-assets/graphviz-native-android-arm64-v8a.tar.gz
-            release-assets/graphviz-native-android-armeabi-v7a.tar.gz
-            release-assets/graphviz-native-android-x86_64.tar.gz
-            release-assets/graphviz-native-android-x86.tar.gz
-            release-assets/graphviz-native-ios.tar.gz
-            release-assets/graphviz-native-ios-device-arm64.tar.gz
-            release-assets/graphviz-native-ios-sim-arm64.tar.gz
-            release-assets/graphviz-native-ios-sim-x86_64.tar.gz
-            release-assets/graphviz-native-wasm.tar.gz
+            crates/graphviz-anywhere/release-assets/graphviz-native-linux-x86_64.tar.gz
+            crates/graphviz-anywhere/release-assets/graphviz-native-linux-aarch64.tar.gz
+            crates/graphviz-anywhere/release-assets/graphviz-native-macos-universal.tar.gz
+            crates/graphviz-anywhere/release-assets/graphviz-native-windows-x86_64.tar.gz
+            crates/graphviz-anywhere/release-assets/graphviz-native-windows-arm64.tar.gz
+            crates/graphviz-anywhere/release-assets/graphviz-native-android-arm64-v8a.tar.gz
+            crates/graphviz-anywhere/release-assets/graphviz-native-android-armeabi-v7a.tar.gz
+            crates/graphviz-anywhere/release-assets/graphviz-native-android-x86_64.tar.gz
+            crates/graphviz-anywhere/release-assets/graphviz-native-android-x86.tar.gz
+            crates/graphviz-anywhere/release-assets/graphviz-native-ios.tar.gz
+            crates/graphviz-anywhere/release-assets/graphviz-native-ios-device-arm64.tar.gz
+            crates/graphviz-anywhere/release-assets/graphviz-native-ios-sim-arm64.tar.gz
+            crates/graphviz-anywhere/release-assets/graphviz-native-ios-sim-x86_64.tar.gz
+            crates/graphviz-anywhere/release-assets/graphviz-native-wasm.tar.gz

--- a/.github/workflows/graphviz-release.yml
+++ b/.github/workflows/graphviz-release.yml
@@ -154,7 +154,7 @@ jobs:
         shell: bash
         env:
           GRAPHVIZ_ANYWHERE_NO_DOWNLOAD: "1"
-          GRAPHVIZ_ANYWHERE_DIR: ${{ github.workspace }}/output/macos-universal/lib
+          GRAPHVIZ_ANYWHERE_DIR: ${{ github.workspace }}/crates/graphviz-anywhere/output/macos-universal/lib
         run: |
           # Verify both Darwin targets against the universal library (host + cross)
           rustup target add aarch64-apple-darwin x86_64-apple-darwin
@@ -426,7 +426,7 @@ jobs:
         shell: bash
         env:
           GRAPHVIZ_ANYWHERE_NO_DOWNLOAD: "1"
-          GRAPHVIZ_ANYWHERE_DIR: ${{ github.workspace }}/output/windows-x86_64/lib
+          GRAPHVIZ_ANYWHERE_DIR: ${{ github.workspace }}/crates/graphviz-anywhere/output/windows-x86_64/lib
         run: |
           rustup target add x86_64-pc-windows-msvc
           cargo build --release --target x86_64-pc-windows-msvc -p graphviz-anywhere-example
@@ -438,7 +438,7 @@ jobs:
         shell: bash
         env:
           GRAPHVIZ_ANYWHERE_NO_DOWNLOAD: "1"
-          GRAPHVIZ_ANYWHERE_DIR: ${{ github.workspace }}/output/windows-arm64/lib
+          GRAPHVIZ_ANYWHERE_DIR: ${{ github.workspace }}/crates/graphviz-anywhere/output/windows-arm64/lib
         run: |
           rustup target add aarch64-pc-windows-msvc
           cargo build --release --target aarch64-pc-windows-msvc -p graphviz-anywhere-example

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -532,7 +532,7 @@ dependencies = [
 
 [[package]]
 name = "graphviz-anywhere"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "supramark-diagram-core",
  "thiserror 1.0.69",

--- a/crates/graphviz-anywhere/CHANGELOG.md
+++ b/crates/graphviz-anywhere/CHANGELOG.md
@@ -6,6 +6,32 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.2.4] — 2026-07-12
+
+### Fixed
+
+- **Self-contained desktop executables** — Linux and macOS release downloads
+  now link the static archive that was already shipped beside the shared
+  library. Final Cargo binaries no longer depend on `libgraphviz_api.so` or
+  `libgraphviz_api.dylib`, so downstream build-script rpaths cannot disappear
+  and a same-named system library cannot satisfy the load with an incompatible
+  ABI.
+- **Windows env override** — source output contains both the DLL import library
+  and `graphviz_api_static.lib`. The resolver now selects the merged static
+  archive first and accepts canonical `graphviz_api.lib` as static only when no
+  sibling DLL identifies it as an import library.
+- **ABI-safe target resolution** — GNU-built Linux assets are no longer
+  auto-selected for musl targets, and MSVC `.lib` assets are no longer selected
+  for `windows-gnu`. These targets now require an explicit compatible native
+  build instead of failing later with opaque linker or loader errors.
+- **Runtime smoke coverage** — CI executes a real DOT-to-SVG example from the
+  downloaded release assets on Linux, macOS, and Windows and asserts desktop
+  executables have no Graphviz shared-library dependency.
+- **Release isolation** — the native/Cargo release no longer attempts to
+  publish independently-versioned web and React Native npm packages. A Rust
+  patch release therefore cannot fail midway or accidentally consume an npm
+  version before the crates.io publish step.
+
 ## [0.2.1] — 2026-05-11
 
 ### Fixed
@@ -140,7 +166,8 @@ Target version: **0.2.0** (cross-target build.rs + asset coverage)
 
 ---
 
-[Unreleased]: https://github.com/Actrium/graphviz-anywhere/compare/v0.2.1...HEAD
+[Unreleased]: https://github.com/Actrium/supramark/compare/v0.2.4...HEAD
+[0.2.4]: https://github.com/Actrium/supramark/compare/v0.2.3...v0.2.4
 [0.2.1]: https://github.com/Actrium/graphviz-anywhere/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/Actrium/graphviz-anywhere/compare/v0.1.8...v0.2.0
 [0.1.8]: https://github.com/Actrium/graphviz-anywhere/releases/tag/v0.1.8

--- a/crates/graphviz-anywhere/docs/cross-compile.md
+++ b/crates/graphviz-anywhere/docs/cross-compile.md
@@ -12,6 +12,11 @@ for each supported target triple.
 3. Sibling `output/<platform>/lib/` (local build tree)
 4. Auto-download from GitHub Release (`curl` + `tar`)
 
+Linux, macOS, Windows MSVC, and iOS resolve a static archive; Android resolves
+its package-staged shared library. The resolver deliberately does not map GNU
+Linux assets to musl or MSVC assets to Windows GNU because those ABIs are not
+interchangeable.
+
 Set `GRAPHVIZ_ANYWHERE_NO_DOWNLOAD=1` to make step 4 a hard error (useful in
 CI or airgapped environments). Override the release tag with
 `GRAPHVIZ_ANYWHERE_RELEASE_VERSION=<version>`.
@@ -22,7 +27,7 @@ CI or airgapped environments). Override the release tag with
 
 - **Toolchain**: `gcc` / `clang`, CMake 3.16+, `bison`, `flex`, `pkg-config`
 - **Build**: `./scripts/build-linux.sh --arch x86_64`
-- **Output**: `output/linux-x86_64/lib/libgraphviz_api.so`
+- **Output**: `output/linux-x86_64/lib/libgraphviz_api.a`
 - **Prebuilt path**: `packages/rust/prebuilt/linux/libgraphviz_api.a`
 - **Release asset**: `graphviz-native-linux-x86_64.tar.gz`
 - **Override**: `GRAPHVIZ_ANYWHERE_DIR=output/linux-x86_64 cargo build`
@@ -32,7 +37,7 @@ CI or airgapped environments). Override the release tag with
 
 - **Toolchain**: `aarch64-linux-gnu-gcc`, CMake cross-file or `ARCH=aarch64`
 - **Build**: `./scripts/build-linux.sh --arch aarch64`
-- **Output**: `output/linux-aarch64/lib/libgraphviz_api.so`
+- **Output**: `output/linux-aarch64/lib/libgraphviz_api.a`
 - **Release asset**: `graphviz-native-linux-aarch64.tar.gz` (CI uses `ubuntu-24.04-arm` runner when available)
 - **Override**: `GRAPHVIZ_ANYWHERE_DIR=output/linux-aarch64 cargo build --target aarch64-unknown-linux-gnu`
 - **build.rs auto-resolve**: ✅
@@ -42,7 +47,7 @@ CI or airgapped environments). Override the release tag with
 
 - **Toolchain**: Xcode 14+, `bison`/`flex` from Homebrew
 - **Build**: `./scripts/build-macos.sh --arch universal`
-- **Output**: `output/macos-universal/lib/libgraphviz_api.dylib`
+- **Output**: `output/macos-universal/lib/libgraphviz_api.a`
 - **Prebuilt path**: `packages/rust/prebuilt/macos/libgraphviz_api.a`
 - **Release asset**: `graphviz-native-macos-universal.tar.gz`
 - **Override**: `GRAPHVIZ_ANYWHERE_DIR=output/macos-universal cargo build`
@@ -117,11 +122,14 @@ CI or airgapped environments). Override the release tag with
 
 - **Toolchain**: MSVC 2022, CMake, `bison`/`flex` (winflexbison)
 - **Build**: `./scripts/build-windows.sh`
-- **Output**: `output/windows-x86_64/`; release ships as `.tar.gz`
+- **Output**: `output/windows-x86_64/lib/graphviz_api_static.lib`; the release
+  renames the merged static archive to canonical `lib/graphviz_api.lib`
 - **Release asset**: `graphviz-native-windows-x86_64.tar.gz`
 - **Override**: `$env:GRAPHVIZ_ANYWHERE_DIR = "output\windows-x86_64"; cargo build`
 - **build.rs**: env override works; auto-download extracts the `.tar.gz` release asset
-- **Common errors**: MSVC tools not on PATH when building from source; use a Developer Command Prompt/Git Bash or set `GRAPHVIZ_ANYWHERE_DIR` to a prebuilt directory containing `graphviz_api.lib`
+- **Common errors**: do not point the override at the DLL import library; use
+  `graphviz_api_static.lib`, or a release directory whose canonical
+  `graphviz_api.lib` is the merged static archive
 
 ## aarch64-pc-windows-msvc
 
@@ -144,11 +152,9 @@ The `@actrium/graphviz-anywhere-rn` postinstall script downloads a prebuilt
 native library into `packages/react-native/ios/Frameworks/` and the Android
 JNI libs. This is **separate** from what `build.rs` does.
 
-`build.rs`'s `try_repo_output` now also scans the RN postinstall paths
-(`packages/react-native/ios/Frameworks/lib/`, `packages/react-native/android/libs/<abi>/`)
-when the Rust crate is built inside the same monorepo as the RN package — no
-extra setup needed beyond running `npm install` in `packages/react-native/`
-first.
+`build.rs` scans the Android RN JNI staging paths when the Rust crate is built
+inside the same monorepo. Desktop Rust binaries deliberately do not consume RN
+framework shared libraries; they keep the static, self-contained contract.
 
 If you want to point at a custom location, the env override always wins:
 

--- a/crates/graphviz-anywhere/docs/cross-compile.md
+++ b/crates/graphviz-anywhere/docs/cross-compile.md
@@ -38,7 +38,7 @@ CI or airgapped environments). Override the release tag with
 - **Toolchain**: `aarch64-linux-gnu-gcc`, CMake cross-file or `ARCH=aarch64`
 - **Build**: `./scripts/build-linux.sh --arch aarch64`
 - **Output**: `output/linux-aarch64/lib/libgraphviz_api.a`
-- **Release asset**: `graphviz-native-linux-aarch64.tar.gz` (CI uses `ubuntu-24.04-arm` runner when available)
+- **Release asset**: `graphviz-native-linux-aarch64.tar.gz` (CI uses the native `ubuntu-22.04-arm` runner)
 - **Override**: `GRAPHVIZ_ANYWHERE_DIR=output/linux-aarch64 cargo build --target aarch64-unknown-linux-gnu`
 - **build.rs auto-resolve**: ✅
 - **Common errors**: cross-linker not on PATH → `apt-get install gcc-aarch64-linux-gnu`

--- a/crates/graphviz-anywhere/packages/rust/Cargo.toml
+++ b/crates/graphviz-anywhere/packages/rust/Cargo.toml
@@ -1,16 +1,17 @@
 [package]
 name = "graphviz-anywhere"
-version = "0.2.3"
+version = "0.2.4"
 edition = "2021"
 rust-version = "1.64"
 description = "Safe Rust wrapper for the graphviz-anywhere C library with bundled prebuilt binaries (and a wasm32 JS bridge)"
 license = "Apache-2.0"
 authors = ["kookyleo <kookyleo@gmail.com>"]
-repository = "https://github.com/Actrium/graphviz-anywhere"
+repository = "https://github.com/Actrium/supramark"
 links = "graphviz_api"
 include = [
     "src/",
     "src/build_helpers.rs",
+    "tests/",
     "build.rs",
     "Cargo.toml",
     "prebuilt/",

--- a/crates/graphviz-anywhere/packages/rust/README.md
+++ b/crates/graphviz-anywhere/packages/rust/README.md
@@ -23,9 +23,19 @@ let svg = ctx.render_to_string(
 println!("{svg}");
 ```
 
-Ship native binaries via one of:
+Native linking policy:
 
-- Environment: `GRAPHVIZ_ANYWHERE_DIR=/path/with/lib+include`
+- Linux, macOS, Windows MSVC, and iOS use the shipped static archive. Final
+  executables do not need `libgraphviz_api.so`, `.dylib`, or `.dll` at runtime.
+- Android keeps the shared `.so`; the application package owns JNI library
+  staging and loading.
+- musl Linux and Windows GNU do not reuse GNU/Linux or MSVC assets. Point the
+  build at a native library compiled for the exact ABI.
+
+Supply native binaries via one of:
+
+- Environment: `GRAPHVIZ_ANYWHERE_DIR=/path/with/lib+include` (desktop
+  overrides must contain the static archive)
 - Prebuilt: drop `libgraphviz_api.a` under `packages/rust/prebuilt/<os>/`
 - Repo build: `./scripts/build-<os>.sh` populates `output/<os>*/lib/`
 

--- a/crates/graphviz-anywhere/packages/rust/build.rs
+++ b/crates/graphviz-anywhere/packages/rust/build.rs
@@ -144,20 +144,10 @@ fn try_prebuilt(manifest_dir: &Path) -> bool {
         }
     }
 
-    // 2. Legacy layout — only when host OS == target OS.
-    let host_os = env::var("CARGO_CFG_TARGET_OS")
-        .or_else(|_| env::var("HOST"))
-        .unwrap_or_default();
-    // HOST env is something like "aarch64-apple-darwin"; derive the OS word.
-    let host_os_word = if host_os.contains("darwin") || host_os == "macos" {
-        "macos"
-    } else if host_os.contains("linux") || host_os == "linux" {
-        "linux"
-    } else if host_os.contains("windows") || host_os == "windows" {
-        "windows"
-    } else {
-        ""
-    };
+    // 2. Legacy layout — it has no architecture component, so only use it for
+    // an exact native build. `CARGO_CFG_TARGET_OS` describes the target and
+    // must not be used to infer the host here.
+    let host = env::var("HOST").unwrap_or_default();
     let target_os_word = target_os.as_str();
 
     // Match legacy folder name to target OS.
@@ -168,11 +158,7 @@ fn try_prebuilt(manifest_dir: &Path) -> bool {
         _ => return false,
     };
 
-    // Only use the legacy path when host OS word matches target OS.
-    let host_matches = host_os_word == legacy_folder
-        || host_os_word.is_empty() /* conservative: allow if we can't detect */;
-
-    if host_matches {
+    if legacy_prebuilt_is_compatible(&host, &target) {
         let dir = manifest_dir.join("prebuilt").join(legacy_folder);
         let lib_name = if target_os_word == "windows" {
             "graphviz_api.lib"

--- a/crates/graphviz-anywhere/packages/rust/build.rs
+++ b/crates/graphviz-anywhere/packages/rust/build.rs
@@ -81,21 +81,43 @@ fn try_env_override() -> bool {
     };
 
     let base = PathBuf::from(dir);
-    let mut found = false;
+    let target = env::var("TARGET").unwrap_or_default();
+    let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
+    let prefer_static = asset_is_static(&target);
+    let lib_dirs: Vec<PathBuf> = ["lib", "lib64", "build", "."]
+        .into_iter()
+        .map(|sub| base.join(sub))
+        .filter(|path| path.exists())
+        .collect();
 
-    for sub in ["lib", "lib64", "build", "."] {
-        let lib_dir = base.join(sub);
-        if lib_dir.exists() {
-            emit_search_path(&lib_dir, true);
-            found = true;
+    if prefer_static {
+        if let Some((static_lib, link_name)) = find_static_override(&lib_dirs, &target_os) {
+            emit_static_link(&static_lib, link_name);
+            emit_static_sys_libs(&target_os);
+            return true;
+        }
+    } else {
+        let dynamic_name = if target_os == "windows" {
+            if target.contains("windows-gnu") {
+                "libgraphviz_api.dll.a"
+            } else {
+                "graphviz_api.lib"
+            }
+        } else if target_os == "macos" {
+            "libgraphviz_api.dylib"
+        } else {
+            "libgraphviz_api.so"
+        };
+        for lib_dir in &lib_dirs {
+            if lib_dir.join(dynamic_name).exists() {
+                emit_search_path(lib_dir, true);
+                println!("cargo:rustc-link-lib=dylib=graphviz_api");
+                return true;
+            }
         }
     }
 
-    if found {
-        println!("cargo:rustc-link-lib=dylib=graphviz_api");
-    }
-
-    found
+    false
 }
 
 /// Try to link against a static lib already present in `packages/rust/prebuilt/`.
@@ -229,8 +251,6 @@ fn try_repo_output(manifest_dir: &Path) -> bool {
                 false, // Android: .so preferred
             ));
         }
-    } else if target_os == "macos" {
-        candidates.push((rn_root.join("macos").join("Frameworks").join("lib"), false));
     }
 
     // ── Walk candidates ──────────────────────────────────────────────────────
@@ -255,12 +275,8 @@ fn try_repo_output(manifest_dir: &Path) -> bool {
                 return true;
             }
         } else {
-            // Dynamic desktop/mobile targets: link the self-contained shared
-            // library. A static `.a` is intentionally NOT preferred here — it
-            // cannot embed the C++ runtime (libstdc++) or expat, which the
-            // unified .so already pulls in via --whole-archive; linking the .a
-            // statically would leave those symbols undefined. (Static linking
-            // is only used for iOS, handled by the want_static branch above.)
+            // Android links the shared library staged by the application
+            // package. Desktop and iOS candidates use the static branch above.
             let dylib = if target_os == "macos" {
                 dir.join("libgraphviz_api.dylib")
             } else {
@@ -376,7 +392,11 @@ fn try_github_release() -> bool {
             return false;
         }
 
-        let tar_flag = if asset.ends_with(".zip") { "-xf" } else { "-xzf" };
+        let tar_flag = if asset.ends_with(".zip") {
+            "-xf"
+        } else {
+            "-xzf"
+        };
         let untar = Command::new("tar")
             .arg(tar_flag)
             .arg(&archive)
@@ -402,10 +422,12 @@ fn try_github_release() -> bool {
     }
 
     let is_static = asset_is_static(&target);
-    emit_search_path(&lib_subdir, !is_static);
     if is_static {
-        println!("cargo:rustc-link-lib=static=graphviz_api");
+        emit_static_link(&lib_file, "graphviz_api");
+        let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
+        emit_static_sys_libs(&target_os);
     } else {
+        emit_search_path(&lib_subdir, true);
         println!("cargo:rustc-link-lib=dylib=graphviz_api");
     }
     println!("cargo:rerun-if-env-changed=GRAPHVIZ_ANYWHERE_RELEASE_VERSION");

--- a/crates/graphviz-anywhere/packages/rust/src/build_helpers.rs
+++ b/crates/graphviz-anywhere/packages/rust/src/build_helpers.rs
@@ -116,6 +116,16 @@ pub fn is_ios_target(target: &str) -> bool {
     )
 }
 
+/// Returns whether the legacy per-OS prebuilt layout is safe to use.
+///
+/// Legacy directories do not encode an architecture, so they are only valid
+/// for a native build where Cargo's host and target triples match exactly.
+/// Missing host metadata must fail closed rather than risk linking a host
+/// archive into a cross-compiled binary.
+pub fn legacy_prebuilt_is_compatible(host: &str, target: &str) -> bool {
+    !host.is_empty() && host == target
+}
+
 /// Returns `true` when the default native link is static.
 ///
 /// Desktop and iOS executables must be self-contained: a Cargo build-script
@@ -384,6 +394,26 @@ mod tests {
         assert!(is_ios_target("x86_64-apple-ios"));
         assert!(!is_ios_target("aarch64-apple-darwin"));
         assert!(!is_ios_target("aarch64-linux-android"));
+    }
+
+    #[test]
+    fn legacy_prebuilt_is_native_only() {
+        assert!(legacy_prebuilt_is_compatible(
+            "aarch64-apple-darwin",
+            "aarch64-apple-darwin"
+        ));
+        assert!(!legacy_prebuilt_is_compatible(
+            "aarch64-apple-darwin",
+            "x86_64-apple-darwin"
+        ));
+        assert!(!legacy_prebuilt_is_compatible(
+            "x86_64-unknown-linux-gnu",
+            "aarch64-unknown-linux-gnu"
+        ));
+        assert!(!legacy_prebuilt_is_compatible(
+            "",
+            "x86_64-pc-windows-msvc"
+        ));
     }
 
     // ── asset_is_static (static vs. dynamic link policy) ─────────────────────────

--- a/crates/graphviz-anywhere/packages/rust/src/build_helpers.rs
+++ b/crates/graphviz-anywhere/packages/rust/src/build_helpers.rs
@@ -10,11 +10,9 @@
 pub fn target_triple_to_asset_name(target: &str) -> Option<&'static str> {
     match target {
         // ── Linux ──────────────────────────────────────────────────────────────
-        "x86_64-unknown-linux-gnu"
-        | "x86_64-unknown-linux-musl" => Some("graphviz-native-linux-x86_64.tar.gz"),
+        "x86_64-unknown-linux-gnu" => Some("graphviz-native-linux-x86_64.tar.gz"),
 
-        "aarch64-unknown-linux-gnu"
-        | "aarch64-unknown-linux-musl" => Some("graphviz-native-linux-aarch64.tar.gz"),
+        "aarch64-unknown-linux-gnu" => Some("graphviz-native-linux-aarch64.tar.gz"),
 
         // ── macOS ──────────────────────────────────────────────────────────────
         "x86_64-apple-darwin"
@@ -35,8 +33,7 @@ pub fn target_triple_to_asset_name(target: &str) -> Option<&'static str> {
         "x86_64-apple-ios" => Some("graphviz-native-ios-sim-x86_64.tar.gz"),
 
         // ── Windows ────────────────────────────────────────────────────────────
-        "x86_64-pc-windows-msvc"
-        | "x86_64-pc-windows-gnu" => Some("graphviz-native-windows-x86_64.tar.gz"),
+        "x86_64-pc-windows-msvc" => Some("graphviz-native-windows-x86_64.tar.gz"),
         "aarch64-pc-windows-msvc" => Some("graphviz-native-windows-arm64.tar.gz"),
 
         _ => None,
@@ -50,11 +47,13 @@ pub fn target_triple_to_asset_name(target: &str) -> Option<&'static str> {
 pub fn target_triple_to_prebuilt_subdir(target: &str) -> Option<(&'static str, &'static str)> {
     // (subdirectory under prebuilt/, lib filename)
     match target {
-        "x86_64-unknown-linux-gnu"
-        | "x86_64-unknown-linux-musl" => Some(("x86_64-unknown-linux-gnu", "libgraphviz_api.a")),
+        "x86_64-unknown-linux-gnu" => {
+            Some(("x86_64-unknown-linux-gnu", "libgraphviz_api.a"))
+        }
 
-        "aarch64-unknown-linux-gnu"
-        | "aarch64-unknown-linux-musl" => Some(("aarch64-unknown-linux-gnu", "libgraphviz_api.a")),
+        "aarch64-unknown-linux-gnu" => {
+            Some(("aarch64-unknown-linux-gnu", "libgraphviz_api.a"))
+        }
 
         "x86_64-apple-darwin" => Some(("x86_64-apple-darwin", "libgraphviz_api.a")),
         "aarch64-apple-darwin" => Some(("aarch64-apple-darwin", "libgraphviz_api.a")),
@@ -63,13 +62,9 @@ pub fn target_triple_to_prebuilt_subdir(target: &str) -> Option<(&'static str, &
         "aarch64-apple-ios-sim" => Some(("aarch64-apple-ios-sim", "libgraphviz_api.a")),
         "x86_64-apple-ios" => Some(("x86_64-apple-ios", "libgraphviz_api.a")),
 
-        "aarch64-linux-android" => Some(("aarch64-linux-android", "libgraphviz_api.a")),
-        "armv7-linux-androideabi" => Some(("armv7-linux-androideabi", "libgraphviz_api.a")),
-        "x86_64-linux-android" => Some(("x86_64-linux-android", "libgraphviz_api.a")),
-        "i686-linux-android" => Some(("i686-linux-android", "libgraphviz_api.a")),
-
-        "x86_64-pc-windows-msvc"
-        | "x86_64-pc-windows-gnu" => Some(("x86_64-pc-windows-msvc", "graphviz_api.lib")),
+        "x86_64-pc-windows-msvc" => {
+            Some(("x86_64-pc-windows-msvc", "graphviz_api.lib"))
+        }
         "aarch64-pc-windows-msvc" => Some(("aarch64-pc-windows-msvc", "graphviz_api.lib")),
 
         _ => None,
@@ -83,11 +78,9 @@ pub fn target_triple_to_prebuilt_subdir(target: &str) -> Option<(&'static str, &
 /// as "not found".
 pub fn target_triple_to_output_dirs(target: &str) -> &'static [&'static str] {
     match target {
-        "x86_64-unknown-linux-gnu"
-        | "x86_64-unknown-linux-musl" => &["output/linux-x86_64/lib", "output/linux/lib"],
+        "x86_64-unknown-linux-gnu" => &["output/linux-x86_64/lib", "output/linux/lib"],
 
-        "aarch64-unknown-linux-gnu"
-        | "aarch64-unknown-linux-musl" => &["output/linux-aarch64/lib", "output/linux/lib"],
+        "aarch64-unknown-linux-gnu" => &["output/linux-aarch64/lib", "output/linux/lib"],
 
         "x86_64-apple-darwin"
         | "aarch64-apple-darwin"
@@ -102,8 +95,7 @@ pub fn target_triple_to_output_dirs(target: &str) -> &'static [&'static str] {
         "aarch64-apple-ios-sim" => &["output/ios/iphonesimulator-arm64/lib"],
         "x86_64-apple-ios" => &["output/ios/iphonesimulator-x86_64/lib"],
 
-        "x86_64-pc-windows-msvc"
-        | "x86_64-pc-windows-gnu" => &[
+        "x86_64-pc-windows-msvc" => &[
             "output/windows-x86_64/lib",
             "output/windows-x86_64/bin",
         ],
@@ -124,10 +116,18 @@ pub fn is_ios_target(target: &str) -> bool {
     )
 }
 
-/// Returns `true` for targets where the release asset uses `.a` (static archive)
-/// rather than `.so` / `.dylib`.
+/// Returns `true` when the default native link is static.
+///
+/// Desktop and iOS executables must be self-contained: a Cargo build-script
+/// rpath is not propagated to final downstream binaries, and a same-named
+/// system library can otherwise be selected at process launch. Android keeps
+/// the shared library because the application package owns JNI library
+/// staging and loading.
 pub fn asset_is_static(target: &str) -> bool {
-    is_ios_target(target) || target.contains("windows")
+    is_ios_target(target)
+        || target.contains("windows-msvc")
+        || target.contains("unknown-linux-gnu")
+        || target.contains("apple-darwin")
 }
 
 /// Returns the lib filename to expect inside the extracted release archive.
@@ -135,11 +135,55 @@ pub fn asset_lib_filename(target: &str) -> &'static str {
     match target {
         "x86_64-apple-darwin"
         | "aarch64-apple-darwin"
-        | "universal-apple-darwin" => "libgraphviz_api.dylib",
+        | "universal-apple-darwin" => "libgraphviz_api.a",
         t if is_ios_target(t) => "libgraphviz_api.a",
-        t if t.contains("windows") => "graphviz_api.lib",
+        t if t.contains("windows-msvc") => "graphviz_api.lib",
+        t if t.contains("unknown-linux-gnu") => "libgraphviz_api.a",
         _ => "libgraphviz_api.so",
     }
+}
+
+/// Resolve a static library from an explicit override's candidate directories.
+///
+/// Windows source builds place a DLL import library and the merged static
+/// archive beside one another. `graphviz_api_static.lib` always wins. The
+/// canonical `graphviz_api.lib` is accepted only when no adjacent DLL proves
+/// that it is an import library (the canonical name is used by release assets).
+pub fn find_static_override(
+    lib_dirs: &[std::path::PathBuf],
+    target_os: &str,
+) -> Option<(std::path::PathBuf, &'static str)> {
+    if target_os != "windows" {
+        return lib_dirs
+            .iter()
+            .map(|dir| dir.join("libgraphviz_api.a"))
+            .find(|path| path.is_file())
+            .map(|path| (path, "graphviz_api"));
+    }
+
+    if let Some(path) = lib_dirs
+        .iter()
+        .map(|dir| dir.join("graphviz_api_static.lib"))
+        .find(|path| path.is_file())
+    {
+        return Some((path, "graphviz_api_static"));
+    }
+
+    let has_dll = lib_dirs.iter().any(|lib_dir| {
+        lib_dir.join("graphviz_api.dll").is_file()
+            || lib_dir
+                .parent()
+                .map_or(false, |parent| parent.join("bin/graphviz_api.dll").is_file())
+    });
+    if has_dll {
+        return None;
+    }
+
+    lib_dirs
+        .iter()
+        .map(|dir| dir.join("graphviz_api.lib"))
+        .find(|path| path.is_file())
+        .map(|path| (path, "graphviz_api"))
 }
 
 // ── Tests ──────────────────────────────────────────────────────────────────────
@@ -162,10 +206,6 @@ mod tests {
     fn linux_aarch64_asset() {
         assert_eq!(
             target_triple_to_asset_name("aarch64-unknown-linux-gnu"),
-            Some("graphviz-native-linux-aarch64.tar.gz")
-        );
-        assert_eq!(
-            target_triple_to_asset_name("aarch64-unknown-linux-musl"),
             Some("graphviz-native-linux-aarch64.tar.gz")
         );
     }
@@ -269,9 +309,7 @@ mod tests {
 
     #[test]
     fn prebuilt_subdir_android_x86() {
-        let (subdir, lib) = target_triple_to_prebuilt_subdir("i686-linux-android").unwrap();
-        assert_eq!(subdir, "i686-linux-android");
-        assert_eq!(lib, "libgraphviz_api.a");
+        assert_eq!(target_triple_to_prebuilt_subdir("i686-linux-android"), None);
     }
 
     #[test]
@@ -323,13 +361,13 @@ mod tests {
     }
 
     #[test]
-    fn asset_lib_filename_macos_is_dylib() {
-        assert_eq!(asset_lib_filename("aarch64-apple-darwin"), "libgraphviz_api.dylib");
+    fn asset_lib_filename_macos_is_static() {
+        assert_eq!(asset_lib_filename("aarch64-apple-darwin"), "libgraphviz_api.a");
     }
 
     #[test]
-    fn asset_lib_filename_linux_is_so() {
-        assert_eq!(asset_lib_filename("x86_64-unknown-linux-gnu"), "libgraphviz_api.so");
+    fn asset_lib_filename_linux_is_static() {
+        assert_eq!(asset_lib_filename("x86_64-unknown-linux-gnu"), "libgraphviz_api.a");
     }
 
     #[test]
@@ -351,19 +389,83 @@ mod tests {
     // ── asset_is_static (static vs. dynamic link policy) ─────────────────────────
 
     #[test]
-    fn asset_is_static_for_ios_and_windows() {
-        // iOS and Windows release assets are linked statically.
+    fn asset_is_static_for_desktop_and_ios() {
         assert!(asset_is_static("aarch64-apple-ios"));
         assert!(asset_is_static("aarch64-apple-ios-sim"));
         assert!(asset_is_static("x86_64-apple-ios"));
         assert!(asset_is_static("x86_64-pc-windows-msvc"));
-        // The published release asset for Linux/macOS/Android is the
-        // self-contained shared library (.so/.dylib), not a static archive.
-        assert!(!asset_is_static("x86_64-unknown-linux-gnu"));
-        assert!(!asset_is_static("aarch64-unknown-linux-gnu"));
-        assert!(!asset_is_static("aarch64-apple-darwin"));
-        assert!(!asset_is_static("x86_64-apple-darwin"));
+        assert!(asset_is_static("x86_64-unknown-linux-gnu"));
+        assert!(asset_is_static("aarch64-unknown-linux-gnu"));
+        assert!(asset_is_static("aarch64-apple-darwin"));
+        assert!(asset_is_static("x86_64-apple-darwin"));
         assert!(!asset_is_static("aarch64-linux-android"));
+    }
+
+    #[test]
+    fn incompatible_abi_assets_are_not_auto_selected() {
+        assert_eq!(target_triple_to_asset_name("x86_64-unknown-linux-musl"), None);
+        assert_eq!(target_triple_to_asset_name("aarch64-unknown-linux-musl"), None);
+        assert_eq!(target_triple_to_asset_name("x86_64-pc-windows-gnu"), None);
+        assert_eq!(target_triple_to_prebuilt_subdir("x86_64-unknown-linux-musl"), None);
+        assert_eq!(target_triple_to_prebuilt_subdir("x86_64-pc-windows-gnu"), None);
+        assert!(target_triple_to_output_dirs("aarch64-unknown-linux-musl").is_empty());
+        assert!(target_triple_to_output_dirs("x86_64-pc-windows-gnu").is_empty());
+    }
+
+    #[test]
+    fn windows_override_prefers_merged_static_archive() {
+        let root = std::env::temp_dir().join(format!(
+            "graphviz-anywhere-static-override-{}",
+            std::process::id()
+        ));
+        let lib = root.join("lib");
+        let bin = root.join("bin");
+        std::fs::create_dir_all(&lib).unwrap();
+        std::fs::create_dir_all(&bin).unwrap();
+        std::fs::write(lib.join("graphviz_api.lib"), b"import").unwrap();
+        std::fs::write(lib.join("graphviz_api_static.lib"), b"static").unwrap();
+        std::fs::write(bin.join("graphviz_api.dll"), b"dll").unwrap();
+
+        let resolved = find_static_override(std::slice::from_ref(&lib), "windows").unwrap();
+        assert_eq!(resolved.0, lib.join("graphviz_api_static.lib"));
+        assert_eq!(resolved.1, "graphviz_api_static");
+
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn windows_override_rejects_import_library_as_static() {
+        let root = std::env::temp_dir().join(format!(
+            "graphviz-anywhere-import-override-{}",
+            std::process::id()
+        ));
+        let lib = root.join("lib");
+        let bin = root.join("bin");
+        std::fs::create_dir_all(&lib).unwrap();
+        std::fs::create_dir_all(&bin).unwrap();
+        std::fs::write(lib.join("graphviz_api.lib"), b"import").unwrap();
+        std::fs::write(bin.join("graphviz_api.dll"), b"dll").unwrap();
+
+        assert!(find_static_override(&[lib], "windows").is_none());
+
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn windows_release_canonical_library_is_static_without_dll() {
+        let root = std::env::temp_dir().join(format!(
+            "graphviz-anywhere-release-override-{}",
+            std::process::id()
+        ));
+        let lib = root.join("lib");
+        std::fs::create_dir_all(&lib).unwrap();
+        std::fs::write(lib.join("graphviz_api.lib"), b"static").unwrap();
+
+        let resolved = find_static_override(std::slice::from_ref(&lib), "windows").unwrap();
+        assert_eq!(resolved.0, lib.join("graphviz_api.lib"));
+        assert_eq!(resolved.1, "graphviz_api");
+
+        std::fs::remove_dir_all(root).unwrap();
     }
 
     #[test]

--- a/crates/graphviz-anywhere/packages/rust/src/lib.rs
+++ b/crates/graphviz-anywhere/packages/rust/src/lib.rs
@@ -681,7 +681,7 @@ mod tests {
     fn engine_implements_clone_copy() {
         let e1 = Engine::Dot;
         let e2 = e1;
-        let e3 = e1.clone();
+        let e3 = e1;
         assert_eq!(e1, e2);
         assert_eq!(e2, e3);
     }
@@ -696,7 +696,7 @@ mod tests {
     fn format_implements_clone_copy() {
         let f1 = Format::Svg;
         let f2 = f1;
-        let f3 = f1.clone();
+        let f3 = f1;
         assert_eq!(f1, f2);
         assert_eq!(f2, f3);
     }

--- a/crates/graphviz-anywhere/scripts/build-windows.sh
+++ b/crates/graphviz-anywhere/scripts/build-windows.sh
@@ -17,10 +17,7 @@
 #   - Visual Studio 2022 with "MSVC v143 - VS 2022 C++ ARM64 build tools"
 #     component installed (workload: Desktop development with C++).
 #   - CMake generator platform "ARM64" (passed automatically below).
-# The arm64 build has NOT been smoke-tested locally (no ARM64 Windows host
-# available).  CI validation is required before shipping release assets.
-# TODO(verify-in-ci): run a matrix job on windows-11-arm runner once
-# GitHub Actions makes it GA, or use QEMU/cross-toolchain on windows-latest.
+# CI builds and executes the ARM64 example on a native windows-11-arm runner.
 # ────────────────────────────────────────────────────────────────────────────
 
 set -euo pipefail
@@ -71,7 +68,6 @@ prepare_graphviz_source "${GV_PATCHED}"
 # htmllex.c fails with "Cannot open include file: 'expat.h'".)
 log_info "Configuring Graphviz..."
 mkdir -p "${BUILD_DIR}/graphviz"
-# TODO(verify-in-ci): ARM64 generator path untested — needs windows-arm64 runner
 cmake -S "${GV_PATCHED}" -B "${BUILD_DIR}/graphviz" \
     -G "Visual Studio 17 2022" -A "${CMAKE_PLATFORM}" \
     "${GV_CMAKE_COMMON_ARGS[@]}" \
@@ -121,7 +117,6 @@ install(TARGETS graphviz_api
 )
 CMAKE_EOF
 
-# TODO(verify-in-ci): ARM64 wrapper CMake path untested — needs windows-arm64 runner
 cmake -S "${BUILD_DIR}/wrapper" -B "${BUILD_DIR}/wrapper/build" \
     -G "Visual Studio 17 2022" -A "${CMAKE_PLATFORM}" \
     -DSRC_DIR="${WRAPPER_SRC}" \
@@ -148,18 +143,24 @@ log_info "Building merged static library (graphviz_api_static.lib) via lib.exe..
 LIBEXE=""
 VSWHERE="C:/Program Files (x86)/Microsoft Visual Studio/Installer/vswhere.exe"
 if [ -f "${VSWHERE}" ]; then
-    VS_INSTALL="$("${VSWHERE}" -latest -products '*' -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath 2>/dev/null | tr -d '\r')"
+    VS_INSTALL="$("${VSWHERE}" -latest -products '*' -property installationPath 2>/dev/null | tr -d '\r')"
     if [ -n "${VS_INSTALL}" ]; then
         # VC tools version string lives in a single-line text file
         VC_VER_FILE="${VS_INSTALL}/VC/Auxiliary/Build/Microsoft.VCToolsVersion.default.txt"
         if [ -f "${VC_VER_FILE}" ]; then
             VC_VER="$(cat "${VC_VER_FILE}" | tr -d '[:space:]')"
-            case "$ARCH" in
-                x86_64) HOST_SUBDIR="x64" ;;
-                arm64)  HOST_SUBDIR="x64" ;;  # cross-compile: host tools are x64
-            esac
-            CANDIDATE="${VS_INSTALL}/VC/Tools/MSVC/${VC_VER}/bin/Host${HOST_SUBDIR}/${HOST_SUBDIR}/lib.exe"
-            [ -f "${CANDIDATE}" ] && LIBEXE="${CANDIDATE}"
+            if [ "$ARCH" = "arm64" ]; then
+                HOST_TOOL_DIRS=("Hostarm64/arm64" "Hostx64/x64" "Hostx86/x86")
+            else
+                HOST_TOOL_DIRS=("Hostx64/x64" "Hostx86/x86")
+            fi
+            for host_dir in "${HOST_TOOL_DIRS[@]}"; do
+                CANDIDATE="${VS_INSTALL}/VC/Tools/MSVC/${VC_VER}/bin/${host_dir}/lib.exe"
+                if [ -f "${CANDIDATE}" ]; then
+                    LIBEXE="${CANDIDATE}"
+                    break
+                fi
+            done
         fi
     fi
 fi


### PR DESCRIPTION
## Summary
- prefer static Graphviz release assets on Linux, macOS, Windows MSVC, and iOS
- reject incompatible musl/MSVC asset mappings and correctly resolve Windows static overrides
- activate and harden the multi-platform Graphviz release workflow
- bump graphviz-anywhere to 0.2.4

## Validation
- macOS arm64 (s67): crate tests, DOT-to-SVG, Markon 0.15.11 release build, loader trap, otool
- Ubuntu 24.04 x86_64 (s68): crate tests, DOT-to-SVG, Markon release build, loader trap, ldd/readelf
- Windows 11 x64 (s69): crate tests, DOT-to-SVG, Markon release build, loader trap, dumpbin
- local: 33 unit tests + 30 link-policy tests, clippy -D warnings, cargo package verify, actionlint