### PR TITLE
fix(rn): use container gap for block spacing, drop trailing margin

### DIFF
--- a/packages/renderers/rn/__tests__/spacing.test.ts
+++ b/packages/renderers/rn/__tests__/spacing.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, mock } from 'bun:test';
+
+// styles.ts import react-native 的 StyleSheet;其 JS 入口含 Flow 语法,bun 无法加载。
+// 用 identity mock —— 测试只关心样式对象的 gap 模型,不依赖 StyleSheet.create 运行时。
+mock.module('react-native', () => ({
+  StyleSheet: { create: (styles: unknown) => styles },
+}));
+
+const { defaultStyles } = await import('../src/styles');
+
+/**
+ * block 间距 gap 模型测试。
+ *
+ * 模型:间距跟着容器走 (gap),不跟着 block 走 (marginBottom)。
+ * - root (column + gap:8) 管 top-level block 间距,无 trailing。
+ * - list (gap:4) 管 list_item 间距。
+ * - 承载 block children 的嵌套容器 (footnote 内层 / definition description / generic container)
+ *   各自在渲染处独立加 gap,不复用共享的 listItem / listItemText —— 后者是 row 布局、不带 gap。
+ */
+describe('block spacing gap model', () => {
+  it('root 用 column + gap 统一 top-level block 间距,无 trailing', () => {
+    expect(defaultStyles.root.flexDirection).toBe('column');
+    expect(defaultStyles.root.gap).toBe(8);
+  });
+
+  it('list 用 gap 给 list_item 间距', () => {
+    expect(defaultStyles.list.gap).toBe(4);
+  });
+
+  it('共享 listItem 是 row 布局且不带 gap (不被嵌套容器污染)', () => {
+    expect(defaultStyles.listItem.flexDirection).toBe('row');
+    expect((defaultStyles.listItem as Record<string, unknown>).gap).toBeUndefined();
+  });
+
+  it('共享 listItemText 不带 gap (不被嵌套容器污染)', () => {
+    expect((defaultStyles.listItemText as Record<string, unknown>).gap).toBeUndefined();
+  });
+
+  it('block 默认样式不再携带 marginBottom (间距改由容器 gap 管)', () => {
+    expect((defaultStyles.paragraph as Record<string, unknown>).marginBottom).toBeUndefined();
+    expect((defaultStyles.h1 as Record<string, unknown>).marginBottom).toBeUndefined();
+    expect((defaultStyles.codeBlock as Record<string, unknown>).marginBottom).toBeUndefined();
+  });
+
+  it('标题用 marginTop 表达"上方比下方宽"的分级 (与 root gap 叠加)', () => {
+    // 上方间距 = root gap(8) + marginTop;下方间距 = root gap(8)
+    expect((defaultStyles.h1 as Record<string, unknown>).marginTop).toBe(8); // 上方 16
+    expect((defaultStyles.h2 as Record<string, unknown>).marginTop).toBe(6); // 上方 14
+    expect((defaultStyles.h3 as Record<string, unknown>).marginTop).toBe(4); // 上方 12
+    expect((defaultStyles.h4 as Record<string, unknown>).marginTop).toBe(2); // 上方 10
+    // h5/h6 不加 marginTop,与上方块等距
+    expect((defaultStyles.h5 as Record<string, unknown>).marginTop).toBeUndefined();
+    expect((defaultStyles.h6 as Record<string, unknown>).marginTop).toBeUndefined();
+  });
+});

--- a/packages/renderers/rn/src/DiagramNode.tsx
+++ b/packages/renderers/rn/src/DiagramNode.tsx
@@ -219,16 +219,13 @@ function buildRenderOptions(
 }
 
 const styles = StyleSheet.create({
-  diagram: {
-    marginBottom: 8,
-  },
+  diagram: {},
   placeholder: {
     width: '100%',
     padding: 8,
     borderRadius: 4,
     borderWidth: 1,
     borderColor: '#ccc',
-    marginBottom: 8,
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'center',

--- a/packages/renderers/rn/src/MathBlock.tsx
+++ b/packages/renderers/rn/src/MathBlock.tsx
@@ -87,9 +87,7 @@ export const MathBlock: React.FC<MathBlockProps> = ({ node }) => {
 };
 
 const styles = StyleSheet.create({
-  mathContainer: {
-    marginVertical: 8,
-  },
+  mathContainer: {},
   placeholderText: {
     fontSize: 14,
     color: '#666',
@@ -100,7 +98,6 @@ const styles = StyleSheet.create({
     borderRadius: 4,
     borderWidth: 1,
     borderColor: '#ccc',
-    marginVertical: 8,
     flexDirection: 'row',
     alignItems: 'center',
   },
@@ -108,7 +105,6 @@ const styles = StyleSheet.create({
     backgroundColor: '#f5f5f5',
     padding: 8,
     borderRadius: 4,
-    marginVertical: 8,
   },
   codeText: {
     fontFamily: 'Menlo',

--- a/packages/renderers/rn/src/Supramark.tsx
+++ b/packages/renderers/rn/src/Supramark.tsx
@@ -368,7 +368,7 @@ function renderNode(
       ) {
         const title = container.params || (container.data?.title as string | undefined);
         const kind = containerName;
-        const admonitionContainerStyle = { flexDirection: 'column' as const, marginBottom: 4 };
+        const admonitionContainerStyle = { flexDirection: 'column' as const, gap: 4 };
 
         const renderAdmonitionContent = () =>
           container.children.map((child, index) =>
@@ -437,7 +437,7 @@ function renderNode(
       const isCompact = defOptions.compact !== false; // 默认紧凑
       // Column 布局：term 一行，description 缩进一行。
       // 避免 row 布局下 description 被 term 挤压导致 Text 不换行。
-      const defItemStyle = { flexDirection: 'column' as const, marginBottom: 4 };
+      const defItemStyle = { flexDirection: 'column' as const };
       const defDescriptionStyle = { paddingLeft: 16 };
       if (!isFeatureGroupEnabled(config, ['@supramark/feature-definition-list'])) {
         // 禁用时，将定义列表退化为普通列表样式

--- a/packages/renderers/rn/src/Supramark.tsx
+++ b/packages/renderers/rn/src/Supramark.tsx
@@ -75,7 +75,14 @@ export interface SupramarkProps {
   markdown: string;
   /** 预解析的 AST（优先级高于 markdown） */
   ast?: SupramarkRootNode;
-  /** 自定义样式（覆盖默认样式） */
+  /**
+   * 自定义样式（覆盖默认样式）。
+   *
+   * 间距模型：块间距由 root.gap（默认 8）统一管理，不再使用每块的
+   * marginBottom。若自定义某块的 marginBottom（如 paragraph:12），
+   * 会与 root.gap 叠加 → 实际间距 20。如需完全自定义间距，
+   * 请同时设置 root: { gap: 0 }。
+   */
   styles?: SupramarkStyles;
   /** 主题：'light' | 'dark' | 自定义样式对象 */
   theme?: 'light' | 'dark' | SupramarkStyles;
@@ -303,6 +310,10 @@ function renderNode(
       const container = node;
       const containerName = container.name;
 
+      // 纵向 block 容器：html 卡片（标题+提示）、未识别 container 的 block children。
+      // 不复用 styles.listItem —— 它是 row 布局，会把 block children 横向排列且无间距。
+      const blockContainerStyle = { flexDirection: 'column' as const, gap: 8 };
+
       // 检查是否有注册的自定义渲染器
       if (containerRenderers && containerRenderers[containerName]) {
         return containerRenderers[containerName]({
@@ -338,9 +349,9 @@ function renderNode(
         const data = container.data || {};
         const title = (data.title as string) || container.params || '[HTML 页面]';
         const content = (
-          <View style={styles.listItem}>
-            <Text style={[styles.listItemText, { fontWeight: '600' }]}>{title}</Text>
-            <Text style={styles.listItemText}>
+          <View style={blockContainerStyle}>
+            <Text style={{ fontWeight: '600', lineHeight: 20 }}>{title}</Text>
+            <Text style={{ lineHeight: 20 }}>
               点击卡片以在独立容器中打开 HTML 页面（需要宿主实现 onOpenHtmlPage 回调）。
             </Text>
           </View>
@@ -409,9 +420,9 @@ function renderNode(
 
       // 默认：渲染为通用容器块
       return (
-        <View key={key} style={styles.listItem}>
+        <View key={key} style={blockContainerStyle}>
           {container.params && (
-            <Text style={[styles.listItemText, { fontWeight: '600' }]}>
+            <Text style={{ fontWeight: '600', lineHeight: 20 }}>
               {container.name}: {container.params}
             </Text>
           )}
@@ -438,7 +449,7 @@ function renderNode(
       // Column 布局：term 一行，description 缩进一行。
       // 避免 row 布局下 description 被 term 挤压导致 Text 不换行。
       const defItemStyle = { flexDirection: 'column' as const };
-      const defDescriptionStyle = { paddingLeft: 16 };
+      const defDescriptionStyle = { paddingLeft: 16, gap: 8 };
       if (!isFeatureGroupEnabled(config, ['@supramark/feature-definition-list'])) {
         // 禁用时，将定义列表退化为普通列表样式
         return (
@@ -530,7 +541,7 @@ function renderNode(
       return (
         <View key={key} style={styles.listItem}>
           <Text style={styles.bullet}>[{def.index}]</Text>
-          <View style={styles.listItemText}>{renderFootnoteContent()}</View>
+          <View style={[styles.listItemText, { gap: 8 }]}>{renderFootnoteContent()}</View>
         </View>
       );
     }

--- a/packages/renderers/rn/src/styles.ts
+++ b/packages/renderers/rn/src/styles.ts
@@ -409,7 +409,7 @@ export const darkThemeStyles: SupramarkStyles = {
     color: '#e6edf3',
   },
   root: {
-    // backgroundColor: '#0d1117',
+    backgroundColor: '#0d1117',
   },
 };
 
@@ -419,6 +419,6 @@ export const darkThemeStyles: SupramarkStyles = {
 export const lightThemeStyles: SupramarkStyles = {
   // Light 主题使用默认样式，这里可以做一些微调
   root: {
-    // backgroundColor: '#ffffff',
+    backgroundColor: '#ffffff',
   },
 };

--- a/packages/renderers/rn/src/styles.ts
+++ b/packages/renderers/rn/src/styles.ts
@@ -85,18 +85,22 @@ export const defaultStyles = StyleSheet.create({
   h1: {
     fontSize: 24,
     fontWeight: '700',
+    marginTop: 8,
   },
   h2: {
     fontSize: 20,
     fontWeight: '600',
+    marginTop: 6,
   },
   h3: {
     fontSize: 18,
     fontWeight: '600',
+    marginTop: 4,
   },
   h4: {
     fontSize: 16,
     fontWeight: '500',
+    marginTop: 2,
   },
   h5: {
     fontSize: 14,

--- a/packages/renderers/rn/src/styles.ts
+++ b/packages/renderers/rn/src/styles.ts
@@ -80,56 +80,47 @@ export interface SupramarkStyles {
  */
 export const defaultStyles = StyleSheet.create({
   paragraph: {
-    marginBottom: 8,
     lineHeight: 20,
   },
   h1: {
     fontSize: 24,
     fontWeight: '700',
-    marginBottom: 12,
   },
   h2: {
     fontSize: 20,
     fontWeight: '600',
-    marginBottom: 10,
   },
   h3: {
     fontSize: 18,
     fontWeight: '600',
-    marginBottom: 8,
   },
   h4: {
     fontSize: 16,
     fontWeight: '500',
-    marginBottom: 6,
   },
   h5: {
     fontSize: 14,
     fontWeight: '500',
-    marginBottom: 4,
   },
   h6: {
     fontSize: 12,
     fontWeight: '500',
-    marginBottom: 4,
   },
   codeBlock: {
     backgroundColor: '#f5f5f5',
     padding: 8,
     borderRadius: 4,
-    marginBottom: 8,
   },
   code: {
     fontFamily: 'Menlo',
     fontSize: 12,
   },
   list: {
-    marginBottom: 8,
+    gap: 4,
   },
   listItem: {
     flexDirection: 'row',
     alignItems: 'flex-start',
-    marginBottom: 4,
   },
   bullet: {
     marginRight: 6,
@@ -144,7 +135,6 @@ export const defaultStyles = StyleSheet.create({
     borderRadius: 4,
     borderWidth: 1,
     borderColor: '#ccc',
-    marginBottom: 8,
   },
   diagramPlaceholderText: {
     fontSize: 12,
@@ -156,7 +146,6 @@ export const defaultStyles = StyleSheet.create({
     borderColor: '#dee2e6',
     borderRadius: 8,
     padding: 16,
-    marginBottom: 12,
   },
   mapCardHeader: {
     marginBottom: 12,
@@ -276,7 +265,6 @@ export const defaultStyles = StyleSheet.create({
     maxWidth: '100%',
     borderWidth: 1,
     borderColor: '#ddd',
-    marginBottom: 12,
   },
   tableRow: {
     flexDirection: 'row',
@@ -306,7 +294,8 @@ export const defaultStyles = StyleSheet.create({
     textAlign: 'right',
   },
   root: {
-    // 默认无样式，用户可自定义
+    flexDirection: 'column',
+    gap: 8,
   },
 });
 
@@ -420,7 +409,7 @@ export const darkThemeStyles: SupramarkStyles = {
     color: '#e6edf3',
   },
   root: {
-    backgroundColor: '#0d1117',
+    // backgroundColor: '#0d1117',
   },
 };
 
@@ -430,6 +419,6 @@ export const darkThemeStyles: SupramarkStyles = {
 export const lightThemeStyles: SupramarkStyles = {
   // Light 主题使用默认样式，这里可以做一些微调
   root: {
-    backgroundColor: '#ffffff',
+    // backgroundColor: '#ffffff',
   },
 };


### PR DESCRIPTION
## Background

Inside a container (e.g. a chat bubble), the last block (paragraph / heading / code block / ...) had extra space below it, making the container's bottom padding larger than the other three sides.

## Root cause

Each block's default style carried its own `marginBottom` for spacing (paragraph=8, h1=12, table=12, codeBlock=8, list=8, listItem=4, mapCard=12, ...), and `renderNode` did **not** strip the margin on the last block — so the final block always left a trailing margin. `MathBlock` / `DiagramNode` additionally hardcoded `marginVertical` / `marginBottom: 8` (not controllable via the `styles` prop), with the same trailing issue.

## Approach

Move vertical block spacing from per-block `marginBottom` to **container `gap`**. gap only applies between siblings, so the final block has no trailing margin. RN ≥ 0.71 supports gap; this repo already uses `gap:6` in `mapCardContent`.

Effect: `[A,B,C] → nothing after C`; `[A] → nothing after A`; spacing between middle blocks is preserved.

## Changes

- **styles.ts**: `root` gets `flexDirection:column + gap:8`; remove the spacing `marginBottom` from paragraph / h1-h6 / codeBlock / list / listItem / diagramPlaceholder / mapCard / table; `list` gets `gap:4`.
- **Supramark.tsx**: `admonitionContainerStyle` switches to `gap:4`; `defItemStyle` drops marginBottom (covered by `list` gap).
- **MathBlock.tsx** / **DiagramNode.tsx**: drop hardcoded `marginVertical` / `marginBottom`.
- Map card **internal** layout (`mapCardHeader` / `mapCardTitle` / `mapCardContent`) unchanged.

Only affects `@supramark/rn`; the web renderer is not touched.

## Visual changes (FYI)

Top-level block spacing is now a uniform 8: paragraphs stay 8→8; headings (was 12/10), tables / map cards (12), code blocks (8) converge to 8. Multiple footnotes 4→8; admonition inner paragraph spacing 8→4.

## Test plan

- [x] Single-line paragraph: bubble's bottom inset matches top / left / right
- [x] Multiple paragraphs: spacing preserved between, none trailing after the last
- [x] Heading + text / code + text / list + text: normal spacing, no trailing on the last block
- [x] Ordered / unordered lists: normal item spacing, no trailing on the last item
- [x] Both dark and light themes render correctly
- [x] `tsc --noEmit` passes