### PR TITLE
test(parser): fix two public_api assertions failing on main since #121

### DIFF
--- a/crates/supramark-markdown/tests/public_api.rs
+++ b/crates/supramark-markdown/tests/public_api.rs
@@ -310,7 +310,12 @@ fn public_api_preserves_raw_html_blocks() {
     };
 
     assert_eq!(format, "html");
-    assert_eq!(value, "<div>Hello</div>");
+    // An HTML block owns its line terminator. CommonMark 0.31.2 defines the
+    // expected output for `<div>Hello</div>\n` as the source lines verbatim,
+    // newline included, which is what `html_block.rs` now emits (700cc57e) and
+    // what the 652/652 conformance run depends on. This assertion encoded the
+    // pre-#121 behaviour and was not updated with it.
+    assert_eq!(value, "<div>Hello</div>\n");
     assert!(*block);
 }
 
@@ -331,7 +336,8 @@ fn public_api_preserves_multiline_raw_html_blocks() {
     };
 
     assert_eq!(format, "html");
-    assert_eq!(value, "<div>\n  <p>x</p>\n</div>");
+    // Trailing newline retained, same rule as the single-line case above.
+    assert_eq!(value, "<div>\n  <p>x</p>\n</div>\n");
     assert!(*block);
 }
 


### PR DESCRIPTION
## What broke

`cargo test -p supramark-markdown --test public_api` fails on `main` as of `18f636e1` (the #121 merge):

```
---- public_api_preserves_raw_html_blocks stdout ----
assertion `left == right` failed
  left: "<div>Hello</div>\n"
 right: "<div>Hello</div>"

---- public_api_preserves_multiline_raw_html_blocks stdout ----
  left: "<div>\n  <p>x</p>\n</div>\n"
 right: "<div>\n  <p>x</p>\n</div>"

test result: FAILED. 24 passed; 2 failed
```

This is the only red on `main`; the `commonmark-conformance` workflow run for `18f636e1` fails on exactly these two.

## Which side is right

The parser. #121's `700cc57e` changed `html_block.rs` to emit `value: self.content.clone()` with the line terminator retained. CommonMark 0.31.2 defines an HTML block's expected output as its source lines verbatim, newline included — that change is part of what took the suite to 652/652, and reverting it would take conformance back down. The two assertions encoded the pre-#121 behaviour and simply were not updated alongside it, so this PR updates them.

## Why the PR's own checks did not catch it

Two gaps stacked:

- the required status checks (`Lint`, `Test & Build (20.x)`, `Test & Build (22.x)`) do not run this crate's Rust integration tests;
- the `commonmark-conformance` workflow, which does run them, triggers on **push to main** only. It has no `pull_request` trigger — `commonmark-conformance.yml:122` even contains a `github.event_name != 'pull_request'` guard written in anticipation of one. Adding that trigger is already an ask in #106.

Same shape as #123 for `mermaid-little`: a crate whose Rust tests no required check runs.

## Verification

`cargo test -p supramark-markdown` — 59 lib + 26 integration, 0 failures.

I merged #121, so this one is on me. Flagging it rather than quietly folding the fix into something else.
