### PR TITLE
fix(markdown): preserve break in tight list item text before nested block

### DIFF
--- a/crates/supramark-markdown/src/plugins/cmark/block/list.rs
+++ b/crates/supramark-markdown/src/plugins/cmark/block/list.rs
@@ -88,7 +88,13 @@ impl NodeValue for ListItem {
         node: &Node,
         ctx: &crate::supramark::AstV2Ctx<'_>,
     ) -> Option<Vec<crate::supramark::SupramarkNode>> {
-        let (checked, children) = ctx.map_list_item_children(&node.children);
+        let (checked, mut children) = ctx.map_list_item_children(&node.children);
+        // Tight items unwrap the paragraph, so an inline text run can sit
+        // directly next to a nested block (e.g. `- a\n  - b`). cmark emits a
+        // line break between them (`<li>a\n<ul>`); carry that break as a
+        // trailing space on the text node so renderers that echo `node.value`
+        // still separate the text from the block. See issue #115.
+        preserve_text_break_before_blocks(&mut children);
         Some(vec![crate::supramark::SupramarkNode::ListItem {
             checked,
             children,
@@ -106,6 +112,36 @@ impl NodeValue for ListItem {
 
 pub fn add(md: &mut MarkdownParser) {
     md.block.add_rule::<ListScanner>().after::<HrScanner>();
+}
+
+/// Append a trailing space to a text node that sits immediately before a
+/// block-level sibling, preserving the soft break that cmark renders as a
+/// newline between inline text and a nested block within a list item.
+fn preserve_text_break_before_blocks(children: &mut [crate::supramark::SupramarkNode]) {
+    for index in 0..children.len() {
+        let next_is_block = index + 1 < children.len() && is_block_level(&children[index + 1]);
+        if let crate::supramark::SupramarkNode::Text { value, .. } = &mut children[index] {
+            if next_is_block && !value.ends_with(' ') && !value.ends_with('\n') {
+                value.push(' ');
+            }
+        }
+    }
+}
+
+fn is_block_level(node: &crate::supramark::SupramarkNode) -> bool {
+    !matches!(
+        node,
+        crate::supramark::SupramarkNode::Text { .. }
+            | crate::supramark::SupramarkNode::Strong { .. }
+            | crate::supramark::SupramarkNode::Emphasis { .. }
+            | crate::supramark::SupramarkNode::InlineCode { .. }
+            | crate::supramark::SupramarkNode::Link { .. }
+            | crate::supramark::SupramarkNode::Image { .. }
+            | crate::supramark::SupramarkNode::Break { .. }
+            | crate::supramark::SupramarkNode::Delete { .. }
+            | crate::supramark::SupramarkNode::MathInline { .. }
+            | crate::supramark::SupramarkNode::FootnoteReference { .. }
+    )
 }
 
 #[doc(hidden)]

--- a/crates/supramark-markdown/tests/public_api.rs
+++ b/crates/supramark-markdown/tests/public_api.rs
@@ -130,6 +130,110 @@ fn public_api_maps_task_list_items() {
     assert_eq!(first_text(second_children), "Todo");
 }
 
+#[test]
+fn public_api_preserves_break_in_tight_list_item_before_nested_block() {
+    // Tight list item whose text is followed by a nested list keeps a
+    // trailing space on the text node, mirroring cmark's `<li>a\n<ul>`
+    // formatting so renderers that echo `node.value` separate the text
+    // from the nested block. See issue #115.
+    let ast = parse("- a\n  - b\n");
+    let SupramarkNode::Root { children, .. } = ast else {
+        panic!("expected root");
+    };
+    let SupramarkNode::List {
+        children: items, ..
+    } = &children[0]
+    else {
+        panic!("expected list");
+    };
+    let SupramarkNode::ListItem {
+        children: first, ..
+    } = &items[0]
+    else {
+        panic!("expected first item");
+    };
+    // The tight paragraph is unwrapped, so the text node is a direct child.
+    let SupramarkNode::Text { value, .. } = &first[0] else {
+        panic!("expected text, got {first:?}");
+    };
+    assert_eq!(value, "a ");
+    assert!(matches!(&first[1], SupramarkNode::List { .. }));
+
+    // The nested item has no following block, so its text stays unpadded.
+    let SupramarkNode::List {
+        children: nested, ..
+    } = &first[1]
+    else {
+        panic!("expected nested list");
+    };
+    let SupramarkNode::ListItem {
+        children: nested_item,
+        ..
+    } = &nested[0]
+    else {
+        panic!("expected nested item");
+    };
+    let SupramarkNode::Text { value, .. } = &nested_item[0] else {
+        panic!("expected nested text");
+    };
+    assert_eq!(value, "b");
+}
+
+#[test]
+fn public_api_does_not_pad_tight_item_without_nested_block() {
+    // A plain tight item with no following block must not receive a trailing
+    // space — cmark renders `<li>foo</li>` with no trailing whitespace.
+    let ast = parse("- foo\n- bar\n");
+    let SupramarkNode::Root { children, .. } = ast else {
+        panic!("expected root");
+    };
+    let SupramarkNode::List {
+        children: items, ..
+    } = &children[0]
+    else {
+        panic!("expected list");
+    };
+    let SupramarkNode::ListItem {
+        children: first, ..
+    } = &items[0]
+    else {
+        panic!("expected first item");
+    };
+    let SupramarkNode::Text { value, .. } = &first[0] else {
+        panic!("expected text");
+    };
+    assert_eq!(value, "foo");
+}
+
+#[test]
+fn public_api_does_not_pad_loose_list_item_text() {
+    // Loose items keep the paragraph wrapper, so the text is not a direct
+    // child of the list item and must be left untouched.
+    let ast = parse("- foo\n\n  - bar\n");
+    let SupramarkNode::Root { children, .. } = ast else {
+        panic!("expected root");
+    };
+    let SupramarkNode::List {
+        children: items, ..
+    } = &children[0]
+    else {
+        panic!("expected list");
+    };
+    let SupramarkNode::ListItem {
+        children: first, ..
+    } = &items[0]
+    else {
+        panic!("expected first item");
+    };
+    let SupramarkNode::Paragraph { children, .. } = &first[0] else {
+        panic!("expected paragraph, got {first:?}");
+    };
+    let SupramarkNode::Text { value, .. } = &children[0] else {
+        panic!("expected text");
+    };
+    assert_eq!(value, "foo");
+}
+
 fn first_text(nodes: &[SupramarkNode]) -> &str {
     match &nodes[0] {
         SupramarkNode::Paragraph { children, .. } => first_text(children),


### PR DESCRIPTION
## Summary
- Fixes CommonMark issue #115: tight list item text directly followed by a nested block (e.g. `- a\n  - b`) lost the line break between them, producing `<li>a<ul>` instead of cmark's `<li>a\n<ul>`. The parser dropped the trailing soft break, so the text node value was `a` instead of `a `.
- In `ListItem::to_ast_v2`, append a trailing space to a text node that sits immediately before a block-level sibling. Plain tight items (no following block) and loose items (paragraph-wrapped) are left untouched.
- All 6 representative cases (0009, 0294, 0300, 0307, 0319, 0323) now pass the semantic conformance comparison. A full semantic run recovers 151 previously-failing list cases with **0 regressions** (the only 2 "new" failures — 0126, 0130 — are pre-existing `astToHtml` fenced-code-block differences unrelated to lists; they fail identically on `main`).

## Test plan
- [x] `cargo test -p supramark-markdown` — 55 lib + 29 integration tests pass, including 3 new tests:
  - `public_api_preserves_break_in_tight_list_item_before_nested_block` (value `a `, nested item still `b`)
  - `public_api_does_not_pad_tight_item_without_nested_block` (value `foo`, no trailing space)
  - `public_api_does_not_pad_loose_list_item_text` (loose item text untouched)
- [x] `cargo fmt --check` and `cargo clippy` clean for the changed file
- [x] Verified all 6 CommonMark cases pass via `tests/markdown-conformance` semantic comparison
- [ ] Full visual conformance baseline regeneration (production web renderer) should be run in CI to refresh `baselines/commonmark.json` — left for a follow-up since it requires the browser harness.

Closes #115.
