### PR TITLE
fix(markdown): count Unicode symbols as punctuation for emphasis flanking

### DIFF
--- a/crates/supramark-markdown/src/common/utils.rs
+++ b/crates/supramark-markdown/src/common/utils.rs
@@ -303,10 +303,11 @@ pub fn calc_right_whitespace_with_tabstops(source: &str, mut indent: i32) -> (us
 
 /// Checks whether a given character should count as punctuation
 ///
-/// used to determine word boundaries, made to match the implementation of
-/// `isPunctChar` from the JS library.
-/// This is currently implemented as a `match`, but might be simplified as a
-/// regex if benchmarking shows this to be beneficient.
+/// Matches the CommonMark reference `isPunctChar` definition: an ASCII
+/// punctuation character or a character in the Unicode general categories
+/// `P` (punctuation) or `S` (symbol). Without `S`, currency/math symbols
+/// such as `£`, `€` wrongly act as word boundaries in emphasis flanking
+/// (see CommonMark 0.31.2 case 0354).
 pub fn is_punct_char(ch: char) -> bool {
     use unicode_general_category::get_general_category;
     use unicode_general_category::GeneralCategory::*;
@@ -314,7 +315,9 @@ pub fn is_punct_char(ch: char) -> bool {
     match get_general_category(ch) {
         // P
         ConnectorPunctuation | DashPunctuation | OpenPunctuation | ClosePunctuation |
-        InitialPunctuation | FinalPunctuation | OtherPunctuation => true,
+        InitialPunctuation | FinalPunctuation | OtherPunctuation |
+        // S — CommonMark counts symbols as punctuation for flanking
+        MathSymbol | CurrencySymbol | ModifierSymbol | OtherSymbol => true,
 
         // L
         UppercaseLetter | LowercaseLetter | TitlecaseLetter | ModifierLetter | OtherLetter |
@@ -322,8 +325,6 @@ pub fn is_punct_char(ch: char) -> bool {
         NonspacingMark | SpacingMark | EnclosingMark |
         // N
         DecimalNumber | LetterNumber | OtherNumber |
-        // S
-        MathSymbol | CurrencySymbol | ModifierSymbol | OtherSymbol |
         // Z
         SpaceSeparator | LineSeparator | ParagraphSeparator |
         // C
@@ -335,9 +336,54 @@ pub fn is_punct_char(ch: char) -> bool {
 mod tests {
     use super::cut_right_whitespace_with_tabstops as cut_ws;
     use super::find_indent_of;
+    use super::is_punct_char;
     use super::replace_entity_pattern;
     use super::rfind_and_count;
     use super::unescape_all;
+
+    #[test]
+    fn is_punct_char_matches_commonmark_reference() {
+        // ASCII punctuation.
+        for ch in [
+            '!', '"', '#', '$', '%', '&', '\'', '(', ')', '*', '+', ',', '-', '.', '/', ':', ';',
+            '<', '=', '>', '?', '@', '[', '\\', ']', '^', '_', '`', '{', '|', '}', '~',
+        ] {
+            assert!(
+                is_punct_char(ch),
+                "ASCII punct {ch:?} should be punctuation"
+            );
+        }
+
+        // Unicode P (punctuation) categories.
+        for ch in ['“', '”', '‘', '’', '—', '–', '…', '«', '»', '¿', '¡'] {
+            assert!(is_punct_char(ch), "Unicode P {ch:?} should be punctuation");
+        }
+
+        // Unicode S (symbol) categories — currency, math, modifier, other.
+        // CommonMark 0.31.2 case 0354 depends on these counting as punctuation.
+        for ch in ['£', '€', '¥', '¢', '+', '<', '=', '>', '|', '^', '`', '~'] {
+            assert!(is_punct_char(ch), "Unicode S {ch:?} should be punctuation");
+        }
+        for ch in ['∞', '∂', '√', '∑', '∏', '∫', '∴', '≈', '≠', '≤', '≥'] {
+            assert!(
+                is_punct_char(ch),
+                "Math symbol {ch:?} should be punctuation"
+            );
+        }
+        for ch in ['©', '®', '™', '°', '‰', '§', '¶', '•'] {
+            assert!(
+                is_punct_char(ch),
+                "Other symbol {ch:?} should be punctuation"
+            );
+        }
+
+        // Non-punctuation: letters, marks, numbers, whitespace, control.
+        for ch in [
+            'a', 'Z', '0', '5', ' ', '\t', '\n', 'α', 'β', '中', '文', '日', 'ä', 'ø',
+        ] {
+            assert!(!is_punct_char(ch), "{ch:?} should NOT be punctuation");
+        }
+    }
 
     #[test]
     fn rfind_and_count_test() {

--- a/crates/supramark-markdown/tests/public_api.rs
+++ b/crates/supramark-markdown/tests/public_api.rs
@@ -658,3 +658,41 @@ fn nests_footnote_definition_inside_blockquote() {
     };
     assert_eq!(label, "a");
 }
+
+/// CommonMark 0.31.2 case 0354: currency/math symbols (`$`, `£`, `€`) are
+/// Unicode punctuation for flanking, so `*$*` / `*£*` / `*€*` must not form
+/// emphasis. Regression test for <https://github.com/Actrium/supramark/issues/116>.
+#[test]
+fn emphasis_unicode_symbol_flanking_case_0354() {
+    let ast = parse("*$*alpha.\n\n*£*bravo.\n\n*€*charlie.\n");
+    let SupramarkNode::Root { children, .. } = ast else {
+        panic!("expected root");
+    };
+
+    let expected = ["*$*alpha.", "*£*bravo.", "*€*charlie."];
+    assert_eq!(children.len(), expected.len());
+
+    for (node, want) in children.iter().zip(expected) {
+        let SupramarkNode::Paragraph { children, .. } = node else {
+            panic!("expected paragraph, got {node:?}");
+        };
+        assert_no_emphasis(children);
+        assert_eq!(children.len(), 1, "expected a single text child");
+        let SupramarkNode::Text { value, .. } = &children[0] else {
+            panic!("expected text, got {:?}", children[0]);
+        };
+        assert_eq!(value, want);
+    }
+}
+
+fn assert_no_emphasis(nodes: &[SupramarkNode]) {
+    for node in nodes {
+        match node {
+            SupramarkNode::Emphasis { .. } | SupramarkNode::Strong { .. } => {
+                panic!("unexpected emphasis/strong node: {node:?}");
+            }
+            SupramarkNode::Paragraph { children, .. } => assert_no_emphasis(children),
+            _ => {}
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- 修复强调解析中 Unicode 标点 flanking 判定错误：`is_punct_char` 此前只把 Unicode **P**（标点）类算作标点，对 **S**（符号）类（`£`/`€` 等 CurrencySymbol）返回 false，导致 `*£*bravo.` / `*€*charlie.` 错误产出 `<em>`。
- 对齐 CommonMark 参考实现的 `isPunctChar`（`\p{P}\p{S}`）：将 `MathSymbol | CurrencySymbol | ModifierSymbol | OtherSymbol` 纳入标点分支。
- 修复 CommonMark 0.31.2 用例 0354（`*$*alpha.` / `*£*bravo.` / `*€*charlie.` 均不应产出强调）。

Closes #116.

## Root cause
`crates/supramark-markdown/src/common/utils.rs` 的 `is_punct_char` 用 `unicode_general_category` 分类字符，但 Symbol 类被归入 `false` 分支。CommonMark 参考实现 ([commonmark.js](https://github.com/commonmark/commonmark.js)) 的定义为 `^[!-/:-@\[-`{-~\p{P}\p{S}]`，即 ASCII 标点 **或** Unicode P/S。少了 S 后，货币/数学符号在 flanking 判定中被当作普通字符，使第二个 `*` 被误判为 right-flanking 能闭合。

## Changes
- `crates/supramark-markdown/src/common/utils.rs`：把 Symbol 四个子类从 `false` 分支移到 `true` 分支。
- `crates/supramark-markdown/tests/public_api.rs`：新增集成测试 `emphasis_unicode_symbol_flanking_case_0354`，直接解析 0354 输入并断言无 emphasis/strong 节点。
- `crates/supramark-markdown/src/common/utils.rs`：新增单元测试 `is_punct_char_matches_commonmark_reference`，覆盖 ASCII 标点、Unicode P、Unicode S（货币/数学/其他符号）及非标点字符。

## Test plan
- [x] `cargo test -p supramark-markdown` — 27 项全过（含 2 个新增）
- [x] `cargo fmt -p supramark-markdown --check` — 干净
- [x] CommonMark 语义对照：用例 0354 通过
- [x] 全量 CommonMark 语义对照与未修改 parser 逐用例差分 = **修复 1（0354）、回归 0**