### PR TITLE
ci: pre-build wasm serially in feature type-check to fix rustup race

### DIFF
--- a/.github/workflows/feature-quality.yml
+++ b/.github/workflows/feature-quality.yml
@@ -8,6 +8,7 @@ on:
       - 'packages/core/**'
       - 'scripts/feature-lint.ts'
       - 'scripts/features-lint.ts'
+      - '.github/workflows/feature-quality.yml'
   pull_request:
     branches: [main, develop]
     paths:
@@ -15,6 +16,7 @@ on:
       - 'packages/core/**'
       - 'scripts/feature-lint.ts'
       - 'scripts/features-lint.ts'
+      - '.github/workflows/feature-quality.yml'
 
 jobs:
   lint-features:
@@ -128,6 +130,17 @@ jobs:
         uses: taiki-e/install-action@v2
         with:
           tool: wasm-pack
+
+      # Pre-build the in-tree wasm packages serially before the concurrent
+      # workspace build. `rust-toolchain.toml` pins an exact stable that differs
+      # from the `@stable` installed above, so the first `cargo`/`wasm-pack`
+      # invocation triggers a rustup install. Running that install once here
+      # (single process) avoids the rustup download race where parallel `bun run
+      # --filter '*' build` entries each trigger rustup and clobber each other's
+      # `.partial` download for the same component (clippy), which left
+      # `@actrium/d2-little-web` without a dist entry and broke the Vite build.
+      - name: Build in-tree wasm packages
+        run: bun run build:wasm
 
       - name: TypeScript workspace build
         run: bun run build


### PR DESCRIPTION
## Summary

Fixes a pre-existing CI flake in the `Feature Quality Check` workflow's `TypeScript Type Check` job that surfaced while validating #86 (but is independent of it — `main` is affected too).

## Root cause

The `type-check` job ran `bun run --filter '*' build` directly. That fans out concurrent `wasm-pack` invocations across the d2 / mermaid / markdown / plantuml web packages. `rust-toolchain.toml` pins Rust `1.97.0`, but the setup step installs `@stable` (currently `1.97.1`), so each concurrent `cargo metadata` triggers a separate rustup install of `1.97.0`. Multiple rustup processes then clobber each other's `.partial` download for the same component:

```
info: downloading 6 components
info: rolling back changes
error: component download failed for clippy-x86_64-unknown-linux-gnu:
  could not rename 'downloaded' file from
  '/home/runner/.rustup/downloads/<hash>.partial' to
  '/home/runner/.rustup/downloads/<hash>':
  No such file or directory (os error 2)
```

`@actrium/d2-little-web` (and `mermaid-little-web`, `markdown-web`) failed to build and emitted no dist entry, so the downstream Vite build of `example-react-web-csr` failed with:

```
[commonjs--resolver] Failed to resolve entry for package "@actrium/d2-little-web".
```

The Vite error is just the symptom; the real cause is that the pinned `1.97.0` toolchain was never installed before the concurrent build fan-out.

## Fix

Add a `bun run build:wasm` step before `bun run build`, matching:
- the `test-features` job in this same workflow (`.github/workflows/feature-quality.yml`), and
- the `test-build` job in `.github/workflows/ci.yml`.

`scripts/build-wasm.ts` builds the four in-tree wasm crates **serially**, so the `1.97.0` toolchain is installed once by a single rustup process before the parallel `bun run --filter '*' build` fan-out — eliminating the download race.

## Why this approach

- **Minimal & consistent**: reuses the exact pattern already green in two other jobs in the repo.
- **DRY**: does not hardcode `1.97.0` into the workflow; `rust-toolchain.toml` stays the single source of truth, so future toolchain bumps need no CI edit.
- **Root-cause fix**: the race is gone because no concurrent rustup install can happen, not because we papered over the symptom.

## Validation

- [x] `bun run build:wasm` — 4 wasm crates built serially, `✅ Built 4 wasm package(s)`
- [x] `bun run build` — 40 packages `Exited with code 0`, 0 failures (native-rn packages `skipping build` as on CI)
- [x] YAML structure verified — `Build in-tree wasm packages` step sits between `Install wasm-pack` and `TypeScript workspace build`
- [x] Confirmed via #86 CI logs that `d2-little-web`/`mermaid-little-web`/`markdown-web` failed with the rustup rename race, and `plantuml-little-web` (which started later, after the toolchain settled) succeeded

## Test plan

- [ ] `TypeScript Type Check` job passes on this PR (the flake it was failing on)
- [ ] No regression in `Test Feature Packages` / `Test & Build` jobs