### PR TITLE
fix(mermaid): reserve edge-label space at layout time for CJK (#93)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -875,6 +875,7 @@ dependencies = [
  "supramark-diagram-core",
  "supramark-font-metrics",
  "thiserror 1.0.69",
+ "unicode-width",
 ]
 
 [[package]]

--- a/crates/mermaid-little/Cargo.toml
+++ b/crates/mermaid-little/Cargo.toml
@@ -113,6 +113,10 @@ supramark-diagram-core = { path = "../supramark-diagram-core", version = "0.1" }
 font_metrics_core = { package = "supramark-font-metrics", path = "../font-metrics", version = "0.1" }
 thiserror = "1"
 log = "0.4"
+# East Asian Width lookup, used by `layout::label_metrics` to decide which
+# glyphs render ~1em wide. Same version d2-little already pins, so the
+# workspace resolves to a single copy.
+unicode-width = "0.1"
 env_logger = { version = "0.11", optional = true }
 # QuickJS bindings for the optional `katex` feature. Pinned to 0.10 (last
 # release compatible with rust-version = "1.82"; 0.11+ requires 1.87).

--- a/crates/mermaid-little/examples/fc_diff_probe.rs
+++ b/crates/mermaid-little/examples/fc_diff_probe.rs
@@ -92,7 +92,7 @@ fn main() {
             theme::apply_theme_variables(&mut theme, tv);
         }
         let l = match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            layout_fc::layout(&d, &theme)
+            layout_fc::layout(&d, &theme, false)
         })) {
             Ok(Ok(l)) => l,
             _ => {

--- a/crates/mermaid-little/src/engine.rs
+++ b/crates/mermaid-little/src/engine.rs
@@ -10,7 +10,9 @@
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
 
-use supramark_diagram_core::{DiagramEngine, DiagramError, EngineAst, RenderOutput};
+use supramark_diagram_core::{
+    DiagramEngine, DiagramError, EngineAst, EngineRenderOptions, RenderOutput,
+};
 
 #[cfg(feature = "semantic-serde")]
 use crate::semantic::{self, SemanticError};
@@ -47,6 +49,22 @@ impl DiagramEngine for MermaidEngine {
             engine: ENGINE_ID,
             message: e.to_string(),
         })?;
+        Ok(RenderOutput::svg(svg.into_bytes()))
+    }
+
+    fn render_with_options(
+        &self,
+        source: &str,
+        opts: &EngineRenderOptions,
+    ) -> Result<RenderOutput, DiagramError> {
+        let id = Self::stable_id(source);
+        let ro =
+            crate::RenderOptions::default().with_edge_label_decluster(opts.edge_label_decluster);
+        let svg =
+            crate::convert_with_options(source, &id, &ro).map_err(|e| DiagramError::Render {
+                engine: ENGINE_ID,
+                message: e.to_string(),
+            })?;
         Ok(RenderOutput::svg(svg.into_bytes()))
     }
 
@@ -181,6 +199,40 @@ mod tests {
     fn render_produces_svg_bytes() {
         let src = "flowchart TD\n    A --> B\n";
         let out = MermaidEngine.render(src).unwrap();
+        assert_eq!(out.mime, "image/svg+xml");
+        let svg = String::from_utf8(out.bytes).unwrap();
+        assert!(svg.contains("<svg"));
+    }
+}
+
+#[cfg(all(test, feature = "metrics-ttf-parser"))]
+mod render_options_tests {
+    use super::*;
+    use supramark_diagram_core::{DiagramEngine, EngineRenderOptions};
+
+    #[test]
+    fn render_with_default_options_matches_render() {
+        // Default options must be byte-identical to the canonical render —
+        // the trait override must not perturb the path when nothing is opted in.
+        let src = "flowchart LR\n    A[Start] -->|label| B[End]\n";
+        let canonical = MermaidEngine.render(src).unwrap();
+        let with_default = MermaidEngine
+            .render_with_options(src, &EngineRenderOptions::default())
+            .unwrap();
+        assert_eq!(canonical.bytes, with_default.bytes);
+    }
+
+    #[test]
+    fn render_with_edge_label_decluster_produces_svg() {
+        let src = "flowchart LR\n    A -->|one| B\n    A -->|two| B\n";
+        let out = MermaidEngine
+            .render_with_options(
+                src,
+                &EngineRenderOptions {
+                    edge_label_decluster: true,
+                },
+            )
+            .unwrap();
         assert_eq!(out.mime, "image/svg+xml");
         let svg = String::from_utf8(out.bytes).unwrap();
         assert!(svg.contains("<svg"));

--- a/crates/mermaid-little/src/layout/edge_label_decluster.rs
+++ b/crates/mermaid-little/src/layout/edge_label_decluster.rs
@@ -1,0 +1,262 @@
+//! Opt-in edge-label collision avoidance for flowcharts.
+//!
+//! Dagre (and upstream Mermaid) place every edge label at the midpoint of its
+//! spline with no mutual avoidance, so labels on edges that share a midpoint
+//! region — opposite-direction edges between the same node pair, or a dense
+//! fan-in — stack on top of each other. This is confirmed upstream behaviour
+//! (see issue #93), not a Supramark regression, so the default render path
+//! stays byte-exact with `mermaid@11.14.0`.
+//!
+//! This module provides an opt-in post-layout pass that nudges overlapping
+//! label bounding boxes apart. It runs on the *final* rendered label centres
+//! (after `recompute_edge_label_position`), so it agrees with whatever the
+//! renderer actually draws. The pass is greedy iterative pairwise separation
+//! along the axis of minimum penetration — the standard AABB resolution used
+//! by label-displacers in graph layout. Each label may only move a bounded
+//! distance from its base position so it stays tethered to its edge.
+//!
+//! The function is pure arithmetic over centre-based rects `(cx, cy, w, h)`
+//! so it is trivially testable without laying out a real diagram.
+
+/// A centre-based axis-aligned label rectangle.
+pub type LabelRect = (f64, f64, f64, f64);
+
+/// Separation tuning. Picked to remove the overlap clusters reported in #93
+/// (which sit within ~20 px of each other) while keeping labels visibly
+/// anchored to their edges.
+pub struct DeclusterConfig {
+    /// Extra gap left between labels after separation, in diagram units.
+    pub gap: f64,
+    /// Maximum distance a label centre may move from its base position.
+    pub max_displacement: f64,
+    /// Upper bound on resolution iterations. Greedy separation converges
+    /// quickly for the small N of a typical flowchart; the cap is a backstop.
+    pub max_iters: usize,
+}
+
+impl Default for DeclusterConfig {
+    fn default() -> Self {
+        Self {
+            gap: 6.0,
+            max_displacement: 80.0,
+            max_iters: 16,
+        }
+    }
+}
+
+/// Push overlapping label rects apart in place, with no obstacles.
+///
+/// `centres[i] = (cx, cy, w, h)` — the label centre and its full width/height.
+/// `base[i]` is the original centre used to clamp displacement; pass the same
+/// slice as `centres` before mutation if you want clamping relative to the
+/// input positions (the normal case). On return, `centres` holds the adjusted
+/// centres; widths/heights are unchanged.
+pub fn decluster(centres: &mut [LabelRect], base: &[LabelRect], cfg: &DeclusterConfig) {
+    decluster_with_obstacles(centres, base, &[], cfg);
+}
+
+/// Like [`decluster`], but labels are also pushed out of static `obstacles`
+/// (e.g. flowchart node rectangles). Obstacles never move — the full
+/// penetration plus gap is borne by the label alone (one-way), resolved along
+/// the axis of minimum penetration and clamped to the label's base position.
+/// With `obstacles` empty this is identical to [`decluster`].
+pub fn decluster_with_obstacles(
+    centres: &mut [LabelRect],
+    base: &[LabelRect],
+    obstacles: &[LabelRect],
+    cfg: &DeclusterConfig,
+) {
+    let n = centres.len();
+    debug_assert_eq!(base.len(), n);
+    if n == 0 {
+        return;
+    }
+    for _ in 0..cfg.max_iters {
+        let moved_o = push_off_obstacles(centres, base, obstacles, cfg);
+        let moved_l = separate_labels(centres, base, cfg);
+        if !moved_o && !moved_l {
+            break;
+        }
+    }
+    // Final sweep: label<->label only. Issue #93 is label/label overlap, so
+    // the pass must end with labels mutually separated wherever a separation
+    // exists, even if an obstacle push earlier in the loop drove two labels
+    // together. We do NOT run a trailing obstacle pass here: on a dense layout
+    // nudging a label off a node pushes it into a neighbour, reintroducing the
+    // label/label overlap this sweep just removed. Node overlap from dagre's
+    // midpoint placement is upstream behaviour and only best-effort — the
+    // earlier interleaved obstacle passes already remove what they can without
+    // trading label/label overlap for it.
+    for _ in 0..cfg.max_iters {
+        if !separate_labels(centres, base, cfg) {
+            break;
+        }
+    }
+}
+
+/// One pass of mutual label<->label separation. Returns true if any label
+/// moved. Each overlapping pair is pushed apart along the axis of minimum
+/// penetration, splitting the displacement equally between the two labels.
+fn separate_labels(
+    centres: &mut [LabelRect],
+    base: &[LabelRect],
+    cfg: &DeclusterConfig,
+) -> bool {
+    let n = centres.len();
+    let mut moved = false;
+    for i in 0..n {
+        for j in (i + 1)..n {
+            let (ax, ay, aw, ah) = centres[i];
+            let (bx, by, bw, bh) = centres[j];
+            let pen_x = (aw / 2.0 + bw / 2.0) - (ax - bx).abs();
+            let pen_y = (ah / 2.0 + bh / 2.0) - (ay - by).abs();
+            if pen_x <= 0.0 || pen_y <= 0.0 {
+                continue;
+            }
+            moved = true;
+            if pen_x < pen_y {
+                let dir = if ax <= bx { -1.0 } else { 1.0 };
+                let push = (pen_x + cfg.gap) / 2.0;
+                centres[i].0 = clamp_to_base(base[i].0, ax + dir * push, cfg);
+                centres[j].0 = clamp_to_base(base[j].0, bx - dir * push, cfg);
+            } else {
+                let dir = if ay <= by { -1.0 } else { 1.0 };
+                let push = (pen_y + cfg.gap) / 2.0;
+                centres[i].1 = clamp_to_base(base[i].1, ay + dir * push, cfg);
+                centres[j].1 = clamp_to_base(base[j].1, by - dir * push, cfg);
+            }
+        }
+    }
+    moved
+}
+
+/// One pass of one-way label<->obstacle separation. Returns true if any label
+/// moved. The label bears the full penetration plus gap; obstacles never move.
+fn push_off_obstacles(
+    centres: &mut [LabelRect],
+    base: &[LabelRect],
+    obstacles: &[LabelRect],
+    cfg: &DeclusterConfig,
+) -> bool {
+    let n = centres.len();
+    let mut moved = false;
+    for i in 0..n {
+        for &(ox, oy, ow, oh) in obstacles {
+            let (ax, ay, aw, ah) = centres[i];
+            let pen_x = (aw / 2.0 + ow / 2.0) - (ax - ox).abs();
+            let pen_y = (ah / 2.0 + oh / 2.0) - (ay - oy).abs();
+            if pen_x <= 0.0 || pen_y <= 0.0 {
+                continue;
+            }
+            moved = true;
+            if pen_x < pen_y {
+                let dir = if ax <= ox { -1.0 } else { 1.0 };
+                let push = pen_x + cfg.gap;
+                centres[i].0 = clamp_to_base(base[i].0, centres[i].0 + dir * push, cfg);
+            } else {
+                let dir = if ay <= oy { -1.0 } else { 1.0 };
+                let push = pen_y + cfg.gap;
+                centres[i].1 = clamp_to_base(base[i].1, centres[i].1 + dir * push, cfg);
+            }
+        }
+    }
+    moved
+}
+
+/// Clamp `value` to within `max_displacement` of `base_value`.
+fn clamp_to_base(base_value: f64, value: f64, cfg: &DeclusterConfig) -> f64 {
+    let delta = value - base_value;
+    let clamped = delta.clamp(-cfg.max_displacement, cfg.max_displacement);
+    base_value + clamped
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rects_equal(a: &[LabelRect], b: &[(f64, f64)]) {
+        for (i, ((cx, cy, _, _), (ex, ey))) in a.iter().zip(b.iter()).enumerate() {
+            assert!(
+                (cx - ex).abs() < 1e-6 && (cy - ey).abs() < 1e-6,
+                "rect[{i}] centre = ({cx}, {cy}), expected ({ex}, {ey})"
+            );
+        }
+    }
+
+    #[test]
+    fn no_op_when_no_overlap() {
+        let mut r = [(0.0, 0.0, 10.0, 10.0), (100.0, 100.0, 10.0, 10.0)];
+        let base = r;
+        decluster(&mut r, &base, &DeclusterConfig::default());
+        rects_equal(&r, &[(0.0, 0.0), (100.0, 100.0)]);
+    }
+
+    #[test]
+    fn separates_vertically_stacked_labels() {
+        // Two 20x10 labels sharing the same centre — the A1<->COMMIT case.
+        let mut r = [(50.0, 50.0, 20.0, 10.0), (50.0, 50.0, 20.0, 10.0)];
+        let base = r;
+        decluster(&mut r, &base, &DeclusterConfig::default());
+        // Equal penetration both axes; the else-branch picks vertical.
+        assert!(
+            (r[0].1 - r[1].1).abs() > 10.0,
+            "labels must split vertically"
+        );
+        // Widths unchanged.
+        assert_eq!(r[0].2, 20.0);
+        assert_eq!(r[1].3, 10.0);
+        // Symmetric about the original centre.
+        assert!(((r[0].1 + r[1].1) / 2.0 - 50.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn result_has_no_remaining_overlaps() {
+        // A dense cluster of four labels plus a distant one.
+        let mut r = vec![
+            (50.0, 50.0, 30.0, 10.0),
+            (52.0, 52.0, 30.0, 10.0),
+            (48.0, 48.0, 30.0, 10.0),
+            (51.0, 51.0, 30.0, 10.0),
+            (500.0, 500.0, 30.0, 10.0),
+        ];
+        let base = r.clone();
+        decluster(&mut r, &base, &DeclusterConfig::default());
+        for i in 0..r.len() {
+            for j in (i + 1)..r.len() {
+                let (ax, ay, aw, ah) = r[i];
+                let (bx, by, bw, bh) = r[j];
+                let pen_x = (aw / 2.0 + bw / 2.0) - (ax - bx).abs();
+                let pen_y = (ah / 2.0 + bh / 2.0) - (ay - by).abs();
+                assert!(
+                    pen_x <= 0.0 || pen_y <= 0.0,
+                    "labels {i} and {j} still overlap (pen_x={pen_x}, pen_y={pen_y})"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn displacement_is_clamped() {
+        // A tiny max_displacement must cap how far a label can move even when
+        // a large overlap would otherwise push it far.
+        let cfg = DeclusterConfig {
+            gap: 0.0,
+            max_displacement: 5.0,
+            max_iters: 16,
+        };
+        let mut r = [(0.0, 0.0, 200.0, 200.0), (0.0, 0.0, 200.0, 200.0)];
+        let base = r;
+        decluster(&mut r, &base, &cfg);
+        // Horizontal penetration (200) == vertical (200); vertical branch.
+        assert!((r[0].1 - 0.0).abs() <= 5.0 + 1e-9);
+        assert!((r[1].1 - 0.0).abs() <= 5.0 + 1e-9);
+    }
+
+    #[test]
+    fn fewer_than_two_labels_is_noop() {
+        let mut r = [(10.0, 10.0, 5.0, 5.0)];
+        let base = r;
+        decluster(&mut r, &base, &DeclusterConfig::default());
+        rects_equal(&r, &[(10.0, 10.0)]);
+    }
+}

--- a/crates/mermaid-little/src/layout/edge_label_decluster.rs
+++ b/crates/mermaid-little/src/layout/edge_label_decluster.rs
@@ -97,11 +97,7 @@ pub fn decluster_with_obstacles(
 /// One pass of mutual label<->label separation. Returns true if any label
 /// moved. Each overlapping pair is pushed apart along the axis of minimum
 /// penetration, splitting the displacement equally between the two labels.
-fn separate_labels(
-    centres: &mut [LabelRect],
-    base: &[LabelRect],
-    cfg: &DeclusterConfig,
-) -> bool {
+fn separate_labels(centres: &mut [LabelRect], base: &[LabelRect], cfg: &DeclusterConfig) -> bool {
     let n = centres.len();
     let mut moved = false;
     for i in 0..n {

--- a/crates/mermaid-little/src/layout/flowchart.rs
+++ b/crates/mermaid-little/src/layout/flowchart.rs
@@ -59,8 +59,12 @@ const LABEL_FONT_SIZE: f64 = 14.0;
 const FLOWCHART_PADDING: f64 = 15.0;
 
 /// Lay out a flowchart diagram. Uses dagre for the graph geometry.
-pub fn layout(d: &FlowchartDiagram, theme: &ThemeVariables) -> Result<FlowchartLayout> {
-    let layout_data = build_layout_data(d);
+pub fn layout(
+    d: &FlowchartDiagram,
+    theme: &ThemeVariables,
+    edge_label_decluster: bool,
+) -> Result<FlowchartLayout> {
+    let layout_data = build_layout_data(d, edge_label_decluster);
     let LayoutResult {
         nodes,
         edges,
@@ -757,7 +761,7 @@ fn intersect_rect(rect: (f64, f64, f64, f64), target: (f64, f64)) -> (f64, f64) 
 }
 
 /// Build a unified `LayoutData` from a flowchart AST.
-fn build_layout_data(d: &FlowchartDiagram) -> LayoutData {
+fn build_layout_data(d: &FlowchartDiagram, edge_label_decluster: bool) -> LayoutData {
     let mut data = LayoutData {
         diagram_type: Some("flowchart-v2".into()),
         direction: Some(d.direction.as_str().into()),
@@ -1020,6 +1024,7 @@ fn build_layout_data(d: &FlowchartDiagram) -> LayoutData {
             &class_map,
             d.html_labels.unwrap_or(true),
             d.curve.as_deref().unwrap_or("basis"),
+            edge_label_decluster,
         );
         // Record original endpoints before retargeting so the isolation check
         // in dagre_bridge can test against the pre-retarget cluster IDs.
@@ -1721,6 +1726,7 @@ fn build_edge<'a>(
     class_map: &BTreeMap<&'a str, &'a ClassDef>,
     html_labels: bool,
     config_curve: &str,
+    edge_label_decluster: bool,
 ) -> unified::Edge {
     // Custom-id syntax `A name@-->B` lets the source set an explicit edge id
     // (`name`). Upstream uses that id directly; only fall back to the
@@ -1765,7 +1771,19 @@ fn build_edge<'a>(
         .as_ref()
         .map(|l| matches!(l.kind, crate::model::flowchart::LabelKind::Markdown))
         .unwrap_or(false);
-    let (lw, lh) = measure_edge_label(label_text, html_labels, is_markdown_label);
+    let (lw_shim, lh) = measure_edge_label(label_text, html_labels, is_markdown_label);
+    // Byte-exact default: dagre reserves the shim width. The shim under-measures
+    // CJK, so in opt-in mode floor the width to the real rendered estimate —
+    // dagre then reserves enough rank space for the label to fit between its
+    // endpoint nodes (the layout-time fix for issue #93 label/node overlaps).
+    // Only floor when the label actually contains CJK, so pure-Latin diagrams
+    // keep their byte-exact spacing. Height is left to the shim: it controls
+    // intra-rank separation, not the inter-rank gap this fixes.
+    let lw = if edge_label_decluster && label_text.chars().any(crate::layout::label_metrics::is_cjk) {
+        crate::layout::label_metrics::cjk_aware_label_width(label_text, lw_shim)
+    } else {
+        lw_shim
+    };
     ue.extra.insert("label_width".into(), lw.to_string());
     ue.extra.insert("label_height".into(), lh.to_string());
 
@@ -2054,7 +2072,7 @@ mod tests {
         let src = "flowchart TD\nA --> B\n";
         let d = fcp::parse(src).unwrap();
         let theme = ThemeVariables::default();
-        let l = layout(&d, &theme).unwrap();
+        let l = layout(&d, &theme, false).unwrap();
         assert_eq!(l.nodes.len(), 2);
         assert_eq!(l.edges.len(), 1);
         let a = l.nodes.iter().find(|n| n.id == "A").unwrap();
@@ -2066,7 +2084,7 @@ mod tests {
         let src = "flowchart TD\nsubgraph s1 [Title]\n  A-->B\nend\nA-->C\n";
         let d = fcp::parse(src).unwrap();
         let theme = ThemeVariables::default();
-        let l = layout(&d, &theme).unwrap();
+        let l = layout(&d, &theme, false).unwrap();
         assert!(l.clusters.iter().any(|c| c.id == "s1"));
         // members must have their parent_id set
         let a = l.nodes.iter().find(|n| n.id == "A").unwrap();
@@ -2078,7 +2096,7 @@ mod tests {
         let src = "flowchart LR\nA-->B\n";
         let d = fcp::parse(src).unwrap();
         let theme = ThemeVariables::default();
-        let l = layout(&d, &theme).unwrap();
+        let l = layout(&d, &theme, false).unwrap();
         let a = l.nodes.iter().find(|n| n.id == "A").unwrap();
         let b = l.nodes.iter().find(|n| n.id == "B").unwrap();
         assert!(b.x.unwrap() > a.x.unwrap());

--- a/crates/mermaid-little/src/layout/flowchart.rs
+++ b/crates/mermaid-little/src/layout/flowchart.rs
@@ -1629,7 +1629,7 @@ fn measure_edge_label(text: &str, html_labels: bool, is_markdown: bool) -> (f64,
         // <p> displays the rendered HTML, but jsdom's getBoundingClientRect
         // still measures the textContent (i.e. marker-free string). In
         // both cases reuse `markdownToHTML` so the measured width matches
-        // upstream — strip_html_for_measurement removes the inserted
+        // upstream — `edge_label_plain_text` strips the inserted
         // `<strong>`/`<em>` tags and yields the plain text.
         crate::render::foreign_object::markdown_label_to_html(text)
     } else {
@@ -1640,7 +1640,7 @@ fn measure_edge_label(text: &str, html_labels: bool, is_markdown: bool) -> (f64,
     // result as ONE line — `<br>` does not split because `textContent`
     // collapses break tags. `\n` characters survive as whitespace and are
     // dropped here to match upstream's `measureTextBlock` shim.
-    let plain = strip_html_for_measurement(&measure_text);
+    let plain = crate::layout::label_metrics::strip_html_for_measurement(&measure_text);
     let w = font_metrics::text_width(&plain, EDGE_LABEL_FONT, EDGE_LABEL_SIZE, false, false);
     if !html_labels {
         // `bbox` of labelGroup = unionOf(rect{-2,-2,w+4,h+4}, text{0,0,w,h})
@@ -1649,71 +1649,6 @@ fn measure_edge_label(text: &str, html_labels: bool, is_markdown: bool) -> (f64,
         return (w + 4.0, h + 4.0);
     }
     (w, h)
-}
-
-/// Strip HTML tags and decode common entities to mirror jsdom's
-/// `textContent` for edge-label width measurement.
-fn strip_html_for_measurement(s: &str) -> String {
-    let mut out = String::with_capacity(s.len());
-    let bytes = s.as_bytes();
-    let mut i = 0;
-    while i < bytes.len() {
-        if bytes[i] == b'<' {
-            // A `<` only starts an HTML tag when followed by an ASCII letter
-            // or `/letter`. Anything else (`<<`, `< `, `<1`, `<!`, `<?`) is
-            // treated as literal text — matching parse_html_text_segments.
-            let next = bytes.get(i + 1).copied();
-            let is_tag_start = match next {
-                Some(c) if c.is_ascii_alphabetic() => true,
-                Some(b'/') => bytes
-                    .get(i + 2)
-                    .map(|c| c.is_ascii_alphabetic())
-                    .unwrap_or(false),
-                _ => false,
-            };
-            if is_tag_start {
-                if let Some(rel_end) = s[i..].find('>') {
-                    i += rel_end + 1;
-                    continue;
-                }
-            }
-            out.push('<');
-            i += 1;
-        } else if bytes[i] == b'&' {
-            if let Some(semi_rel) = s[i..].find(';') {
-                let entity = &s[i + 1..i + semi_rel];
-                let ch = match entity {
-                    "amp" => Some('&'),
-                    "lt" => Some('<'),
-                    "gt" => Some('>'),
-                    "quot" => Some('"'),
-                    "apos" => Some('\''),
-                    "nbsp" => Some('\u{00A0}'),
-                    _ => None,
-                };
-                if let Some(c) = ch {
-                    out.push(c);
-                    i += semi_rel + 1;
-                    continue;
-                }
-            }
-            out.push('&');
-            i += 1;
-        } else if bytes[i] == b'\n' {
-            // textContent treats inline `\n` as whitespace; under
-            // measureTextBlock the legacy single-line behaviour drops it.
-            i += 1;
-        } else {
-            // UTF-8-safe copy of the next char.
-            let mut len = 1usize;
-            while len < 4 && i + len < bytes.len() && (bytes[i + len] & 0xC0) == 0x80 {
-                len += 1;
-            }
-            out.push_str(&s[i..i + len]);
-            i += len;
-        }
-    }
-    out
 }
 
 /// Build a unified::Edge from a model Edge, applying link-style overrides.
@@ -1776,15 +1711,19 @@ fn build_edge<'a>(
     // CJK, so in opt-in mode floor the width to the real rendered estimate —
     // dagre then reserves enough rank space for the label to fit between its
     // endpoint nodes (the layout-time fix for issue #93 label/node overlaps).
-    // Only floor when the label actually contains CJK, so pure-Latin diagrams
-    // keep their byte-exact spacing. Height is left to the shim: it controls
-    // intra-rank separation, not the inter-rank gap this fixes.
+    // The per-glyph estimate runs over the marker-free plain text (tags and
+    // entities stripped), so markup like `<br/>` / `**` / `&amp;` is not billed
+    // and the floor tracks the real painted width. Only floor when the label
+    // actually contains a wide glyph, so pure-Latin diagrams keep their
+    // byte-exact spacing. Height is left to the shim: it controls intra-rank
+    // separation, not the inter-rank gap this fixes.
+    let plain = crate::layout::label_metrics::edge_label_plain_text(label_text, is_markdown_label);
     let lw = if edge_label_decluster
-        && label_text
+        && plain
             .chars()
             .any(crate::layout::label_metrics::is_wide_glyph)
     {
-        crate::layout::label_metrics::cjk_aware_label_width(label_text, lw_shim)
+        crate::layout::label_metrics::cjk_aware_label_width(&plain, lw_shim)
     } else {
         lw_shim
     };

--- a/crates/mermaid-little/src/layout/flowchart.rs
+++ b/crates/mermaid-little/src/layout/flowchart.rs
@@ -1779,7 +1779,11 @@ fn build_edge<'a>(
     // Only floor when the label actually contains CJK, so pure-Latin diagrams
     // keep their byte-exact spacing. Height is left to the shim: it controls
     // intra-rank separation, not the inter-rank gap this fixes.
-    let lw = if edge_label_decluster && label_text.chars().any(crate::layout::label_metrics::is_cjk) {
+    let lw = if edge_label_decluster
+        && label_text
+            .chars()
+            .any(crate::layout::label_metrics::is_wide_glyph)
+    {
         crate::layout::label_metrics::cjk_aware_label_width(label_text, lw_shim)
     } else {
         lw_shim

--- a/crates/mermaid-little/src/layout/label_metrics.rs
+++ b/crates/mermaid-little/src/layout/label_metrics.rs
@@ -1,0 +1,42 @@
+//! Shared CJK-aware label width estimation.
+//!
+//! The byte-exact jsdom shim (`measure_html_markup_label` /
+//! `font_metrics::text_width`) measures ASCII width accurately but
+//! **under-measures CJK glyphs to ~40%** of their real render width — it has
+//! no CJK fallback-font metrics. "账户同步" measures ~28px via the shim but
+//! renders ~72px in a real browser. Any consumer that needs the label's
+//! *visual* width — reserving layout space, or detecting collisions — must
+//! floor the shim measurement with a per-glyph character estimate, or it will
+//! under-reserve / fail to see overlaps.
+//!
+//! Never loosen the shim itself: it drives foreignObject sizing, which must
+//! stay byte-exact with upstream `mermaid@11.14.0`. The floor is applied only
+//! by opt-in consumers on top of the shim result.
+
+/// One em at the rendered edge-label font size (`HTML_LABEL_FONT_SIZE = 16`),
+/// i.e. what the browser actually paints. Layout reservation uses this so dagre
+/// reserves the real on-screen width rather than the shim's under-estimate.
+const EM: f64 = 16.0;
+
+/// Best estimate of `text`'s rendered width, never below the shim `measured`
+/// value. Latin glyphs estimate to ~0.56em (close to the shim, so pure-Latin
+/// labels are effectively unchanged); CJK and fullwidth glyphs estimate to
+/// ~1em, correcting the shim's under-measurement.
+pub fn cjk_aware_label_width(text: &str, measured: f64) -> f64 {
+    let per_glyph: f64 = text
+        .chars()
+        .map(|c| if is_cjk(c) { EM } else { EM * 0.56 })
+        .sum();
+    measured.max(per_glyph)
+}
+
+/// Whether a glyph renders ~1em wide (CJK / fullwidth) and is thus
+/// under-measured by the shim. Used both inside [`cjk_aware_label_width`] and
+/// to cheaply gate the floor on "label contains at least one CJK glyph", so
+/// pure-Latin diagrams are not perturbed.
+pub fn is_cjk(c: char) -> bool {
+    matches!(c as u32,
+        0x3000..=0x303F | 0x3040..=0x309F | 0x30A0..=0x30FF |
+        0x3400..=0x4DBF | 0x4E00..=0x9FFF | 0xF900..=0xFAFF | 0xFF00..=0xFFEF
+    )
+}

--- a/crates/mermaid-little/src/layout/label_metrics.rs
+++ b/crates/mermaid-little/src/layout/label_metrics.rs
@@ -40,3 +40,56 @@ pub fn is_cjk(c: char) -> bool {
         0x3400..=0x4DBF | 0x4E00..=0x9FFF | 0xF900..=0xFAFF | 0xFF00..=0xFFEF
     )
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn is_cjk_detects_cjk_and_fullwidth() {
+        // CJK ideographs + kana + fullwidth latin/space all render ~1em.
+        assert!(is_cjk('账'));
+        assert!(is_cjk('あ')); // hiragana
+        assert!(is_cjk('カ')); // katakana
+        assert!(is_cjk('Ａ')); // fullwidth latin (FF01-FF5E)
+        assert!(is_cjk('　')); // fullwidth space (3000)
+        // ASCII / Latin-1 render narrower and must not trigger the floor.
+        assert!(!is_cjk('A'));
+        assert!(!is_cjk(' '));
+        assert!(!is_cjk('-'));
+        assert!(!is_cjk('é'));
+    }
+
+    #[test]
+    fn cjk_floors_to_one_em_per_glyph() {
+        // "账户同步" = 4 CJK glyphs → 4 × EM = 64; shim (~28) is below, so floor wins.
+        assert_eq!(cjk_aware_label_width("账户同步", 28.0), 64.0);
+    }
+
+    #[test]
+    fn cjk_keeps_shim_when_already_wider() {
+        // If the shim measured wider than the per-glyph estimate, keep the shim.
+        assert_eq!(cjk_aware_label_width("账户同步", 80.0), 80.0);
+    }
+
+    #[test]
+    fn latin_estimates_below_cjk_floor() {
+        // Latin glyphs estimate ~0.56em; "ok" → 2 × 16 × 0.56 = 17.92.
+        // (Call sites gate on is_cjk, so pure-Latin labels never hit this path;
+        // this pins the coefficient for mixed labels.)
+        assert!((cjk_aware_label_width("ok", 12.0) - 17.92).abs() < 1e-9);
+    }
+
+    #[test]
+    fn mixed_takes_max_of_estimate_and_shim() {
+        // "A账" → 0.56em + 1em = 24.96; shim 10 → 24.96.
+        assert!((cjk_aware_label_width("A账", 10.0) - 24.96).abs() < 1e-9);
+        // Same estimate, but shim already larger → keep shim.
+        assert_eq!(cjk_aware_label_width("A账", 40.0), 40.0);
+    }
+
+    #[test]
+    fn empty_returns_shim() {
+        assert_eq!(cjk_aware_label_width("", 5.0), 5.0);
+    }
+}

--- a/crates/mermaid-little/src/layout/label_metrics.rs
+++ b/crates/mermaid-little/src/layout/label_metrics.rs
@@ -3,7 +3,7 @@
 //! The byte-exact jsdom shim (`measure_html_markup_label` /
 //! `font_metrics::text_width`) measures ASCII width accurately but
 //! **under-measures CJK glyphs to ~40%** of their real render width — it has
-//! no CJK fallback-font metrics. "账户同步" measures ~28px via the shim but
+//! no CJK fallback-font metrics. A 4-ideograph label measures ~28px via the shim but
 //! renders ~72px in a real browser. Any consumer that needs the label's
 //! *visual* width — reserving layout space, or detecting collisions — must
 //! floor the shim measurement with a per-glyph character estimate, or it will
@@ -25,67 +25,113 @@ const EM: f64 = 16.0;
 pub fn cjk_aware_label_width(text: &str, measured: f64) -> f64 {
     let per_glyph: f64 = text
         .chars()
-        .map(|c| if is_cjk(c) { EM } else { EM * 0.56 })
+        .map(|c| if is_wide_glyph(c) { EM } else { EM * 0.56 })
         .sum();
     measured.max(per_glyph)
 }
 
-/// Whether a glyph renders ~1em wide (CJK / fullwidth) and is thus
-/// under-measured by the shim. Used both inside [`cjk_aware_label_width`] and
-/// to cheaply gate the floor on "label contains at least one CJK glyph", so
-/// pure-Latin diagrams are not perturbed.
-pub fn is_cjk(c: char) -> bool {
-    matches!(c as u32,
-        0x3000..=0x303F | 0x3040..=0x309F | 0x30A0..=0x30FF |
-        0x3400..=0x4DBF | 0x4E00..=0x9FFF | 0xF900..=0xFAFF | 0xFF00..=0xFFEF
-    )
+/// Whether a glyph renders ~1em wide and is thus under-measured by the shim.
+/// Used both inside [`cjk_aware_label_width`] and to cheaply gate the floor on
+/// "label contains at least one wide glyph", so pure-Latin diagrams are not
+/// perturbed.
+///
+/// Delegates to the Unicode East Asian Width property (`W` and `F` both report
+/// width 2) rather than a hand-rolled range list. Hand-rolled ranges got this
+/// wrong in both directions: Hangul syllables (`U+AC00..`), CJK Ext B+
+/// (`U+20000..`), Bopomofo and the compatibility blocks were all missing, so a
+/// Korean label got no floor at all, while `U+FF00..=U+FFEF` swallowed the
+/// *halfwidth* forms (`U+FF61..=U+FF9F`) and over-reserved them 2x.
+///
+/// Note this is deliberately **not** [`crate::text::is_cjk`]: that one feeds
+/// `display_width` for class-diagram member sizing, which is byte-exact with
+/// upstream and must keep its own range list.
+pub fn is_wide_glyph(c: char) -> bool {
+    unicode_width::UnicodeWidthChar::width(c) == Some(2)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
+    // CJK literals are spelled as `\u{...}` escapes throughout: repo convention
+    // keeps code files ASCII-only. The trailing comment names each glyph.
+    const ZHANG: char = '\u{8D26}'; // CJK ideograph
+    const HIRAGANA_A: char = '\u{3042}';
+    const KATAKANA_KA: char = '\u{30AB}';
+    const FULLWIDTH_A: char = '\u{FF21}';
+    const IDEOGRAPHIC_SPACE: char = '\u{3000}';
+    /// "account sync" in Chinese: 4 ideographs.
+    const ZHANG_HU_TONG_BU: &str = "\u{8D26}\u{6237}\u{540C}\u{6B65}";
+    /// "hello" in Korean: 5 Hangul syllables.
+    const ANNYEONGHASEYO: &str = "\u{C548}\u{B155}\u{D558}\u{C138}\u{C694}";
+
     #[test]
-    fn is_cjk_detects_cjk_and_fullwidth() {
+    fn wide_glyph_detects_cjk_and_fullwidth() {
         // CJK ideographs + kana + fullwidth latin/space all render ~1em.
-        assert!(is_cjk('账'));
-        assert!(is_cjk('あ')); // hiragana
-        assert!(is_cjk('カ')); // katakana
-        assert!(is_cjk('Ａ')); // fullwidth latin (FF01-FF5E)
-        assert!(is_cjk('　')); // fullwidth space (3000)
+        assert!(is_wide_glyph(ZHANG));
+        assert!(is_wide_glyph(HIRAGANA_A));
+        assert!(is_wide_glyph(KATAKANA_KA));
+        assert!(is_wide_glyph(FULLWIDTH_A));
+        assert!(is_wide_glyph(IDEOGRAPHIC_SPACE));
         // ASCII / Latin-1 render narrower and must not trigger the floor.
-        assert!(!is_cjk('A'));
-        assert!(!is_cjk(' '));
-        assert!(!is_cjk('-'));
-        assert!(!is_cjk('é'));
+        assert!(!is_wide_glyph('A'));
+        assert!(!is_wide_glyph(' '));
+        assert!(!is_wide_glyph('-'));
+        assert!(!is_wide_glyph('\u{E9}')); // e-acute
+    }
+
+    #[test]
+    fn wide_glyph_covers_scripts_the_range_list_missed() {
+        assert!(is_wide_glyph('\u{AC00}')); // Hangul syllable
+        assert!(is_wide_glyph('\u{1100}')); // Hangul Jamo
+        assert!(is_wide_glyph('\u{3131}')); // Hangul compatibility Jamo
+        assert!(is_wide_glyph('\u{20000}')); // CJK Ext B
+        assert!(is_wide_glyph('\u{3105}')); // Bopomofo
+        assert!(is_wide_glyph('\u{3231}')); // Enclosed CJK
+    }
+
+    #[test]
+    fn halfwidth_forms_are_not_wide() {
+        // U+FF61..=U+FF9F are *halfwidth*; the old 0xFF00..=0xFFEF range
+        // over-reserved them at 2x their painted width.
+        assert!(!is_wide_glyph('\u{FF71}')); // halfwidth katakana KA-row A
+        assert!(!is_wide_glyph('\u{FF61}')); // halfwidth ideographic full stop
+    }
+
+    #[test]
+    fn korean_label_now_gets_a_floor() {
+        // 5 Hangul syllables -> 5 x EM = 80. The range-list version matched no
+        // character here and returned the shim value untouched.
+        assert_eq!(cjk_aware_label_width(ANNYEONGHASEYO, 44.8), 80.0);
     }
 
     #[test]
     fn cjk_floors_to_one_em_per_glyph() {
-        // "账户同步" = 4 CJK glyphs → 4 × EM = 64; shim (~28) is below, so floor wins.
-        assert_eq!(cjk_aware_label_width("账户同步", 28.0), 64.0);
+        // 4 CJK glyphs -> 4 x EM = 64; shim (~28) is below, so floor wins.
+        assert_eq!(cjk_aware_label_width(ZHANG_HU_TONG_BU, 28.0), 64.0);
     }
 
     #[test]
     fn cjk_keeps_shim_when_already_wider() {
         // If the shim measured wider than the per-glyph estimate, keep the shim.
-        assert_eq!(cjk_aware_label_width("账户同步", 80.0), 80.0);
+        assert_eq!(cjk_aware_label_width(ZHANG_HU_TONG_BU, 80.0), 80.0);
     }
 
     #[test]
     fn latin_estimates_below_cjk_floor() {
-        // Latin glyphs estimate ~0.56em; "ok" → 2 × 16 × 0.56 = 17.92.
-        // (Call sites gate on is_cjk, so pure-Latin labels never hit this path;
-        // this pins the coefficient for mixed labels.)
+        // Latin glyphs estimate ~0.56em; "ok" -> 2 x 16 x 0.56 = 17.92.
+        // (Call sites gate on is_wide_glyph, so pure-Latin labels never hit
+        // this path; this pins the coefficient for mixed labels.)
         assert!((cjk_aware_label_width("ok", 12.0) - 17.92).abs() < 1e-9);
     }
 
     #[test]
     fn mixed_takes_max_of_estimate_and_shim() {
-        // "A账" → 0.56em + 1em = 24.96; shim 10 → 24.96.
-        assert!((cjk_aware_label_width("A账", 10.0) - 24.96).abs() < 1e-9);
-        // Same estimate, but shim already larger → keep shim.
-        assert_eq!(cjk_aware_label_width("A账", 40.0), 40.0);
+        let mixed = format!("A{ZHANG}");
+        // 0.56em + 1em = 24.96; shim 10 -> 24.96.
+        assert!((cjk_aware_label_width(&mixed, 10.0) - 24.96).abs() < 1e-9);
+        // Same estimate, but shim already larger -> keep shim.
+        assert_eq!(cjk_aware_label_width(&mixed, 40.0), 40.0);
     }
 
     #[test]

--- a/crates/mermaid-little/src/layout/label_metrics.rs
+++ b/crates/mermaid-little/src/layout/label_metrics.rs
@@ -49,6 +49,88 @@ pub fn is_wide_glyph(c: char) -> bool {
     unicode_width::UnicodeWidthChar::width(c) == Some(2)
 }
 
+/// The marker-free plain text a label actually paints — the same string
+/// `measure_edge_label` / `measure_html_markup_label` and the browser measure.
+/// Markdown labels go through `markdown_label_to_html` first (so `**x**` →
+/// `<strong>x</strong>`), then [`strip_html_for_measurement`] removes every
+/// tag and decodes entities.
+///
+/// Feed this — not the raw markup — into [`cjk_aware_label_width`]: the
+/// per-glyph estimate must run over painted glyphs only, or markup characters
+/// (`<br/>`, `**`, `&amp;`, `<i class="fa …">`) get billed ~0.56em each and the
+/// width floor re-inflates past the real painted width, re-creating the
+/// off-centre appearance issue #93's fix exists to remove.
+pub fn edge_label_plain_text(text: &str, is_markdown: bool) -> String {
+    let measure_text = if is_markdown {
+        crate::render::foreign_object::markdown_label_to_html(text)
+    } else {
+        text.to_string()
+    };
+    strip_html_for_measurement(&measure_text)
+}
+
+/// Strip HTML tags and decode common entities to mirror jsdom's `textContent`
+/// for label width measurement. A `<` only starts a tag when followed by an
+/// ASCII letter or `/letter` (so `<<`, `<1`, `<!` stay literal); entities
+/// decode to their character; inline `\n` is dropped (textContent whitespace
+/// collapsed by the single-line measure shim).
+pub fn strip_html_for_measurement(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let bytes = s.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'<' {
+            let next = bytes.get(i + 1).copied();
+            let is_tag_start = match next {
+                Some(c) if c.is_ascii_alphabetic() => true,
+                Some(b'/') => bytes
+                    .get(i + 2)
+                    .map(|c| c.is_ascii_alphabetic())
+                    .unwrap_or(false),
+                _ => false,
+            };
+            if is_tag_start {
+                if let Some(rel_end) = s[i..].find('>') {
+                    i += rel_end + 1;
+                    continue;
+                }
+            }
+            out.push('<');
+            i += 1;
+        } else if bytes[i] == b'&' {
+            if let Some(semi_rel) = s[i..].find(';') {
+                let entity = &s[i + 1..i + semi_rel];
+                let ch = match entity {
+                    "amp" => Some('&'),
+                    "lt" => Some('<'),
+                    "gt" => Some('>'),
+                    "quot" => Some('"'),
+                    "apos" => Some('\''),
+                    "nbsp" => Some('\u{00A0}'),
+                    _ => None,
+                };
+                if let Some(c) = ch {
+                    out.push(c);
+                    i += semi_rel + 1;
+                    continue;
+                }
+            }
+            out.push('&');
+            i += 1;
+        } else if bytes[i] == b'\n' {
+            i += 1;
+        } else {
+            let mut len = 1usize;
+            while len < 4 && i + len < bytes.len() && (bytes[i + len] & 0xC0) == 0x80 {
+                len += 1;
+            }
+            out.push_str(&s[i..i + len]);
+            i += len;
+        }
+    }
+    out
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -137,5 +219,32 @@ mod tests {
     #[test]
     fn empty_returns_shim() {
         assert_eq!(cjk_aware_label_width("", 5.0), 5.0);
+    }
+
+    #[test]
+    fn strip_removes_tags_and_decodes_entities() {
+        assert_eq!(strip_html_for_measurement("a<b>b</b>c"), "abc");
+        assert_eq!(strip_html_for_measurement("x<br/>y"), "xy");
+        assert_eq!(strip_html_for_measurement("a&amp;b"), "a&b");
+        assert_eq!(strip_html_for_measurement("1<2"), "1<2"); // literal '<', not a tag
+        assert_eq!(strip_html_for_measurement("a\nb"), "ab"); // inline newline dropped
+    }
+
+    #[test]
+    fn plain_text_strips_markup_before_width_floor() {
+        // Markdown bold wraps the 4 ideographs — the floor must see the glyphs
+        // only, not the `**` markers (which would bill 2 × 0.56em extra and
+        // re-inflate the box past the painted width).
+        let bold = format!("**{ZHANG_HU_TONG_BU}**");
+        assert_eq!(edge_label_plain_text(&bold, true), ZHANG_HU_TONG_BU);
+        // A `<br/>` between glyphs is a tag, not 5 painted chars.
+        let br = "\u{8D26}\u{6237}<br/>\u{540C}\u{6B65}";
+        assert_eq!(edge_label_plain_text(br, false), ZHANG_HU_TONG_BU);
+        // `&amp;` decodes to a single `&`, so the entity isn't billed as 5 chars.
+        let ent = "\u{8D26}\u{6237}&amp;\u{540C}\u{6B65}";
+        assert_eq!(
+            edge_label_plain_text(ent, false),
+            "\u{8D26}\u{6237}&\u{540C}\u{6B65}"
+        );
     }
 }

--- a/crates/mermaid-little/src/layout/mod.rs
+++ b/crates/mermaid-little/src/layout/mod.rs
@@ -3,9 +3,11 @@
 //! [`DiagramLayout`] the renderer pattern-matches on.
 
 pub mod dagre_bridge;
+pub mod edge_label_decluster;
 pub mod gantt;
 pub mod gitgraph;
 pub mod intersect;
+pub mod label_metrics;
 pub mod packet;
 pub mod pie;
 pub mod radar;

--- a/crates/mermaid-little/src/lib.rs
+++ b/crates/mermaid-little/src/lib.rs
@@ -37,6 +37,7 @@ pub mod katex;
 pub mod layout;
 pub mod math;
 pub mod model;
+pub mod options;
 pub mod parser;
 pub mod preprocess;
 pub mod render;
@@ -47,6 +48,7 @@ pub mod theme;
 
 pub use engine::MermaidEngine;
 pub use error::MermaidError;
+pub use options::RenderOptions;
 pub use semantic::{parse_semantic, MermaidAst};
 
 /// Mirror `tests/support/generate_ref.mjs#renumberCounterIds` —
@@ -82,7 +84,26 @@ fn renumber_counter_ids(svg: &str, re: &regex::Regex, sep: &str) -> String {
 /// The `id` argument becomes the root `<svg id="..">` attribute and is
 /// scoped through CSS selectors. Use a stable value — e.g. the
 /// fixture path — for byte-exact reproducibility.
+///
+/// Equivalent to [`convert_with_options`] with [`RenderOptions::byte_exact`]
+/// (no readability tweaks; output stays byte-exact with upstream).
 pub fn convert_with_id(source: &str, id: &str) -> Result<String, MermaidError> {
+    convert_with_options(source, id, &RenderOptions::byte_exact())
+}
+
+/// Convert mermaid source text into SVG with non-byte-exact readability
+/// tweaks applied.
+///
+/// `opts` carries opt-in enhancements that deliberately diverge from upstream
+/// `mermaid@11.14.0` to improve readability. [`RenderOptions::byte_exact`]
+/// (also [`RenderOptions::default`]) reproduces upstream output exactly; see
+/// the fields on [`RenderOptions`] for what each flag does and why it is off
+/// by default.
+pub fn convert_with_options(
+    source: &str,
+    id: &str,
+    opts: &RenderOptions,
+) -> Result<String, MermaidError> {
     // Preprocess only to (a) pick the right diagram type — detection
     // runs on the frontmatter/directive-stripped head — and (b) read
     // the global `theme` name. Per-diagram parsers receive the RAW
@@ -91,7 +112,7 @@ pub fn convert_with_id(source: &str, id: &str) -> Result<String, MermaidError> {
     // `packet.showBits`, `themeVariables.pieOuterStrokeWidth`). Doing
     // it this way lets Wave 1 agents keep one API boundary —
     // `parse(&str)` — without a Config parameter.
-    let svg = make_foreign_objects_non_clipping(&convert_with_id_inner(source, id)?);
+    let svg = make_foreign_objects_non_clipping(&convert_with_id_inner(source, id, opts)?);
     // Apply the same per-SVG counter normalisation that
     // `generate_ref.mjs` runs over upstream's reference output. Only
     // `classId-\w+-N` is relevant today — class diagrams are the only
@@ -154,7 +175,11 @@ fn has_svg_attr(tag: &str, name: &str) -> bool {
     false
 }
 
-fn convert_with_id_inner(source: &str, id: &str) -> Result<String, MermaidError> {
+fn convert_with_id_inner(
+    source: &str,
+    id: &str,
+    opts: &RenderOptions,
+) -> Result<String, MermaidError> {
     let pre = preprocess::preprocess(source)?;
     let theme_name = pre.config.theme.as_deref().unwrap_or("default");
     let mut theme = theme::get_theme(theme_name);
@@ -334,8 +359,8 @@ fn convert_with_id_inner(source: &str, id: &str) -> Result<String, MermaidError>
         }
         detect::DiagramKind::Flowchart => {
             let d = parser::flowchart::parse(source)?;
-            let l = layout::flowchart::layout(&d, &theme)?;
-            render::svg_flowchart::render(&d, &l, &theme, id)
+            let l = layout::flowchart::layout(&d, &theme, opts.edge_label_decluster)?;
+            render::svg_flowchart::render_with_options(&d, &l, &theme, id, opts)
         }
         detect::DiagramKind::Venn => {
             let d = parser::venn::parse(source)?;

--- a/crates/mermaid-little/src/main.rs
+++ b/crates/mermaid-little/src/main.rs
@@ -8,6 +8,7 @@ fn main() -> ExitCode {
     let mut args = std::env::args().skip(1);
     let mut input_path: Option<PathBuf> = None;
     let mut output_path: Option<PathBuf> = None;
+    let mut edge_label_decluster = false;
 
     while let Some(arg) = args.next() {
         match arg.as_str() {
@@ -18,8 +19,13 @@ fn main() -> ExitCode {
                 };
                 output_path = Some(PathBuf::from(v));
             }
+            "--edge-label-decluster" => {
+                edge_label_decluster = true;
+            }
             "-h" | "--help" => {
-                println!("usage: mermaid-little [input.mmd] [-o output.svg]");
+                println!(
+                    "usage: mermaid-little [input.mmd] [-o output.svg] [--edge-label-decluster]"
+                );
                 return ExitCode::SUCCESS;
             }
             other if !other.starts_with('-') => {
@@ -50,11 +56,25 @@ fn main() -> ExitCode {
         }
     };
 
-    let svg = match mermaid_little::convert(&source) {
-        Ok(s) => s,
-        Err(e) => {
-            eprintln!("error: {e}");
-            return ExitCode::FAILURE;
+    let svg = if edge_label_decluster {
+        match mermaid_little::convert_with_options(
+            &source,
+            "mermaid-1",
+            &mermaid_little::RenderOptions::default().with_edge_label_decluster(true),
+        ) {
+            Ok(s) => s,
+            Err(e) => {
+                eprintln!("error: {e}");
+                return ExitCode::FAILURE;
+            }
+        }
+    } else {
+        match mermaid_little::convert(&source) {
+            Ok(s) => s,
+            Err(e) => {
+                eprintln!("error: {e}");
+                return ExitCode::FAILURE;
+            }
         }
     };
 

--- a/crates/mermaid-little/src/options.rs
+++ b/crates/mermaid-little/src/options.rs
@@ -1,0 +1,43 @@
+//! Opt-in render options.
+//!
+//! `RenderOptions::default()` is byte-exact with upstream `mermaid@11.14.0` —
+//! every field defaults to off/false. Fields that improve readability at the
+//! cost of byte-exactness are opt-in, so the default `convert` / `convert_with_id`
+//! path is unchanged.
+//!
+//! See `convert_with_options`.
+
+/// Non-byte-exact readability tweaks. All off by default.
+///
+/// `edge_label_decluster` — flowchart edge labels are normally placed at the
+/// dagre spline midpoint with no mutual avoidance, so labels on edges that
+/// share a midpoint region overlap (opposite-direction edges between the same
+/// node pair, dense fan-ins, etc.). This is upstream behaviour (confirmed via
+/// mermaid.live, issue #93), not a Supramark regression. When enabled:
+/// (1) the layout-time edge-label width is floored to its real rendered width
+/// for CJK labels (the byte-exact shim under-measures CJK), so dagre reserves
+/// enough inter-node space for the label to fit instead of overlapping an
+/// endpoint node, and the emitted `<foreignObject>` uses that same width so
+/// the visible text is centred between its endpoints rather than overflowing
+/// a too-narrow box;
+/// (2) a render-time pass nudges any still-overlapping label boxes apart.
+/// Both are off by default, so the default path stays byte-exact.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct RenderOptions {
+    pub edge_label_decluster: bool,
+}
+
+impl RenderOptions {
+    /// All options off — byte-exact with upstream.
+    pub const fn byte_exact() -> Self {
+        Self {
+            edge_label_decluster: false,
+        }
+    }
+
+    /// Builder: enable edge-label collision avoidance.
+    pub const fn with_edge_label_decluster(mut self, on: bool) -> Self {
+        self.edge_label_decluster = on;
+        self
+    }
+}

--- a/crates/mermaid-little/src/render/svg_flowchart.rs
+++ b/crates/mermaid-little/src/render/svg_flowchart.rs
@@ -14,10 +14,14 @@
 //!   follow-up iterations.
 
 use crate::error::Result;
+use crate::layout::edge_label_decluster::{
+    decluster, decluster_with_obstacles, DeclusterConfig, LabelRect,
+};
 use crate::layout::flowchart::FlowchartLayout;
 use crate::layout::unified::types::Point;
 use crate::layout::unified::{Cluster, Edge as UEdge, Node as UNode};
 use crate::model::flowchart::FlowchartDiagram;
+use crate::options::RenderOptions;
 use crate::render::edges;
 use crate::render::markers;
 use crate::render::shapes;
@@ -1009,6 +1013,7 @@ fn compute_viewbox_browser(
     l: &FlowchartLayout,
     padding: f64,
     title: Option<&str>,
+    adjustments: &EdgeLabelAdjustments,
 ) -> (f64, f64, f64, f64, f64) {
     use crate::render::foreign_object::{
         measure_html_markup_label, replace_fa_icons, HtmlLabelFont,
@@ -1158,9 +1163,9 @@ fn compute_viewbox_browser(
         let processed = replace_fa_icons(label_text);
         let (lw, lh) = measure_html_markup_label(&processed, &font, 200.0, true);
         let lw = lw + FLOWCHART_EDGE_LABEL_PADDING_X * 2.0;
-        let dagre_lx = e.label_x.unwrap_or(0.0);
-        let dagre_ly = e.label_y.unwrap_or(0.0);
-        let (lx, ly) = recompute_edge_label_position(e, l).unwrap_or((dagre_lx, dagre_ly));
+        let (lx, ly) = adjustments
+            .get(&e.id)
+            .unwrap_or_else(|| base_edge_label_pos(e, l));
         bounds.expand_box(lx - lw / 2.0, ly - lh / 2.0, lw, lh);
     }
 
@@ -1196,7 +1201,23 @@ pub fn render(
     theme: &ThemeVariables,
     id: &str,
 ) -> Result<String> {
+    render_with_options(d, l, theme, id, &RenderOptions::byte_exact())
+}
+
+/// Render with non-byte-exact readability tweaks applied (see [`RenderOptions`]).
+pub fn render_with_options(
+    d: &FlowchartDiagram,
+    l: &FlowchartLayout,
+    theme: &ThemeVariables,
+    id: &str,
+    opts: &RenderOptions,
+) -> Result<String> {
     let padding = l.diagram_padding;
+
+    // Opt-in edge-label collision avoidance (#93): precompute nudged centres
+    // before any label is emitted. Empty when the option is off, so the
+    // byte-exact path is unchanged.
+    let adjustments = build_edge_label_adjustments(l, opts);
 
     // Build cluster bounds map for cluster-endpoint edge clipping.
     // Keys are the original cluster IDs; values are the AABB bounds.
@@ -1341,7 +1362,13 @@ pub fn render(
         if is_cyclic_segment_from_anchor_rewrite(e) {
             continue;
         }
-        inner.push_str(&render_edge_label(e, html_labels, l));
+        inner.push_str(&render_edge_label(
+            e,
+            html_labels,
+            l,
+            &adjustments,
+            opts.edge_label_decluster,
+        ));
     }
     inner.push_str(unified_shell::close_layer());
 
@@ -1395,6 +1422,8 @@ pub fn render(
                     theme,
                     id,
                     html_labels,
+                    &adjustments,
+                    opts.edge_label_decluster,
                 ));
             }
         } else {
@@ -1497,7 +1526,7 @@ pub fn render(
     // bounds including shape geometry, edge curves, and label
     // positions. We compute from layout nodes and edges.
     let (vb_x, vb_y, vb_w, vb_h, content_center_x) =
-        compute_viewbox_browser(l, padding, d.meta.title.as_deref());
+        compute_viewbox_browser(l, padding, d.meta.title.as_deref(), &adjustments);
 
     // ── Assemble final SVG ─────────────────────────────────────────
     let acc_title = d.meta.acc_title.as_deref();
@@ -2274,6 +2303,7 @@ fn upstream_cluster_render_order(d: &FlowchartDiagram, l: &FlowchartLayout) -> V
 ///
 /// This function is recursive: isolated sub-clusters within `cnode` are
 /// themselves rendered as nested inner root groups.
+#[allow(clippy::too_many_arguments)]
 fn render_isolated_cluster_inner_root(
     cnode: &UNode,
     d: &FlowchartDiagram,
@@ -2281,6 +2311,8 @@ fn render_isolated_cluster_inner_root(
     theme: &ThemeVariables,
     svg_id: &str,
     html_labels: bool,
+    adjustments: &EdgeLabelAdjustments,
+    decluster: bool,
 ) -> String {
     // Retrieve pre-computed outer translate from the layout engine.
     let tx = cnode
@@ -2462,7 +2494,7 @@ fn render_isolated_cluster_inner_root(
         if is_cyclic_segment_from_anchor_rewrite(e) {
             continue;
         }
-        out.push_str(&render_edge_label(e, html_labels, l));
+        out.push_str(&render_edge_label(e, html_labels, l, adjustments, decluster));
     }
     out.push_str(unified_shell::close_layer());
 
@@ -2517,6 +2549,8 @@ fn render_isolated_cluster_inner_root(
             theme,
             svg_id,
             html_labels,
+            adjustments,
+            decluster,
         ));
     }
 
@@ -3489,7 +3523,13 @@ fn render_edge_path(
     )
 }
 
-fn render_edge_label(e: &UEdge, html_labels: bool, l: &FlowchartLayout) -> String {
+fn render_edge_label(
+    e: &UEdge,
+    html_labels: bool,
+    l: &FlowchartLayout,
+    adjustments: &EdgeLabelAdjustments,
+    decluster: bool,
+) -> String {
     use crate::render::foreign_object::{
         markdown_label_to_html, measure_html_markup_label, render_edge_label as fo_edge,
         replace_fa_icons, string_label_to_html, HtmlLabelFont, LabelOpts,
@@ -3541,8 +3581,21 @@ fn render_edge_label(e: &UEdge, html_labels: bool, l: &FlowchartLayout) -> Strin
         let (w, h) = measure_html_markup_label(&processed, &HtmlLabelFont::default(), 200.0, true);
         (w, h, None)
     };
-    let dagre_lx = e.label_x.unwrap_or(0.0);
-    let dagre_ly = e.label_y.unwrap_or(0.0);
+    // Opt-in decluster: dagre reserved rank space for the CJK-floored label
+    // width (stored on the edge at layout time, see `build_edge`). Emit the
+    // foreignObject at that same width so the real glyphs fit inside the box
+    // and the centring transform (`translate(-w/2, …)`) centres the visible
+    // text. The shim under-measures CJK, so without this the box is too narrow
+    // and the text overflows to one side, making the label look off-centre.
+    let w = if decluster {
+        e.extra
+            .get("label_width")
+            .and_then(|s| s.parse::<f64>().ok())
+            .filter(|&lw| lw > w)
+            .unwrap_or(w)
+    } else {
+        w
+    };
     // Mirror upstream `positionEdgeLabel` (edges.js:253). When `paths.updatedPath`
     // is set (i.e. the rendered SVG path differs from the dagre point sequence,
     // typically because the edge crosses a cluster boundary via
@@ -3552,7 +3605,12 @@ fn render_edge_label(e: &UEdge, html_labels: bool, l: &FlowchartLayout) -> Strin
     // edges (via `orig_start` / `orig_end` referencing an `is_group` node)
     // and recomputing the label position with `cutPathAtIntersect` +
     // `traverseEdge` ported from upstream `edges.js`.
-    let (lx, ly) = recompute_edge_label_position(e, l).unwrap_or((dagre_lx, dagre_ly));
+    //
+    // When the opt-in decluster pass moved this label, prefer the adjusted
+    // centre; otherwise use the byte-exact base position above.
+    let (lx, ly) = adjustments
+        .get(&e.id)
+        .unwrap_or_else(|| base_edge_label_pos(e, l));
     // htmlLabels=false path — emit `<text>`/`<tspan>` instead of <foreignObject>.
     // Mirrors upstream `createText(...)` non-html branch (createText.ts:338+,
     // createFormattedText) plus `insertEdgeLabel` which moves the
@@ -4505,17 +4563,23 @@ fn cut_path_at_intersect_xywh(
 /// Returns the half-total-distance midpoint of the polyline. Returns `None`
 /// when the path collapses to a single point or degenerate length.
 fn traverse_edge_midpoint(pts: &[(f64, f64)]) -> Option<(f64, f64)> {
+    point_along_arc(pts, 0.5)
+}
+
+/// Point at arc-length fraction `t` along the polyline (0 = start, 1 = end,
+/// 0.5 = midpoint). Used by the opt-in decluster pass to slide a label along
+/// its own edge to a position that does not sit on a node or a sibling label.
+fn point_along_arc(pts: &[(f64, f64)], t: f64) -> Option<(f64, f64)> {
     if pts.len() < 2 {
         return None;
     }
-    // Total length.
     let mut total = 0.0_f64;
     for w in pts.windows(2) {
         let dx = w[1].0 - w[0].0;
         let dy = w[1].1 - w[0].1;
         total += (dx * dx + dy * dy).sqrt();
     }
-    let mut remaining = total / 2.0;
+    let mut remaining = total * t.clamp(0.0, 1.0);
     let mut prev: Option<(f64, f64)> = None;
     for &(px, py) in pts {
         if let Some((ppx, ppy)) = prev {
@@ -4564,35 +4628,48 @@ fn traverse_edge_midpoint(pts: &[(f64, f64)]) -> Option<(f64, f64)> {
 /// This is the `isLabelCoordinateInPath` check (utils.ts:289). When the basis
 /// curve interpolation moves the visual midpoint away from the dagre control
 /// point, the label is recomputed via `calcLabelPosition` on the polyline.
-fn recompute_edge_label_position(e: &UEdge, l: &FlowchartLayout) -> Option<(f64, f64)> {
+/// The edge polyline after the same cluster-boundary clipping
+/// [`recompute_edge_label_position`] applies (`orig_start` / `orig_end`
+/// re-clip). Factored out so the opt-in decluster pass can sample positions
+/// along the *same* path the byte-exact label centre is computed on, instead
+/// of the raw dagre points (which may extend into a cluster frame). Returns
+/// `None` when the edge has no usable points.
+fn processed_edge_points(e: &UEdge, l: &FlowchartLayout) -> Option<Vec<(f64, f64)>> {
     let pts_ref = e.points.as_ref()?;
     if pts_ref.len() < 2 {
         return None;
     }
     let mut pts: Vec<(f64, f64)> = pts_ref.iter().map(|p| (p.x, p.y)).collect();
-    let orig_start = e.extra.get("orig_start").map(|s| s.as_str());
-    let orig_end = e.extra.get("orig_end").map(|s| s.as_str());
     let cluster_bbox = |id: &str| -> Option<(f64, f64, f64, f64)> {
         let n = l.nodes.iter().find(|n| n.id == id && n.is_group)?;
-        let x = n.x?;
-        let y = n.y?;
-        let w = n.width?;
-        let h = n.height?;
-        Some((x, y, w, h))
+        Some((n.x?, n.y?, n.width?, n.height?))
     };
-    let pts_before = pts.clone();
-    if let Some(end_id) = orig_end {
+    if let Some(end_id) = e.extra.get("orig_end").map(|s| s.as_str()) {
         if let Some((nx, ny, nw, nh)) = cluster_bbox(end_id) {
             pts = cut_path_at_intersect_xywh(&pts, nx, ny, nw, nh);
         }
     }
-    if let Some(start_id) = orig_start {
+    if let Some(start_id) = e.extra.get("orig_start").map(|s| s.as_str()) {
         if let Some((nx, ny, nw, nh)) = cluster_bbox(start_id) {
             pts.reverse();
             pts = cut_path_at_intersect_xywh(&pts, nx, ny, nw, nh);
             pts.reverse();
         }
     }
+    if pts.len() < 2 {
+        None
+    } else {
+        Some(pts)
+    }
+}
+
+fn recompute_edge_label_position(e: &UEdge, l: &FlowchartLayout) -> Option<(f64, f64)> {
+    let pts_ref = e.points.as_ref()?;
+    if pts_ref.len() < 2 {
+        return None;
+    }
+    let pts_before: Vec<(f64, f64)> = pts_ref.iter().map(|p| (p.x, p.y)).collect();
+    let pts = processed_edge_points(e, l)?;
     let path_actually_changed = pts.len() != pts_before.len()
         || pts
             .iter()
@@ -4612,15 +4689,255 @@ fn recompute_edge_label_position(e: &UEdge, l: &FlowchartLayout) -> Option<(f64,
             return None;
         }
     }
-    if pts.len() < 2 {
-        return None;
-    }
     let (x, y) = traverse_edge_midpoint(&pts)?;
     if e.extra.contains_key("scope_parent") {
         Some((x, y))
     } else {
         Some((round_to_5(x), round_to_5(y)))
     }
+}
+
+/// The byte-exact edge-label centre for `e` — the same expression the
+/// upstream-mirroring render path uses: `recompute_edge_label_position`
+/// when it overrides the dagre midpoint, else the raw dagre label anchor.
+/// Factored out so the opt-in decluster pass and the render path agree on
+/// the base position a label is nudged *from*.
+fn base_edge_label_pos(e: &UEdge, l: &FlowchartLayout) -> (f64, f64) {
+    let dagre_lx = e.label_x.unwrap_or(0.0);
+    let dagre_ly = e.label_y.unwrap_or(0.0);
+    recompute_edge_label_position(e, l).unwrap_or((dagre_lx, dagre_ly))
+}
+
+/// Edge-id → declustered label centre. Populated only when
+/// `RenderOptions::edge_label_decluster` is on; empty otherwise, so the
+/// byte-exact path is untouched (`get` returns `None` everywhere).
+#[derive(Default)]
+struct EdgeLabelAdjustments(std::collections::HashMap<String, (f64, f64)>);
+
+impl EdgeLabelAdjustments {
+    fn get(&self, id: &str) -> Option<(f64, f64)> {
+        self.0.get(id).copied()
+    }
+}
+
+/// Visual width floor for an edge-label collision box.
+///
+/// The byte-exact jsdom shim has no metrics for the browser's CJK fallback
+/// font, so it measures CJK glyphs far too narrow — e.g. "接收设备离线时暂存"
+/// measures ~54 px but paints ~152 px. A label whose real width exceeds its
+/// measured width collides on screen while the decluster reads it as clear, so
+/// pairs that obviously stack never get pushed apart. Floor the width at a
+/// per-glyph estimate (CJK ≈ 1em, others ≈ 0.56em) so the box tracks what the
+/// browser paints. Height the shim gets right (line-height 1.5 × font-size).
+/// Precompute declustered edge-label centres for the opt-in readability pass.
+///
+/// Mirrors the canonical visible-label selection (skips replaced self-loops,
+/// cyclic anchor-rewrite segments, and empty labels) and the same
+/// `(lx, ly, lw, lh)` the viewBox bounds loop uses, then runs the decluster
+/// algorithm. Returns an empty map when the option is off.
+fn build_edge_label_adjustments(l: &FlowchartLayout, opts: &RenderOptions) -> EdgeLabelAdjustments {
+    use crate::render::foreign_object::{
+        measure_html_markup_label, replace_fa_icons, HtmlLabelFont,
+    };
+    if !opts.edge_label_decluster {
+        return EdgeLabelAdjustments::default();
+    }
+    let font = HtmlLabelFont::default();
+    // Collide against the label's *visual* box, not the shim's measured box:
+    // the shim under-measures CJK width (see `cjk_aware_label_width`), so a
+    // width floor keeps the box honest about what the browser paints. Height
+    // the shim measures correctly. Only the centre propagates; the emitted
+    // label keeps its real measured size.
+    const COLLISION_MARGIN: f64 = 4.0;
+    // Solid leaf nodes are static obstacles. Cluster (is_group) frames are
+    // background outlines only, so they are excluded. Computed once and reused
+    // both as the obstacle list for the AABB fallback and as the node-hit term
+    // in the along-edge t selection.
+    let obstacles: Vec<LabelRect> = l
+        .nodes
+        .iter()
+        .filter(|n| !n.is_group)
+        .filter_map(|n| {
+            let (Some(x), Some(y), Some(w), Some(h)) = (n.x, n.y, n.width, n.height) else {
+                return None;
+            };
+            if w <= 0.0 || h <= 0.0 {
+                return None;
+            }
+            Some((x, y, w + COLLISION_MARGIN * 2.0, h + COLLISION_MARGIN * 2.0))
+        })
+        .collect();
+    // Each entry carries its own (cluster-clipped) edge polyline so the label
+    // can be slid along it. Edges with no usable points fall through to the
+    // byte-exact base position and are not recorded here.
+    type EdgeLabelEntry = (String, Vec<(f64, f64)>, f64, f64);
+    let mut entries: Vec<EdgeLabelEntry> = Vec::new();
+    for e in &l.edges {
+        if is_replaced_self_loop(e) || is_cyclic_segment_from_anchor_rewrite(e) {
+            continue;
+        }
+        let label_text = e.label.as_deref().unwrap_or("");
+        if label_text.is_empty() {
+            continue;
+        }
+        let processed = replace_fa_icons(label_text);
+        let (lw_m, lh) = measure_html_markup_label(&processed, &font, 200.0, true);
+        let lw = crate::layout::label_metrics::cjk_aware_label_width(&processed, lw_m)
+            + FLOWCHART_EDGE_LABEL_PADDING_X * 2.0
+            + COLLISION_MARGIN * 2.0;
+        let lh = lh + COLLISION_MARGIN * 2.0;
+        if let Some(pts) = processed_edge_points(e, l) {
+            entries.push((e.id.clone(), pts, lw, lh));
+        }
+    }
+    let n = entries.len();
+    if n == 0 {
+        return EdgeLabelAdjustments::default();
+    }
+    // centres[i] = (cx, cy, w, h), initialised at the arc-length midpoint (t=0.5).
+    let mut centres: Vec<LabelRect> = entries
+        .iter()
+        .map(|(_, pts, w, h)| {
+            let (cx, cy) = point_along_arc(pts, 0.5).unwrap_or((0.0, 0.0));
+            (cx, cy, *w, *h)
+        })
+        .collect();
+    let midpoint = centres.clone();
+    // Along-edge t selection. For each label, try a spread of arc-length
+    // fractions (closest to the midpoint first) and move to the one with the
+    // lowest conflict score — a node hit costs more than a label hit. This is
+    // coordinate descent in t-space: labels stay on their own edges (so the
+    // result reads as "label belongs to this edge") while dodging nodes and
+    // siblings. Candidates are bounded away from the endpoints so a label
+    // never slides all the way onto a terminal node.
+    const T_CANDIDATES: [f64; 9] = [0.50, 0.40, 0.60, 0.35, 0.65, 0.30, 0.70, 0.25, 0.75];
+    for _ in 0..24 {
+        let mut moved = false;
+        for i in 0..n {
+            let (cx, cy, _, _) = centres[i];
+            let mut best_score = label_conflict_score(i, cx, cy, &centres, &obstacles);
+            let mut best_pos = (cx, cy);
+            for &t in T_CANDIDATES.iter() {
+                let Some((tx, ty)) = point_along_arc(&entries[i].1, t) else {
+                    continue;
+                };
+                let s = label_conflict_score(i, tx, ty, &centres, &obstacles);
+                // Strict `<`: on ties keep the earlier candidate, which is the
+                // one closer to the midpoint (T_CANDIDATES is ordered so).
+                if s < best_score {
+                    best_score = s;
+                    best_pos = (tx, ty);
+                }
+            }
+            if (best_pos.0 - cx).abs() > 1e-9 || (best_pos.1 - cy).abs() > 1e-9 {
+                centres[i].0 = best_pos.0;
+                centres[i].1 = best_pos.1;
+                moved = true;
+            }
+        }
+        if !moved {
+            break;
+        }
+    }
+    // AABB fallback: separate overlapping siblings and push labels off nodes.
+    // Base is the post-slide position so the nudge stays small and the label
+    // remains near its edge. The obstacle push is what clears small node
+    // overlaps the t selection cannot avoid by sliding alone (e.g. an edge that
+    // crosses a node region): a short perpendicular nudge off the node.
+    //
+    // Guard: snapshot each label's node overlap at its best along-edge
+    // position, then revert any label the fallback left with MORE node overlap.
+    // This stops a label that is wider than the gap between two collinear nodes
+    // (a long CJK label on a short horizontal edge between two same-row nodes)
+    // from oscillating between them under the obstacle push and landing worse
+    // than the t selection's position. Small clears (overlap shrank) are kept.
+    let t_positions = centres.clone();
+    let t_node: Vec<f64> = (0..n)
+        .map(|i| node_overlap_area(i, &centres, &obstacles))
+        .collect();
+    let base = centres.clone();
+    let cfg = DeclusterConfig {
+        gap: 4.0,
+        max_displacement: 30.0,
+        max_iters: 24,
+    };
+    decluster_with_obstacles(&mut centres, &base, &obstacles, &cfg);
+    let mut reverted = false;
+    for i in 0..n {
+        if node_overlap_area(i, &centres, &obstacles) > t_node[i] + 1e-9 {
+            centres[i] = t_positions[i];
+            reverted = true;
+        }
+    }
+    // A revert can re-introduce a sibling overlap; re-separate labels only
+    // (no obstacle push, which would re-trigger the oscillation above).
+    if reverted {
+        let base2 = centres.clone();
+        decluster(&mut centres, &base2, &cfg);
+    }
+    // Record only labels whose final centre left the arc-length midpoint, so
+    // unchanged labels fall through to the byte-exact base position.
+    let mut map = std::collections::HashMap::with_capacity(n);
+    for i in 0..n {
+        let (bx, by, _, _) = midpoint[i];
+        let (mx, my, _, _) = centres[i];
+        if (mx - bx).abs() > 1e-9 || (my - by).abs() > 1e-9 {
+            map.insert(entries[i].0.clone(), (round_to_5(mx), round_to_5(my)));
+        }
+    }
+    EdgeLabelAdjustments(map)
+}
+
+/// Conflict score for label `i` if its centre were `(cx, cy)`: node hits
+/// weighted 10×, label hits 1×. Lower is better. Used by the along-edge t
+/// selection to pick the position with the least collision cost.
+fn label_conflict_score(
+    i: usize,
+    cx: f64,
+    cy: f64,
+    centres: &[LabelRect],
+    obstacles: &[LabelRect],
+) -> f64 {
+    let (_, _, w, h) = centres[i];
+    let mut node_hits = 0;
+    for &(ox, oy, ow, oh) in obstacles {
+        let pen_x = (w / 2.0 + ow / 2.0) - (cx - ox).abs();
+        let pen_y = (h / 2.0 + oh / 2.0) - (cy - oy).abs();
+        if pen_x > 0.0 && pen_y > 0.0 {
+            node_hits += 1;
+        }
+    }
+    let mut label_hits = 0;
+    for (j, &(bx, by, bw, bh)) in centres.iter().enumerate() {
+        if j == i {
+            continue;
+        }
+        let pen_x = (w / 2.0 + bw / 2.0) - (cx - bx).abs();
+        let pen_y = (h / 2.0 + bh / 2.0) - (cy - by).abs();
+        if pen_x > 0.0 && pen_y > 0.0 {
+            label_hits += 1;
+        }
+    }
+    node_hits as f64 * 10.0 + label_hits as f64
+}
+
+/// Total overlap area between label `i` (at its current centre in `centres`)
+/// and all node obstacles. Used to guard the AABB fallback so it never leaves a
+/// label with more node overlap than the along-edge t selection found: a label
+/// wider than the gap between two collinear nodes gets pushed off one node
+/// straight onto the other, and without this guard the pass would end with a
+/// larger node overlap than where the t selection left it.
+fn node_overlap_area(i: usize, centres: &[LabelRect], obstacles: &[LabelRect]) -> f64 {
+    let (cx, cy, w, h) = centres[i];
+    let mut area = 0.0;
+    for &(ox, oy, ow, oh) in obstacles {
+        let pen_x = (w / 2.0 + ow / 2.0) - (cx - ox).abs();
+        let pen_y = (h / 2.0 + oh / 2.0) - (cy - oy).abs();
+        if pen_x > 0.0 && pen_y > 0.0 {
+            area += pen_x * pen_y;
+        }
+    }
+    area
 }
 
 /// Build the rendered `d=` attribute approximation for the upstream
@@ -4698,7 +5015,7 @@ mod tests {
         let src = "flowchart TD\nA --> B\n";
         let d = fcp::parse(src).unwrap();
         let th = theme::get_theme("default");
-        let l = fcl::layout(&d, &th).unwrap();
+        let l = fcl::layout(&d, &th, false).unwrap();
         let svg = render(&d, &l, &th, "test").unwrap();
         assert!(svg.starts_with("<svg "));
         assert!(svg.contains(r#"aria-roledescription="flowchart-v2""#));
@@ -4713,7 +5030,7 @@ mod tests {
         let src = "graph LR\nA-->B\n";
         let d = fcp::parse(src).unwrap();
         let th = theme::get_theme("default");
-        let l = fcl::layout(&d, &th).unwrap();
+        let l = fcl::layout(&d, &th, false).unwrap();
         let svg = render(&d, &l, &th, "t").unwrap();
         assert!(svg.contains(r#"aria-roledescription="flowchart-v2""#));
     }
@@ -4723,7 +5040,7 @@ mod tests {
         let src = "flowchart TD\nsubgraph s1 [Title]\nA-->B\nend\n";
         let d = fcp::parse(src).unwrap();
         let th = theme::get_theme("default");
-        let l = fcl::layout(&d, &th).unwrap();
+        let l = fcl::layout(&d, &th, false).unwrap();
         let svg = render(&d, &l, &th, "t").unwrap();
         assert!(svg.contains(r#"class="clusters""#));
         assert!(svg.contains(r#"class="cluster"#));
@@ -4840,7 +5157,7 @@ mod tests {
     fn render_fixture(source: &str, id: &str) -> String {
         let d = fcp::parse(source).expect("parse");
         let theme = theme::get_theme("default");
-        let l = fcl::layout(&d, &theme).expect("layout");
+        let l = fcl::layout(&d, &theme, false).expect("layout");
         super::render(&d, &l, &theme, id).expect("render")
     }
 

--- a/crates/mermaid-little/src/render/svg_flowchart.rs
+++ b/crates/mermaid-little/src/render/svg_flowchart.rs
@@ -4893,7 +4893,13 @@ fn build_edge_label_adjustments(l: &FlowchartLayout, opts: &RenderOptions) -> Ed
         }
         let processed = replace_fa_icons(label_text);
         let (lw_m, lh) = measure_html_markup_label(&processed, &font, 200.0, true);
-        let lw = crate::layout::label_metrics::cjk_aware_label_width(&processed, lw_m)
+        // Floor the width over the marker-free plain text (tags / entities
+        // stripped), not the raw markup — otherwise `<br/>`, `**` and `&amp;`
+        // are billed ~0.56em each and the collision box widens past the real
+        // painted width, re-creating the off-centre overlap from issue #93.
+        let is_markdown = e.label_type.as_deref() == Some("markdown");
+        let plain = crate::layout::label_metrics::edge_label_plain_text(&processed, is_markdown);
+        let lw = crate::layout::label_metrics::cjk_aware_label_width(&plain, lw_m)
             + FLOWCHART_EDGE_LABEL_PADDING_X * 2.0
             + COLLISION_MARGIN * 2.0;
         let lh = lh + COLLISION_MARGIN * 2.0;

--- a/crates/mermaid-little/src/render/svg_flowchart.rs
+++ b/crates/mermaid-little/src/render/svg_flowchart.rs
@@ -2158,6 +2158,106 @@ fn edge_is_inside_isolated(src: Option<&str>, dst: Option<&str>, l: &FlowchartLa
     }
 }
 
+/// The `translate(tx, ty)` an isolated cluster's inner root group carries.
+///
+/// Single source of truth: `render_isolated_cluster_inner_root` emits exactly
+/// this, and the edge-label decluster pass uses it to lift cluster-local
+/// coordinates into screen space. If the two ever disagreed, the pass would
+/// resolve collisions that do not exist on screen.
+fn isolated_cluster_translate(cnode: &UNode) -> (f64, f64) {
+    // Prefer the pre-computed outer translate from the layout engine.
+    let tx = cnode
+        .extra
+        .get("outer_tx")
+        .and_then(|s| s.parse::<f64>().ok())
+        .unwrap_or_else(|| {
+            // Fallback: classic formula using inner dagre coords.
+            let cx = cnode.x.unwrap_or(0.0);
+            let w = cnode.width.unwrap_or(0.0);
+            let padding = cnode.padding.unwrap_or(8.0);
+            cx - padding - w / 2.0
+        });
+    let ty = cnode
+        .extra
+        .get("outer_ty")
+        .and_then(|s| s.parse::<f64>().ok())
+        .unwrap_or_else(|| {
+            let cy = cnode.y.unwrap_or(0.0);
+            let h = cnode.height.unwrap_or(0.0);
+            let padding = cnode.padding.unwrap_or(8.0);
+            cy - h / 2.0 - padding
+        });
+    (tx, ty)
+}
+
+/// Isolated-cluster ancestors of `node_id`, outermost first.
+///
+/// Each one emits a nested `<g transform="translate(...)">`, so the screen
+/// position of anything drawn inside is its local position plus the sum of the
+/// chain's translates.
+fn isolated_ancestor_chain(node_id: &str, l: &FlowchartLayout) -> Vec<String> {
+    let mut chain: Vec<String> = Vec::new();
+    let mut current = node_id;
+    // Bounded by the node count so a malformed parent cycle cannot hang render.
+    for _ in 0..l.nodes.len() {
+        let Some(n) = l.nodes.iter().find(|n| n.id == current) else {
+            break;
+        };
+        let Some(parent) = n.parent_id.as_deref() else {
+            break;
+        };
+        if l.isolated_cluster_ids.contains(parent) {
+            chain.push(parent.to_string());
+        }
+        current = parent;
+    }
+    chain.reverse();
+    chain
+}
+
+/// Sum of the translates of a chain of isolated clusters.
+fn chain_translate(chain: &[String], l: &FlowchartLayout) -> (f64, f64) {
+    chain.iter().fold((0.0, 0.0), |(tx, ty), id| {
+        match l.nodes.iter().find(|n| &n.id == id) {
+            Some(cnode) => {
+                let (dx, dy) = isolated_cluster_translate(cnode);
+                (tx + dx, ty + dy)
+            }
+            None => (tx, ty),
+        }
+    })
+}
+
+/// Screen-space offset of a node: it is drawn inside its innermost isolated
+/// cluster's inner root, so every isolated ancestor's translate applies.
+fn node_frame_offset(node_id: &str, l: &FlowchartLayout) -> (f64, f64) {
+    chain_translate(&isolated_ancestor_chain(node_id, l), l)
+}
+
+/// Screen-space offset of an edge label.
+///
+/// An edge renders in the deepest isolated cluster containing *both* endpoints,
+/// i.e. the longest common prefix of the endpoints' ancestor chains. That
+/// matches both render sites: [`edge_is_inside_isolated`] sends an edge whose
+/// endpoints have different outermost isolated ancestors to the outer level
+/// (empty prefix), and `render_isolated_cluster_inner_root` skips an edge whose
+/// endpoint sits in a sub-isolated cluster so the recursion emits it deeper
+/// (longer prefix).
+fn edge_frame_offset(e: &UEdge, l: &FlowchartLayout) -> (f64, f64) {
+    let (Some(s), Some(d)) = (e.start.as_deref(), e.end.as_deref()) else {
+        return (0.0, 0.0);
+    };
+    let cs = isolated_ancestor_chain(s, l);
+    let cd = isolated_ancestor_chain(d, l);
+    let common: Vec<String> = cs
+        .iter()
+        .zip(cd.iter())
+        .take_while(|(a, b)| a == b)
+        .map(|(a, _)| a.clone())
+        .collect();
+    chain_translate(&common, l)
+}
+
 /// Return true if `node_id` is a descendant of `cluster_id` (transitively).
 fn is_descendant_of(node_id: &str, cluster_id: &str, l: &FlowchartLayout) -> bool {
     let mut current = node_id;
@@ -2314,28 +2414,7 @@ fn render_isolated_cluster_inner_root(
     adjustments: &EdgeLabelAdjustments,
     decluster: bool,
 ) -> String {
-    // Retrieve pre-computed outer translate from the layout engine.
-    let tx = cnode
-        .extra
-        .get("outer_tx")
-        .and_then(|s| s.parse::<f64>().ok())
-        .unwrap_or_else(|| {
-            // Fallback: classic formula using inner dagre coords.
-            let cx = cnode.x.unwrap_or(0.0);
-            let w = cnode.width.unwrap_or(0.0);
-            let padding = cnode.padding.unwrap_or(8.0);
-            cx - padding - w / 2.0
-        });
-    let ty = cnode
-        .extra
-        .get("outer_ty")
-        .and_then(|s| s.parse::<f64>().ok())
-        .unwrap_or_else(|| {
-            let cy = cnode.y.unwrap_or(0.0);
-            let h = cnode.height.unwrap_or(0.0);
-            let padding = cnode.padding.unwrap_or(8.0);
-            cy - h / 2.0 - padding
-        });
+    let (tx, ty) = isolated_cluster_translate(cnode);
 
     let mut out = String::new();
     out.push_str(&format!(
@@ -2494,7 +2573,13 @@ fn render_isolated_cluster_inner_root(
         if is_cyclic_segment_from_anchor_rewrite(e) {
             continue;
         }
-        out.push_str(&render_edge_label(e, html_labels, l, adjustments, decluster));
+        out.push_str(&render_edge_label(
+            e,
+            html_labels,
+            l,
+            adjustments,
+            decluster,
+        ));
     }
     out.push_str(unified_shell::close_layer());
 
@@ -4764,13 +4849,39 @@ fn build_edge_label_adjustments(l: &FlowchartLayout, opts: &RenderOptions) -> Ed
             if w <= 0.0 || h <= 0.0 {
                 return None;
             }
-            Some((x, y, w + COLLISION_MARGIN * 2.0, h + COLLISION_MARGIN * 2.0))
+            // A node inside an isolated cluster carries cluster-local coords.
+            // Lift it into screen space so it can be compared against labels
+            // that live in a different frame.
+            let (ox, oy) = node_frame_offset(&n.id, l);
+            Some((
+                x + ox,
+                y + oy,
+                w + COLLISION_MARGIN * 2.0,
+                h + COLLISION_MARGIN * 2.0,
+            ))
         })
         .collect();
     // Each entry carries its own (cluster-clipped) edge polyline so the label
     // can be slid along it. Edges with no usable points fall through to the
     // byte-exact base position and are not recorded here.
-    type EdgeLabelEntry = (String, Vec<(f64, f64)>, f64, f64);
+    //
+    // Everything below runs in SCREEN space. Labels inside an isolated cluster
+    // are emitted under `<g class="root" transform="translate(...)">`, so their
+    // raw coords are cluster-local; comparing those directly against another
+    // frame's coords invents collisions between labels that are far apart on
+    // screen (and pushes them apart for no reason). Each entry is translated in
+    // on the way here and translated back out when the adjustment is recorded.
+    struct EdgeLabelEntry {
+        id: String,
+        /// The edge's polyline, already in screen space.
+        points: Vec<(f64, f64)>,
+        w: f64,
+        h: f64,
+        /// Translate that was added to `points`; subtracted again before the
+        /// adjustment is stored, so the map stays in the frame the label is
+        /// actually emitted in (the same frame `base_edge_label_pos` uses).
+        offset: (f64, f64),
+    }
     let mut entries: Vec<EdgeLabelEntry> = Vec::new();
     for e in &l.edges {
         if is_replaced_self_loop(e) || is_cyclic_segment_from_anchor_rewrite(e) {
@@ -4787,7 +4898,18 @@ fn build_edge_label_adjustments(l: &FlowchartLayout, opts: &RenderOptions) -> Ed
             + COLLISION_MARGIN * 2.0;
         let lh = lh + COLLISION_MARGIN * 2.0;
         if let Some(pts) = processed_edge_points(e, l) {
-            entries.push((e.id.clone(), pts, lw, lh));
+            let offset = edge_frame_offset(e, l);
+            let points: Vec<(f64, f64)> = pts
+                .into_iter()
+                .map(|(x, y)| (x + offset.0, y + offset.1))
+                .collect();
+            entries.push(EdgeLabelEntry {
+                id: e.id.clone(),
+                points,
+                w: lw,
+                h: lh,
+                offset,
+            });
         }
     }
     let n = entries.len();
@@ -4797,9 +4919,9 @@ fn build_edge_label_adjustments(l: &FlowchartLayout, opts: &RenderOptions) -> Ed
     // centres[i] = (cx, cy, w, h), initialised at the arc-length midpoint (t=0.5).
     let mut centres: Vec<LabelRect> = entries
         .iter()
-        .map(|(_, pts, w, h)| {
-            let (cx, cy) = point_along_arc(pts, 0.5).unwrap_or((0.0, 0.0));
-            (cx, cy, *w, *h)
+        .map(|en| {
+            let (cx, cy) = point_along_arc(&en.points, 0.5).unwrap_or((0.0, 0.0));
+            (cx, cy, en.w, en.h)
         })
         .collect();
     let midpoint = centres.clone();
@@ -4818,7 +4940,7 @@ fn build_edge_label_adjustments(l: &FlowchartLayout, opts: &RenderOptions) -> Ed
             let mut best_score = label_conflict_score(i, cx, cy, &centres, &obstacles);
             let mut best_pos = (cx, cy);
             for &t in T_CANDIDATES.iter() {
-                let Some((tx, ty)) = point_along_arc(&entries[i].1, t) else {
+                let Some((tx, ty)) = point_along_arc(&entries[i].points, t) else {
                     continue;
                 };
                 let s = label_conflict_score(i, tx, ty, &centres, &obstacles);
@@ -4882,7 +5004,12 @@ fn build_edge_label_adjustments(l: &FlowchartLayout, opts: &RenderOptions) -> Ed
         let (bx, by, _, _) = midpoint[i];
         let (mx, my, _, _) = centres[i];
         if (mx - bx).abs() > 1e-9 || (my - by).abs() > 1e-9 {
-            map.insert(entries[i].0.clone(), (round_to_5(mx), round_to_5(my)));
+            // Back out of screen space into the frame this label is emitted in.
+            let (ox, oy) = entries[i].offset;
+            map.insert(
+                entries[i].id.clone(),
+                (round_to_5(mx - ox), round_to_5(my - oy)),
+            );
         }
     }
     EdgeLabelAdjustments(map)

--- a/crates/mermaid-little/tests/edge_label_decluster.rs
+++ b/crates/mermaid-little/tests/edge_label_decluster.rs
@@ -1,0 +1,187 @@
+//! Integration test for the opt-in edge-label collision-avoidance pass (#93).
+//!
+//! Dagre places every flowchart edge label at its spline midpoint with no
+//! mutual avoidance, so labels on edges that share a midpoint region overlap
+//! (here: opposite-direction edges `A1 <-> COMMIT` plus a dense fan-in around
+//! the `Devices` boundary). That overlap is upstream Mermaid behaviour
+//! (confirmed via mermaid.live), so the default render stays byte-exact and
+//! the decluster is opt-in via `RenderOptions::edge_label_decluster`.
+
+#![cfg(feature = "metrics-ttf-parser")]
+
+use mermaid_little::{convert_with_id, convert_with_options, RenderOptions};
+use regex::Regex;
+use std::sync::OnceLock;
+
+/// The exact source from issue #93 — a `flowchart LR` whose edge labels stack.
+const REPRO: &str = r#"flowchart LR
+    subgraph Devices["用户设备"]
+        A1["Alice / Laptop"]
+        A2["Alice / Phone"]
+        B1["Bob / Laptop"]
+        B2["Bob / Phone"]
+    end
+
+    DIR["Directory + Domain Authority"]
+    COMMIT["Conversation Committer"]
+    RELAY["Encrypted Relay"]
+    GW["Mail Gateway"]
+    MTA["Existing MTA"]
+    SMTP["SMTP Network"]
+
+    A1 <-->|"已提交密文直连"| B1
+    A2 <-->|"账户同步"| A1
+    B2 <-->|"账户同步"| B1
+    A1 -->|"签名提案 + HLC"| COMMIT
+    COMMIT -->|"会话内序号 + 提交证明"| A1
+    A1 -->|"接收设备离线时暂存"| RELAY
+    RELAY -->|"拉取/唤醒"| B1
+    Devices <-->|"签名目录与策略"| DIR
+    Devices <-->|"外部邮件明文边界"| GW
+    GW <--> MTA
+    MTA <--> SMTP
+"#;
+
+#[derive(Clone, Copy)]
+struct Rect {
+    cx: f64,
+    cy: f64,
+    w: f64,
+    h: f64,
+}
+
+/// Parse every `<g class="edgeLabel" transform="translate(cx,cy)">` and its
+/// inner `foreignObject width height` out of the rendered SVG.
+fn edge_label_rects(svg: &str) -> Vec<Rect> {
+    static BLOCK_RE: OnceLock<Regex> = OnceLock::new();
+    static SIZE_RE: OnceLock<Regex> = OnceLock::new();
+    let block = BLOCK_RE.get_or_init(|| {
+        Regex::new(
+            r#"<g class="edgeLabel" transform="translate\(([-0-9.]+),\s*([-0-9.]+)\)">(?s:.*?)</g>\s*</g>"#,
+        )
+        .expect("block regex")
+    });
+    let size = SIZE_RE.get_or_init(|| {
+        Regex::new(r#"width="([0-9.]+)"[^>]*height="([0-9.]+)""#).expect("size regex")
+    });
+
+    let mut rects = Vec::new();
+    for cap in block.captures_iter(svg) {
+        let (Ok(cx), Ok(cy)) = (cap[1].parse::<f64>(), cap[2].parse::<f64>()) else {
+            continue;
+        };
+        let Some(idx) = cap[0].find("foreignObject") else {
+            continue;
+        };
+        let Some(sm) = size.captures(&cap[0][idx..]) else {
+            continue;
+        };
+        let (Ok(w), Ok(h)) = (sm[1].parse::<f64>(), sm[2].parse::<f64>()) else {
+            continue;
+        };
+        if w > 0.0 && h > 0.0 {
+            rects.push(Rect { cx, cy, w, h });
+        }
+    }
+    rects
+}
+
+fn viewbox(svg: &str) -> (f64, f64, f64, f64) {
+    let v = svg
+        .split("viewBox=\"")
+        .nth(1)
+        .and_then(|s| s.split('"').next())
+        .unwrap_or("0 0 0 0");
+    let nums: Vec<f64> = v
+        .split_whitespace()
+        .filter_map(|t| t.parse().ok())
+        .collect();
+    match nums.as_slice() {
+        [x, y, w, h] => (*x, *y, *w, *h),
+        _ => (0.0, 0.0, 0.0, 0.0),
+    }
+}
+
+/// Count overlapping label pairs (centre-based AABBs).
+fn overlap_pairs(rects: &[Rect]) -> Vec<(usize, usize)> {
+    let mut out = Vec::new();
+    for i in 0..rects.len() {
+        for j in (i + 1)..rects.len() {
+            let a = rects[i];
+            let b = rects[j];
+            let ox = (a.w / 2.0 + b.w / 2.0) - (a.cx - b.cx).abs();
+            let oy = (a.h / 2.0 + b.h / 2.0) - (a.cy - b.cy).abs();
+            if ox > 0.0 && oy > 0.0 {
+                out.push((i, j));
+            }
+        }
+    }
+    out
+}
+
+#[test]
+fn decluster_removes_edge_label_overlaps() {
+    let baseline = convert_with_id(REPRO, "mermaid-1").expect("baseline render");
+    let declustered = convert_with_options(
+        REPRO,
+        "mermaid-1",
+        &RenderOptions::default().with_edge_label_decluster(true),
+    )
+    .expect("declustered render");
+
+    let base_rects = edge_label_rects(&baseline);
+    let decl_rects = edge_label_rects(&declustered);
+
+    assert!(
+        !base_rects.is_empty(),
+        "expected edge labels in the rendered SVG"
+    );
+
+    // The issue's repro stacks labels at shared midpoints, so the byte-exact
+    // baseline has at least one overlapping pair.
+    let base_overlaps = overlap_pairs(&base_rects);
+    assert!(
+        !base_overlaps.is_empty(),
+        "baseline should have overlapping edge labels (else the repro no longer reproduces #93)"
+    );
+
+    // The opt-in pass must remove every overlap.
+    let decl_overlaps = overlap_pairs(&decl_rects);
+    assert!(
+        decl_overlaps.is_empty(),
+        "declustered output still has {} overlapping pair(s)",
+        decl_overlaps.len()
+    );
+
+    // Same number of labels rendered (the pass moves them, never drops them).
+    assert_eq!(base_rects.len(), decl_rects.len());
+
+    // Every label must stay inside the viewBox.
+    let (vbx, vby, vbw, vbh) = viewbox(&declustered);
+    for Rect { cx, cy, w, h } in &decl_rects {
+        let left = cx - w / 2.0;
+        let right = cx + w / 2.0;
+        let top = cy - h / 2.0;
+        let bottom = cy + h / 2.0;
+        assert!(
+            left >= vbx - 0.5
+                && top >= vby - 0.5
+                && right <= vbx + vbw + 0.5
+                && bottom <= vby + vbh + 0.5,
+            "label centre ({cx},{cy}) size ({w}x{h}) falls outside viewBox {vbx} {vby} {vbw} {vbh}"
+        );
+    }
+}
+
+#[test]
+fn byte_exact_default_is_unchanged_by_options() {
+    // `convert_with_id` and `convert_with_options(byte_exact)` must produce
+    // identical output — the option must not perturb the default path.
+    let a = convert_with_id(REPRO, "mermaid-1").expect("render a");
+    let b =
+        convert_with_options(REPRO, "mermaid-1", &RenderOptions::byte_exact()).expect("render b");
+    assert_eq!(
+        a, b,
+        "byte_exact options must match the default convert path"
+    );
+}

--- a/crates/mermaid-little/tests/edge_label_decluster.rs
+++ b/crates/mermaid-little/tests/edge_label_decluster.rs
@@ -250,3 +250,33 @@ fn decluster_floors_cjk_label_width() {
         "decluster should widen the CJK label: base={base_w} decl={decl_w}"
     );
 }
+
+#[test]
+fn decluster_floor_ignores_markup_in_cjk_label() {
+    // A CJK label with a `<br/>` tag: the width floor must run over the painted
+    // glyphs (\u{540c}\u{6b65}\u{6570}\u{636e} = 同步数据, 4 wide → 4*EM = 64),
+    // not the raw markup (同步<br/>数据, 9 chars → ~108.8). Round-2 review
+    // measured the raw-markup floor at ~108.8 vs ~64 correct; the over-wide box
+    // re-created the off-centre overlap this PR fixes. Marks the render-stage
+    // fix for review item "floor runs over raw markup".
+    let src =
+        "flowchart LR\n    A[\"A\"] -->|\"\u{540C}\u{6B65}<br/>\u{6570}\u{636E}\"| B[\"B\"]\n";
+    let svg = convert_with_options(
+        src,
+        "mermaid-1",
+        &RenderOptions::default().with_edge_label_decluster(true),
+    )
+    .expect("render");
+
+    let w = label_width_for(&svg, "\u{540C}\u{6B65}") // 同步
+        .or_else(|| label_width_for(&svg, "\u{6570}\u{636E}")) // 数据
+        .expect("edge label rendered");
+    assert!(
+        w >= 64.0,
+        "CJK width floor lost: {w} (expected >= 4*EM = 64)"
+    );
+    assert!(
+        w < 80.0,
+        "markup chars leaked into the width floor: {w} (expected ~64, raw-markup floor was ~108)"
+    );
+}

--- a/crates/mermaid-little/tests/edge_label_decluster.rs
+++ b/crates/mermaid-little/tests/edge_label_decluster.rs
@@ -230,10 +230,10 @@ fn decluster_floors_cjk_label_width() {
     )
     .expect("declustered render");
 
-    let base_w = label_width_for(&baseline, "账户同步")
-        .expect("baseline renders the 账户同步 label");
-    let decl_w = label_width_for(&declustered, "账户同步")
-        .expect("declustered renders the 账户同步 label");
+    let base_w =
+        label_width_for(&baseline, "账户同步").expect("baseline renders the 账户同步 label");
+    let decl_w =
+        label_width_for(&declustered, "账户同步").expect("declustered renders the 账户同步 label");
 
     // Default path keeps the shim width (well under the real ~64px CJK render).
     assert!(

--- a/crates/mermaid-little/tests/edge_label_decluster.rs
+++ b/crates/mermaid-little/tests/edge_label_decluster.rs
@@ -86,6 +86,35 @@ fn edge_label_rects(svg: &str) -> Vec<Rect> {
     rects
 }
 
+/// foreignObject width of the first edge-label block whose visible text
+/// contains `needle`. Used to check the opt-in CJK width floor.
+fn label_width_for(svg: &str, needle: &str) -> Option<f64> {
+    static BLOCK_RE: OnceLock<Regex> = OnceLock::new();
+    static SIZE_RE: OnceLock<Regex> = OnceLock::new();
+    let block = BLOCK_RE.get_or_init(|| {
+        Regex::new(r#"(?s)<g class="edgeLabel".*?</g>\s*</g>"#).expect("block regex")
+    });
+    let size = SIZE_RE.get_or_init(|| {
+        Regex::new(r#"width="([0-9.]+)"[^>]*height="([0-9.]+)""#).expect("size regex")
+    });
+    for cap in block.captures_iter(svg) {
+        let blob = &cap[0];
+        if !blob.contains(needle) {
+            continue;
+        }
+        let Some(idx) = blob.find("foreignObject") else {
+            continue;
+        };
+        let Some(sm) = size.captures(&blob[idx..]) else {
+            continue;
+        };
+        if let Ok(w) = sm[1].parse::<f64>() {
+            return Some(w);
+        }
+    }
+    None
+}
+
 fn viewbox(svg: &str) -> (f64, f64, f64, f64) {
     let v = svg
         .split("viewBox=\"")
@@ -183,5 +212,41 @@ fn byte_exact_default_is_unchanged_by_options() {
     assert_eq!(
         a, b,
         "byte_exact options must match the default convert path"
+    );
+}
+
+#[test]
+fn decluster_floors_cjk_label_width() {
+    // The shim under-measures CJK ("账户同步" ~28px); opt-in must emit the
+    // foreignObject at the CJK-aware width (~4 × EM = 64) so the real glyphs
+    // fit and centre instead of overflowing a too-narrow box. This locks the
+    // render-stage width floor that fixes the "label looks off-centre / pushed
+    // toward one endpoint" symptom from issue #93.
+    let baseline = convert_with_id(REPRO, "mermaid-1").expect("baseline render");
+    let declustered = convert_with_options(
+        REPRO,
+        "mermaid-1",
+        &RenderOptions::default().with_edge_label_decluster(true),
+    )
+    .expect("declustered render");
+
+    let base_w = label_width_for(&baseline, "账户同步")
+        .expect("baseline renders the 账户同步 label");
+    let decl_w = label_width_for(&declustered, "账户同步")
+        .expect("declustered renders the 账户同步 label");
+
+    // Default path keeps the shim width (well under the real ~64px CJK render).
+    assert!(
+        base_w < 40.0,
+        "baseline 账户同步 width should be the shim (~28), got {base_w}"
+    );
+    // Opt-in floors the width to ≥ 4 × EM = 64.
+    assert!(
+        decl_w >= 64.0,
+        "declustered 账户同步 width should be floored to ≥ 4*EM (64), got {decl_w}"
+    );
+    assert!(
+        decl_w > base_w,
+        "decluster should widen the CJK label: base={base_w} decl={decl_w}"
     );
 }

--- a/crates/mermaid-little/tests/edge_label_frames.rs
+++ b/crates/mermaid-little/tests/edge_label_frames.rs
@@ -1,0 +1,141 @@
+//! The edge-label decluster pass must compare labels in SCREEN space.
+//!
+//! Labels inside an isolated cluster are emitted under
+//! `<g class="root" transform="translate(tx, ty)">`, so their raw coordinates
+//! are cluster-local. Comparing those directly against a label from another
+//! frame invents collisions between labels that are far apart on screen, and
+//! the pass then slides both of them for no reason.
+//!
+//! The fixture below is tuned so the *flat* coordinates collide while the
+//! *screen* coordinates do not:
+//!
+//! | label   | frame        | local coords     | screen coords    |
+//! |---------|--------------|------------------|------------------|
+//! | `gamma` | root         | (377.50, 87.45)  | (377.50,  87.45) |
+//! | `beta`  | S2 (nested)  | (401.77, 66.15)  | (439.27, 310.04) |
+//!
+//! Flat: dx 24.3, dy 21.3 -> the boxes overlap, so a frame-blind pass pushes
+//! them apart. Screen: dy 222.6 -> no overlap exists and nothing should move.
+
+#![cfg(feature = "metrics-ttf-parser")]
+
+use mermaid_little::{convert_with_id, convert_with_options, RenderOptions};
+use regex::Regex;
+use std::sync::OnceLock;
+
+/// Two labelled edges inside a doubly-nested subgraph, plus one labelled edge
+/// at the outer level whose local coordinates land near the cluster's.
+const NESTED_FRAMES: &str = r#"flowchart TD
+    C["C"] -->|"gamma"| D["D"]
+    subgraph S1["Outer"]
+      subgraph S2["Inner"]
+        A["A"] -->|"alpha"| B["B"]
+        B -->|"beta"| E["E"]
+      end
+    end
+    D --> S1
+"#;
+
+fn edge_label_positions(svg: &str) -> Vec<(String, String)> {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    let re = RE.get_or_init(|| {
+        Regex::new(r#"<g class="edgeLabel" transform="translate\(([-0-9.]+),\s*([-0-9.]+)\)">"#)
+            .expect("valid regex")
+    });
+    re.captures_iter(svg)
+        .map(|c| (c[1].to_string(), c[2].to_string()))
+        .collect()
+}
+
+fn isolated_root_translates(svg: &str) -> Vec<(f64, f64)> {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    let re = RE.get_or_init(|| {
+        Regex::new(r#"<g class="root" transform="translate\(([-0-9.]+),\s*([-0-9.]+)\)">"#)
+            .expect("valid regex")
+    });
+    re.captures_iter(svg)
+        .map(|c| (c[1].parse().unwrap_or(0.0), c[2].parse().unwrap_or(0.0)))
+        .collect()
+}
+
+/// Guard the fixture itself: if a layout change stops producing nested
+/// isolated clusters, the regression below would pass vacuously.
+#[test]
+fn fixture_still_produces_nested_isolated_clusters() {
+    let svg = convert_with_id(NESTED_FRAMES, "frames").expect("render");
+    let translates = isolated_root_translates(&svg);
+    assert!(
+        translates.len() >= 2,
+        "expected at least two nested isolated cluster roots, got {translates:?}"
+    );
+    let cumulative_y: f64 = translates.iter().map(|(_, ty)| ty).sum();
+    assert!(
+        cumulative_y > 100.0,
+        "cluster translate must be large enough that flat and screen space \
+         disagree; got cumulative ty {cumulative_y}"
+    );
+}
+
+/// No label in this diagram overlaps any other *on screen*, so enabling the
+/// decluster must be a no-op. Before the frame fix, `gamma` (root frame) and
+/// `beta` (cluster frame) were judged overlapping on their raw coordinates and
+/// both were nudged: `gamma` 87.45 -> 96.45 and `beta` 66.15 -> 60.45.
+#[test]
+fn cross_frame_labels_are_not_declustered_against_each_other() {
+    let base = convert_with_id(NESTED_FRAMES, "frames").expect("render base");
+    let declustered = convert_with_options(
+        NESTED_FRAMES,
+        "frames",
+        &RenderOptions::default().with_edge_label_decluster(true),
+    )
+    .expect("render declustered");
+
+    assert_eq!(
+        edge_label_positions(&base),
+        edge_label_positions(&declustered),
+        "labels in different render frames do not overlap on screen, so the \
+         decluster pass must leave every one of them at its base position"
+    );
+}
+
+/// Stronger form of the above: the whole document is untouched, which also
+/// catches the viewBox being recomputed around phantom-displaced labels.
+#[test]
+fn decluster_is_a_no_op_when_nothing_overlaps_on_screen() {
+    let base = convert_with_id(NESTED_FRAMES, "frames").expect("render base");
+    let declustered = convert_with_options(
+        NESTED_FRAMES,
+        "frames",
+        &RenderOptions::default().with_edge_label_decluster(true),
+    )
+    .expect("render declustered");
+    assert_eq!(base, declustered);
+}
+
+/// Same-frame overlaps must still be resolved: the fix moves the comparison
+/// into screen space, it does not disable the pass. Both labels here live in
+/// the same cluster frame and genuinely stack, so they must separate.
+#[test]
+fn same_frame_overlaps_are_still_declustered() {
+    const STACKED: &str = r#"flowchart LR
+    subgraph S1["Outer"]
+      subgraph S2["Inner"]
+        A["A"] -->|"alpha"| B["B"]
+        A -->|"beta"| B
+      end
+    end
+    C["C"] -->|"gamma"| D["D"]
+"#;
+    let base = convert_with_id(STACKED, "stacked").expect("render base");
+    let declustered = convert_with_options(
+        STACKED,
+        "stacked",
+        &RenderOptions::default().with_edge_label_decluster(true),
+    )
+    .expect("render declustered");
+    assert_ne!(
+        edge_label_positions(&base),
+        edge_label_positions(&declustered),
+        "two labels stacked inside the same cluster frame must still be pushed apart"
+    );
+}

--- a/crates/mermaid-little/tests/flowchart_inline.rs
+++ b/crates/mermaid-little/tests/flowchart_inline.rs
@@ -213,8 +213,9 @@ fn flowchart_parser_roundtrips_all_fixtures() {
             };
             let th = theme::get_theme("default");
             let rel_for_panic = rel.clone();
-            let l_result =
-                std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| fcl::layout(&d, &th, false)));
+            let l_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                fcl::layout(&d, &th, false)
+            }));
             let l = match l_result {
                 Ok(Ok(l)) => l,
                 Ok(Err(e)) => {

--- a/crates/mermaid-little/tests/flowchart_inline.rs
+++ b/crates/mermaid-little/tests/flowchart_inline.rs
@@ -130,7 +130,7 @@ fn render_one(rel: &str) -> Result<String, String> {
     if let Some(tv) = pre.config.theme_variables.as_ref() {
         theme::apply_theme_variables(&mut th, tv);
     }
-    let l = fcl::layout(&d, &th).map_err(|e| format!("layout: {e}"))?;
+    let l = fcl::layout(&d, &th, false).map_err(|e| format!("layout: {e}"))?;
     svg_flowchart::render(&d, &l, &th, &id).map_err(|e| format!("render: {e}"))
 }
 
@@ -214,7 +214,7 @@ fn flowchart_parser_roundtrips_all_fixtures() {
             let th = theme::get_theme("default");
             let rel_for_panic = rel.clone();
             let l_result =
-                std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| fcl::layout(&d, &th)));
+                std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| fcl::layout(&d, &th, false)));
             let l = match l_result {
                 Ok(Ok(l)) => l,
                 Ok(Err(e)) => {
@@ -352,7 +352,7 @@ fn flowchart_single_diff_report() {
     if let Some(tv) = pre.config.theme_variables.as_ref() {
         theme::apply_theme_variables(&mut th, tv);
     }
-    let l = fcl::layout(&d, &th).unwrap();
+    let l = fcl::layout(&d, &th, false).unwrap();
     eprintln!("diagram_padding={}", l.diagram_padding);
     eprintln!("isolated_cluster_ids: {:?}", l.isolated_cluster_ids);
     for n in &l.nodes {
@@ -433,7 +433,7 @@ fn dump_fixture_168() {
         theme::apply_theme_variables(&mut th, tv);
     }
     let d = fcp::parse(source).unwrap();
-    let l = fcl::layout(&d, &th).unwrap();
+    let l = fcl::layout(&d, &th, false).unwrap();
 
     for e in &l.edges {
         if e.id.contains("Sub_In") {
@@ -484,7 +484,7 @@ fn dump_fixture_155_parallel_edge_assignment() {
         theme::apply_theme_variables(&mut th, tv);
     }
     let d = fcp::parse(source).unwrap();
-    let l = fcl::layout(&d, &th).unwrap();
+    let l = fcl::layout(&d, &th, false).unwrap();
 
     for e in &l.edges {
         if e.id == "L_sub1_sub4_0" || e.id == "L_S1_S2_0" {
@@ -551,7 +551,7 @@ fn dump_fixture_168_clusters() {
         theme::apply_theme_variables(&mut th, tv);
     }
     let d = fcp::parse(source).unwrap();
-    let l = fcl::layout(&d, &th).unwrap();
+    let l = fcl::layout(&d, &th, false).unwrap();
 
     for c in &l.clusters {
         eprintln!("Cluster {}: {:?}", c.id, c.bounds);

--- a/crates/supramark-diagram-core/src/lib.rs
+++ b/crates/supramark-diagram-core/src/lib.rs
@@ -31,6 +31,24 @@ impl RenderOutput {
     }
 }
 
+/// Engine-agnostic render hints.
+///
+/// `Default` is the byte-exact / canonical render — every flag is off, so
+/// [`DiagramEngine::render`] and [`DiagramEngine::render_with_options`] produce
+/// identical output when no flag is set. Each field is a non-canonical
+/// readability tweak that an engine may ignore (engines without an
+/// implementation keep the default render).
+///
+/// `edge_label_decluster` — flowchart edge labels normally sit at the dagre
+/// spline midpoint with no mutual avoidance, so labels that share a midpoint
+/// region overlap. This is upstream Mermaid behaviour (issue #93), not a
+/// regression, so it is off by default. Engines that support it (mermaid) nudge
+/// overlapping label boxes apart when set.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct EngineRenderOptions {
+    pub edge_label_decluster: bool,
+}
+
 /// Public unified semantic AST envelope: across the boundary (serialized to
 /// TS / AST v2) it is always `{ engine, kind, data }` (design §0, decision 1).
 /// Each engine uses a strongly typed semantic struct internally and converges
@@ -99,6 +117,20 @@ pub trait DiagramEngine: Send + Sync {
     /// always required).
     fn render(&self, source: &str) -> Result<RenderOutput, DiagramError>;
 
+    /// source -> render output with non-canonical hints applied.
+    ///
+    /// The default implementation ignores `opts` and delegates to [`render`](Self::render),
+    /// so engines that don't support any option render identically either way.
+    /// Engines override this to honour the flags they implement.
+    fn render_with_options(
+        &self,
+        source: &str,
+        opts: &EngineRenderOptions,
+    ) -> Result<RenderOutput, DiagramError> {
+        let _ = opts;
+        self.render(source)
+    }
+
     /// source -> public semantic AST envelope.
     ///
     /// - `Ok(None)`: this engine / diagram kind does not currently support
@@ -152,6 +184,18 @@ impl DiagramRegistry {
         source: &str,
     ) -> Option<Result<RenderOutput, DiagramError>> {
         self.get(engine_id).map(|e| e.render(source))
+    }
+
+    /// Convenience: render with non-canonical hints; returns `None` if the
+    /// engine is not registered.
+    pub fn render_with_options(
+        &self,
+        engine_id: &str,
+        source: &str,
+        opts: &EngineRenderOptions,
+    ) -> Option<Result<RenderOutput, DiagramError>> {
+        self.get(engine_id)
+            .map(|e| e.render_with_options(source, opts))
     }
 
     /// Convenience: get semantics directly; returns `None` if the engine is not registered.

--- a/crates/supramark-diagram/src/lib.rs
+++ b/crates/supramark-diagram/src/lib.rs
@@ -11,7 +11,7 @@ mod chart;
 
 // Re-export core's trait and types so downstream depends on this crate alone.
 pub use supramark_diagram_core::{
-    DiagramEngine, DiagramError, DiagramRegistry, EngineAst, RenderOutput,
+    DiagramEngine, DiagramError, DiagramRegistry, EngineAst, EngineRenderOptions, RenderOutput,
 };
 
 use std::sync::Arc;


### PR DESCRIPTION
## Summary

Refs #93 (supersedes the closed #94).

> **Note:** the `edge_label_decluster` flag is wired through the Rust crate and CLI only — it is not yet exposed to Supramark hosts via the `packages/web` / RN bindings (see review: wiring stops at the Rust crate boundary). The issue should stay open until that binding lands; this PR is `Refs #93`, not `Closes #93`.

Flowchart edge labels overlapped endpoint nodes and each other in dense `LR` layouts. **Root cause**: dagre reserves rank space for edge labels using the width the renderer measures, but the byte-exact jsdom shim under-measures CJK glyphs (~40% of real width) — e.g. "账户同步" measured ~28px vs ~64px real. So dagre under-reserved and the label box overflowed its endpoint nodes; the emitted `<foreignObject>` was also too narrow, so the visible text overflowed to one side and looked off-centre.

Adds an **opt-in** `edge_label_decluster` render option (off by default → default path stays byte-exact with `mermaid@11.14.0`). When enabled:
- **Layout**: the edge-label width is floored to a CJK-aware estimate (one EM per wide glyph via the Unicode East Asian Width property), so dagre reserves enough inter-node space for the label to fit between its endpoints. The floor runs over the **marker-free plain text** (tags/entities stripped), so `<br/>` / `**` / `&amp;` are not billed.
- **Render**: the emitted `<foreignObject>` uses that same width so the visible text is centred between its endpoints instead of overflowing a too-narrow box.
- **Post-process**: a render-time pass nudges apart any labels that still collide, resolving collisions in screen space (per-frame, so isolated-cluster labels with cluster-local coordinates are not mistakenly moved).

Supersedes #94 (pure post-process), which could not fix label/node overlaps where the label is wider than the gap.

## Verification

Chrome headless 1:1 measurement on the issue #93 repro:
- Default (flag off): `LvL=1 LvN=4` — unchanged, matches upstream `mermaid@11.14.0`.
- Decluster (flag on): `LvL=0 LvN=0`; "账户同步" glyph-ink centre offset from the Phone↔Laptop midpoint went **+20.6px (right-shifted) → -1.2px (centred)**.
- CJK label with a `<br/>` tag floors to ~4×EM (64), not the raw-markup ~108 — the over-wide box no longer re-creates the off-centre overlap.

## Test plan

- [x] `cargo test -p mermaid-little` — 1030+ pass / 0 fail (lib + examples + integration)
- [x] `cargo test --test edge_label_decluster` — opt-in AABB non-overlap, byte-exact default, CJK width floor, **markup-floor regression** (`<br/>` CJK label does not over-reserve)
- [x] `cargo test --test edge_label_frames` — isolated-cluster coordinate-frame correctness
- [x] `cargo test --test flowchart_inline` — default byte-exact snapshots unchanged
- [x] `cargo clippy --all-targets` — zero warnings on changed files
- [x] `cargo fmt --check` — clean
- [ ] CI green

## Known follow-ups (not blocking, per review)

- `is_cjk` → `is_wide_glyph` now uses `unicode_width` (covers Hangul, CJK Ext B+, Bopomofo; excludes halfwidth forms).
- `decluster_with_obstacles` is best-effort (does not guarantee zero overlap when `max_displacement` binds); the integration assertion holds for this fixture but the pass is documented as best-effort.
- The flag is not yet exposed through `packages/web` / RN — tracked as the reason this is `Refs #93` rather than `Closes #93`.
- CI has no `cargo test -p mermaid-little` job (d2-little / plantuml-little do) — worth a separate PR.