### PR TITLE
fix(markdown): replace vulnerable mdurl

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -678,16 +678,6 @@ dependencies = [
 
 [[package]]
 name = "idna"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14ddfc70884202db2244c223200c204c2bda1bc6e0998d11b5e024d657209e6"
-dependencies = [
- "unicode-bidi",
- "unicode-normalization",
-]
-
-[[package]]
-name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
@@ -850,14 +840,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "mdurl"
-version = "0.3.1"
+name = "markdown-it-rs-url"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5736ba45bbac8f7ccc99a897f88ce85e508a18baec973a040f2514e6cdbff0d2"
+checksum = "f84517f57025665d68504eee67677134243db330507158d312a3b47bae7845fb"
 dependencies = [
- "idna 0.3.0",
- "once_cell",
- "regex",
+ "idna",
 ]
 
 [[package]]
@@ -1507,7 +1495,7 @@ dependencies = [
 
 [[package]]
 name = "supramark-markdown"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "argparse",
  "const_format",
@@ -1517,7 +1505,7 @@ dependencies = [
  "entities",
  "html-escape",
  "linkify",
- "mdurl",
+ "markdown-it-rs-url",
  "once_cell",
  "pretty_assertions",
  "readonly",
@@ -1697,21 +1685,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tinyvec"
-version = "1.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
-dependencies = [
- "tinyvec_macros",
-]
-
-[[package]]
-name = "tinyvec_macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
-
-[[package]]
 name = "ttf-parser"
 version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1741,12 +1714,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
-name = "unicode-bidi"
-version = "0.3.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
-
-[[package]]
 name = "unicode-general-category"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1763,15 +1730,6 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
-
-[[package]]
-name = "unicode-normalization"
-version = "0.1.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
-dependencies = [
- "tinyvec",
-]
 
 [[package]]
 name = "unicode-segmentation"
@@ -1833,7 +1791,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
 dependencies = [
  "form_urlencoded",
- "idna 1.1.0",
+ "idna",
  "percent-encoding",
  "serde",
 ]

--- a/crates/supramark-markdown/Cargo.toml
+++ b/crates/supramark-markdown/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "supramark-markdown"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Supramark contributors"]
 description = "Supramark-owned Rust Markdown parser and AST v2 output schema."
 readme = "README.md"
@@ -59,7 +59,7 @@ downcast-rs  = ">= 1.0.2, < 2"
 entities     = ">= 0.1.0, < 2"
 html-escape  = ">= 0.1.0, < 0.3"
 linkify      = { version = ">= 0.5.0, < 0.11", optional = true }
-mdurl        = ">= 0.3.1, < 0.4"
+mdurl        = { package = "markdown-it-rs-url", version = "0.1.0" }
 once_cell    = ">= 1.0.1, < 2"
 readonly     = ">= 0.2.0, < 0.3"
 regex        = ">= 1.0.0, < 2"

--- a/crates/supramark-markdown/src/parser/linkfmt.rs
+++ b/crates/supramark-markdown/src/parser/linkfmt.rs
@@ -100,4 +100,22 @@ mod tests {
             .validate_link("data:text/html;base64,PHNjcmlwdD5hbGVydCgnWFNTJyk8L3NjcmlwdD4K")
             .is_none());
     }
+
+    #[test]
+    fn should_preserve_markdown_url_encoding_contract() {
+        let fmt = MDLinkFormatter::new();
+
+        assert_eq!(
+            fmt.normalize_link("https://example.org/a b?x=你好"),
+            "https://example.org/a%20b?x=%E4%BD%A0%E5%A5%BD"
+        );
+        assert_eq!(
+            fmt.normalize_link("https://example.org/already%20escaped"),
+            "https://example.org/already%20escaped"
+        );
+        assert_eq!(
+            fmt.normalize_link("https://example.org/broken%2g"),
+            "https://example.org/broken%252g"
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- replace mdurl 0.3.1 with the API-compatible markdown-it-rs-url crate
- release supramark-markdown 0.1.2
- add URL encoding contract regression coverage

## Security
- removes idna 0.3.0 and RUSTSEC-2024-0421 from the published crate dependency graph
- cargo audit of the packaged crate reports zero vulnerabilities

## Validation
- Rust 1.97 tests on macOS, Linux, and Windows: 79/79 passed on each platform
- cargo package --locked
- package fmt check and Clippy
- Bun workspace build, test, lint, and quality