### PR TITLE
test(rn): register shared react-native mock to fix cross-file clobbering

### DIFF
--- a/packages/renderers/rn/__tests__/DiagramNode.test.tsx
+++ b/packages/renderers/rn/__tests__/DiagramNode.test.tsx
@@ -4,6 +4,8 @@ import { create, act, type ReactTestRenderer } from 'react-test-renderer';
 import type { DiagramRenderResult } from '@supramark/engines';
 import type { SupramarkDiagramNode, SupramarkSourceState } from '@supramark/core';
 
+import './support/mock-react-native';
+
 // react-test-renderer 需要显式开启 act 环境，否则 effect 不会同步 flush。
 (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT =
   true;
@@ -14,16 +16,6 @@ const engineState = {
   renderCalls: 0,
   pendingResolve: null as null | ((result: DiagramRenderResult) => void),
 };
-
-// 用字符串 host 组件 mock react-native 表面，react-test-renderer 会把它们当作
-// host 节点渲染，便于按 testID 断言状态。
-mock.module('react-native', () => ({
-  View: 'View',
-  Text: 'Text',
-  ActivityIndicator: 'ActivityIndicator',
-  Dimensions: { get: () => ({ width: 375, height: 812 }) },
-  StyleSheet: { create: (s: unknown) => s },
-}));
 
 mock.module('react-native-svg', () => ({
   SvgXml: 'SvgXml',

--- a/packages/renderers/rn/__tests__/spacing.test.ts
+++ b/packages/renderers/rn/__tests__/spacing.test.ts
@@ -1,10 +1,6 @@
-import { describe, expect, it, mock } from 'bun:test';
+import { describe, expect, it } from 'bun:test';
 
-// styles.ts import react-native 的 StyleSheet;其 JS 入口含 Flow 语法,bun 无法加载。
-// 用 identity mock —— 测试只关心样式对象的 gap 模型,不依赖 StyleSheet.create 运行时。
-mock.module('react-native', () => ({
-  StyleSheet: { create: (styles: unknown) => styles },
-}));
+import './support/mock-react-native';
 
 const { defaultStyles } = await import('../src/styles');
 

--- a/packages/renderers/rn/__tests__/styles.test.ts
+++ b/packages/renderers/rn/__tests__/styles.test.ts
@@ -1,12 +1,6 @@
-import { describe, expect, it, mock } from 'bun:test';
+import { describe, expect, it } from 'bun:test';
 
-// styles.ts import react-native 的 StyleSheet;react-native 的 JS 入口含 Flow
-// 语法 (import typeof),bun 无法加载。用 identity mock 替代 —— 测试只关心样式对象的
-// 纯逻辑 (mergeStyles / themeBackground / darkThemeStyles 结构),不依赖 StyleSheet.create
-// 的运行时语义。动态 import 确保 mock 先注册、再加载 styles。
-mock.module('react-native', () => ({
-  StyleSheet: { create: (styles: unknown) => styles },
-}));
+import './support/mock-react-native';
 
 const stylesModule = await import('../src/styles');
 const { defaultStyles, darkThemeStyles, mergeStyles, themeBackground } = stylesModule;

--- a/packages/renderers/rn/__tests__/support/mock-react-native.ts
+++ b/packages/renderers/rn/__tests__/support/mock-react-native.ts
@@ -1,0 +1,19 @@
+import { mock } from 'bun:test';
+
+// react-native's JS entry contains Flow syntax (import typeof) that bun cannot load,
+// so tests always run against a mock. bun's mock.module registry is process-wide:
+// when multiple test files each register their own mock, a later narrow surface
+// clobbers an earlier wide one, and already-loaded modules then fail to resolve the
+// missing exports (ActivityIndicator disappeared when DiagramNode.test and
+// styles.test shared one process). Register the react-native mock here once with
+// the full surface; test files import this module instead of calling
+// mock.module('react-native') themselves.
+// String host components are rendered by react-test-renderer as host nodes,
+// which keeps testID-based assertions simple.
+mock.module('react-native', () => ({
+  View: 'View',
+  Text: 'Text',
+  ActivityIndicator: 'ActivityIndicator',
+  Dimensions: { get: () => ({ width: 375, height: 812 }) },
+  StyleSheet: { create: (s: unknown) => s },
+}));


### PR DESCRIPTION
## Summary

bun's `mock.module` registry is process-wide. `spacing.test.ts` / `styles.test.ts` (from #83/#88) registered a StyleSheet-only `react-native` mock while `DiagramNode.test.tsx` (from #86) registered a wider surface. The later registration clobbers the earlier one, and already-loaded modules can then fail to resolve `ActivityIndicator`:

```
SyntaxError: Export named 'ActivityIndicator' not found in module '.../react-native/index.js'.
```

Each suite landed green from its own PR — the CI runs never had both files in one process. After the merges the failure is **environment-dependent**: it reproduces locally on bun 1.3.5 and the pinned 1.3.14 alike (both direct `bun test` and the CI-style `bun run --filter '@supramark/rn' test` invocation; the module error aborts the file and two tests never run), while the GitHub runner happens to pass — so green CI does not cover it.

## Fix

Register one full-surface react-native mock in `__tests__/support/mock-react-native.ts` and import it from all three test files instead of per-file `mock.module('react-native', ...)` calls. The suite no longer depends on mock registration order.

## Validation

- `bun test` in `packages/renderers/rn`: 57 pass / 0 fail (was 55-ran / 1 fail / 1 error), stable across 3 consecutive runs
- `bunx tsc --noEmit` and eslint clean on the touched files
- Verified pre-fix failure and post-fix pass under both bun 1.3.5 and 1.3.14