### PR TITLE
refactor(rn): return canvas background ownership to host

### DIFF
--- a/examples/react-native/App.tsx
+++ b/examples/react-native/App.tsx
@@ -29,7 +29,7 @@ import {
   NativeModules,
 } from 'react-native';
 
-import { Supramark } from '@supramark/rn';
+import { Supramark, themeBackground } from '@supramark/rn';
 import type { SupramarkConfig } from '@supramark/core';
 
 // Feature metadata — id/version is read off these for the FeatureConfig list.
@@ -167,7 +167,7 @@ export default function App() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  const containerStyle = [styles.container, isDark && { backgroundColor: '#0d1117' }];
+  const containerStyle = [styles.container, isDark && { backgroundColor: themeBackground.dark }];
   const headerStyle = [styles.header, isDark && { borderBottomColor: '#30363d' }];
   const titleStyle = [styles.title, isDark && { color: '#ffffff' }];
   const subtitleStyle = [styles.subtitle, isDark && { color: '#8b949e' }];
@@ -225,7 +225,10 @@ export default function App() {
     );
   }
 
-  const detailContentStyle = [styles.detailContent, isDark && { backgroundColor: '#0d1117' }];
+  const detailContentStyle = [
+    styles.detailContent,
+    { backgroundColor: themeBackground[isDark ? 'dark' : 'light'] },
+  ];
   const demoTitleStyle = [styles.demoTitle, isDark && { color: '#ffffff' }];
   const demoDescriptionStyle = [styles.demoDescription, isDark && { color: '#8b949e' }];
   const demoSectionTitleStyle = [styles.demoSectionTitle, isDark && { color: '#ffffff' }];

--- a/packages/renderers/rn/__tests__/styles.test.ts
+++ b/packages/renderers/rn/__tests__/styles.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it, mock } from 'bun:test';
+
+// styles.ts import react-native 的 StyleSheet;react-native 的 JS 入口含 Flow
+// 语法 (import typeof),bun 无法加载。用 identity mock 替代 —— 测试只关心样式对象的
+// 纯逻辑 (mergeStyles / themeBackground / darkThemeStyles 结构),不依赖 StyleSheet.create
+// 的运行时语义。动态 import 确保 mock 先注册、再加载 styles。
+mock.module('react-native', () => ({
+  StyleSheet: { create: (styles: unknown) => styles },
+}));
+
+const stylesModule = await import('../src/styles');
+const { defaultStyles, darkThemeStyles, mergeStyles, themeBackground } = stylesModule;
+
+/**
+ * 画布背景职责边界测试。
+ *
+ * 契约:组件不在 root 上绘制画布背景 —— 画布由宿主提供。
+ * 库只导出与内置主题前景色配套的推荐画布色 (themeBackground) 供宿主选用。
+ */
+describe('theme canvas ownership', () => {
+  describe('themeBackground', () => {
+    it('导出与内置主题前景色配套的推荐画布色', () => {
+      expect(themeBackground.dark).toBe('#0d1117');
+      expect(themeBackground.light).toBe('#ffffff');
+    });
+  });
+
+  describe('darkThemeStyles', () => {
+    it('不在 root 上自带画布背景 (画布由宿主提供)', () => {
+      expect(darkThemeStyles.root).toBeUndefined();
+    });
+
+    it('已移除 lightThemeStyles (light 等同默认主题)', () => {
+      expect((stylesModule as Record<string, unknown>).lightThemeStyles).toBeUndefined();
+    });
+
+    it('保留深色友好的前景色与元素装饰色', () => {
+      expect(darkThemeStyles.paragraph?.color).toBe('#e0e0e0');
+      expect(darkThemeStyles.codeBlock?.backgroundColor).toBe('#2d2d2d');
+      expect(darkThemeStyles.tableHeaderCell?.backgroundColor).toBe('#2d2d2d');
+    });
+  });
+
+  describe('mergeStyles', () => {
+    it('无自定义样式时回退到默认样式', () => {
+      const merged = mergeStyles(undefined);
+      expect(merged.paragraph).toEqual(defaultStyles.paragraph);
+    });
+
+    it('合并后 root 不携带画布背景', () => {
+      const merged = mergeStyles(undefined);
+      expect((merged.root as { backgroundColor?: string }).backgroundColor).toBeUndefined();
+    });
+
+    it('用户自定义样式覆盖默认值,且保留未覆盖字段', () => {
+      const merged = mergeStyles({ paragraph: { color: '#ff0000' } });
+      expect(merged.paragraph.color).toBe('#ff0000');
+      expect(merged.paragraph.lineHeight).toBe(defaultStyles.paragraph.lineHeight);
+    });
+  });
+});

--- a/packages/renderers/rn/src/Supramark.tsx
+++ b/packages/renderers/rn/src/Supramark.tsx
@@ -48,7 +48,6 @@ import {
   defaultStyles,
   mergeStyles,
   darkThemeStyles,
-  lightThemeStyles,
 } from './styles';
 import { ErrorBoundary, ErrorInfo, ErrorDisplay } from './ErrorBoundary';
 
@@ -88,7 +87,18 @@ export interface SupramarkProps {
   ast?: SupramarkRootNode;
   /** 自定义样式（覆盖默认样式） */
   styles?: SupramarkStyles;
-  /** 主题：'light' | 'dark' | 自定义样式对象 */
+  /**
+   * 主题：调整内容元素的前景色与元素装饰色（文字、代码块底、边框等），
+   * 使其在对应明暗的画布上可读。
+   *
+   * - 'dark'：应用 darkThemeStyles（深色友好的前景/元素色）。
+   * - 'light'：使用默认（浅色）前景，等同于不传 theme。
+   * - 也可直接传入自定义 SupramarkStyles 作为主题。
+   *
+   * 重要：组件不在 root 上绘制画布背景。宿主必须为渲染容器提供与 theme
+   * 明暗配套的画布颜色（可用导出的 {@link themeBackground} 作为推荐值），
+   * 否则前景文字可能不可读 —— 例如 theme="dark" 时宿主容器应使用深色背景。
+   */
   theme?: 'light' | 'dark' | SupramarkStyles;
   /** Feature 配置（用于按需启用/禁用图表等扩展能力） */
   config?: SupramarkConfig;
@@ -137,7 +147,7 @@ export const Supramark: React.FC<SupramarkProps> = ({
     let themeStyles: SupramarkStyles | undefined;
 
     if (typeof theme === 'string') {
-      themeStyles = theme === 'dark' ? darkThemeStyles : lightThemeStyles;
+      themeStyles = theme === 'dark' ? darkThemeStyles : undefined;
     } else if (theme) {
       themeStyles = theme;
     }

--- a/packages/renderers/rn/src/styles.ts
+++ b/packages/renderers/rn/src/styles.ts
@@ -417,17 +417,20 @@ export const darkThemeStyles: SupramarkStyles = {
   mapCardInfo: {
     color: '#e6edf3',
   },
-  root: {
-    backgroundColor: '#0d1117',
-  },
 };
 
 /**
- * Light 主题样式（默认主题的别名）
+ * 与内置主题前景色配套的推荐画布背景色。
+ *
+ * 组件自身不在 root 上绘制背景 —— 画布由宿主提供。为保证前景文字可读，
+ * 宿主渲染容器应使用与所选 theme 明暗配套的背景色（可用此常量）：
+ *
+ * - theme="dark"  → themeBackground.dark  (#0d1117)
+ * - theme="light" → themeBackground.light (#ffffff)
+ *
+ * 宿主也可使用自有画布颜色，只要明暗与 theme 一致即可。
  */
-export const lightThemeStyles: SupramarkStyles = {
-  // Light 主题使用默认样式，这里可以做一些微调
-  root: {
-    backgroundColor: '#ffffff',
-  },
-};
+export const themeBackground = {
+  light: '#ffffff',
+  dark: '#0d1117',
+} as const;


### PR DESCRIPTION
## Background

Follow-up to #83. In #83 the gap-fix silently commented out `darkThemeStyles.root.backgroundColor` / `lightThemeStyles.root.backgroundColor`; review flagged it as an unrelated, undisclosed change. #83 reverted those two lines to stay scoped. This PR addresses the underlying question that comment raised: **should the renderer own its canvas background at all?**

## Root cause

The renderer's job is content — text, headings, code blocks, tables. The opaque canvas behind it belongs to the host (chat bubble, card, page). Painting `#0d1117` / `#ffffff` from inside `root`:

- Forces a hard rectangle that clashes with every host container (a chat bubble's rounded corners and brand color get covered by a black/white slab).
- Masks a design gap: the `dark` theme ships light foreground text (`#e0e0e0`) but left the matching dark canvas to guessing — `theme="dark"` without a dark host = unreadable.

## Approach: return the canvas to the host, keep content colors theme-driven

Split "colors" into two layers with different ownership:

| Layer | Owner | Examples |
|---|---|---|
| Canvas background (`root`) | **Host** (this PR removes it) | the opaque page / bubble / card behind content |
| Content colors (foreground + element decoration) | **Library, theme-driven** (unchanged) | text color, code-block bg, borders, map-card bg |

Only the root canvas is returned to the host. Foreground and per-element colors stay in `darkThemeStyles` — that is the library's job (making content readable on a given canvas).

## Changes

- **`styles.ts`**: drop `darkThemeStyles.root`; remove `lightThemeStyles` (it only ever added a white canvas, identical to the default — `theme="light"` now means "default foreground"). Export `themeBackground = { light: '#ffffff', dark: '#0d1117' }` — the recommended host canvas color paired with each built-in theme's foreground.
- **`Supramark.tsx`**: merge logic simplified (`theme === 'dark' ? darkThemeStyles : undefined`); the `theme` prop now documents the contract — the host must provide a canvas whose light/dark matches the theme, and `themeBackground` is the recommended value.
- **`App.tsx`**: the example host paints its own canvas via `themeBackground` — light mode gains an explicit canvas it previously borrowed from the component; dark mode switches from a hardcoded `#0d1117` to the export. This demonstrates the new contract.
- **`__tests__/styles.test.ts`** (new): locks the contract — `darkThemeStyles.root` undefined, `lightThemeStyles` removed, `themeBackground` values, `mergeStyles` behavior.

## Relationship to #83

#83 is a gap / trailing-margin fix and should stay scoped to that. This PR is the standalone, documented removal of canvas ownership. They are independent and land in either order.

## Test plan

- [x] `bun test` in `@supramark/rn` — 7 pass (new `styles.test.ts`)
- [x] `tsc --noEmit` in `@supramark/rn` — clean
- [ ] Simulator, light mode: detail screen renders on an explicit white canvas (previously transparent, borrowed from the component)
- [ ] Simulator, dark mode: visually unchanged (canvas color identical, now sourced from `themeBackground`)