### PR TITLE
fix(mermaid): wire edge_label_decluster to web; relax decluster test

### DIFF
--- a/crates/mermaid-little/packages/web/src/index.ts
+++ b/crates/mermaid-little/packages/web/src/index.ts
@@ -14,7 +14,12 @@
  * ```
  */
 
-// Re-export the raw wasm-bindgen API. `convert`, `convert_with_id`, and
-// `version` are the public functions; everything else (`__wbg_set_wasm`
-// etc.) stays internal to the generated JS.
-export { convert, convert_with_id as convertWithId, version } from './wasm/mermaid_little_web.js';
+// Re-export the raw wasm-bindgen API. `convert`, `convert_with_id`,
+// `convert_with_options`, and `version` are the public functions; everything
+// else (`__wbg_set_wasm` etc.) stays internal to the generated JS.
+export {
+  convert,
+  convert_with_id as convertWithId,
+  convert_with_options as convertWithOptions,
+  version,
+} from './wasm/mermaid_little_web.js';

--- a/crates/mermaid-little/packages/web/src/lib.rs
+++ b/crates/mermaid-little/packages/web/src/lib.rs
@@ -31,6 +31,24 @@ pub fn convert_with_id(mmd: &str, id: &str) -> Result<String, JsValue> {
     mermaid_little::convert_with_id(mmd, id).map_err(|e| JsValue::from_str(&e.to_string()))
 }
 
+/// Convert with an explicit diagram id and non-byte-exact readability
+/// tweaks, mirroring [`mermaid_little::convert_with_options`].
+///
+/// `edge_label_decluster` toggles the opt-in edge-label collision-avoidance
+/// pass (#93). With it off, the output matches [`convert_with_id`] for the
+/// same `id` — pass `"mermaid-1"` to match the default [`convert`] path.
+#[wasm_bindgen]
+pub fn convert_with_options(
+    mmd: &str,
+    id: &str,
+    edge_label_decluster: bool,
+) -> Result<String, JsValue> {
+    let opts =
+        mermaid_little::RenderOptions::default().with_edge_label_decluster(edge_label_decluster);
+    mermaid_little::convert_with_options(mmd, id, &opts)
+        .map_err(|e| JsValue::from_str(&e.to_string()))
+}
+
 /// Version of the compiled `mermaid-little-web` wasm.
 #[wasm_bindgen]
 pub fn version() -> String {

--- a/crates/mermaid-little/packages/web/src/wasm/mermaid_little_web.d.ts
+++ b/crates/mermaid-little/packages/web/src/wasm/mermaid_little_web.d.ts
@@ -8,4 +8,9 @@
 // actual wasm-pack output.
 export function convert(mmd: string): string;
 export function convert_with_id(mmd: string, id: string): string;
+export function convert_with_options(
+  mmd: string,
+  id: string,
+  edge_label_decluster: boolean
+): string;
 export function version(): string;

--- a/crates/mermaid-little/src/layout/edge_label_decluster.rs
+++ b/crates/mermaid-little/src/layout/edge_label_decluster.rs
@@ -15,6 +15,14 @@
 //! by label-displacers in graph layout. Each label may only move a bounded
 //! distance from its base position so it stays tethered to its edge.
 //!
+//! **Best-effort, not a guarantee.** The pass *reduces* overlap but does not
+//! promise zero overlaps: when `max_displacement` binds, labels that cannot
+//! be pushed far enough apart remain stacked. The property the pass actually
+//! provides is "overlap count strictly decreases"; "zero overlaps" is a
+//! fixture-specific fact that holds for some layouts (e.g. the #93 repro)
+//! and not others. Tests assert the general property, and only assert zero
+//! for a fixture known to fully resolve.
+//!
 //! The function is pure arithmetic over centre-based rects `(cx, cy, w, h)`
 //! so it is trivially testable without laying out a real diagram.
 

--- a/crates/mermaid-little/tests/edge_label_decluster.rs
+++ b/crates/mermaid-little/tests/edge_label_decluster.rs
@@ -6,6 +6,12 @@
 //! the `Devices` boundary). That overlap is upstream Mermaid behaviour
 //! (confirmed via mermaid.live), so the default render stays byte-exact and
 //! the decluster is opt-in via `RenderOptions::edge_label_decluster`.
+//!
+//! The pass is **best-effort**: it reduces overlap but does not guarantee
+//! zero overlaps when `max_displacement` binds (see the module header on
+//! `edge_label_decluster`). Tests here assert the general property (overlap
+//! count strictly decreases) plus a fixture-specific zero-overlap check for
+//! the #93 repro, which is known to fully resolve.
 
 #![cfg(feature = "metrics-ttf-parser")]
 
@@ -174,11 +180,27 @@ fn decluster_removes_edge_label_overlaps() {
         "baseline should have overlapping edge labels (else the repro no longer reproduces #93)"
     );
 
-    // The opt-in pass must remove every overlap.
+    // The pass is best-effort: it reduces overlap but does not guarantee
+    // zero overlaps when `max_displacement` binds (see the module header on
+    // `edge_label_decluster`). The general property it does provide is that
+    // the overlap count strictly decreases — assert that here, since it is
+    // robust to layout drift.
     let decl_overlaps = overlap_pairs(&decl_rects);
     assert!(
+        decl_overlaps.len() < base_overlaps.len(),
+        "decluster must reduce overlap count: baseline={}, declustered={}",
+        base_overlaps.len(),
+        decl_overlaps.len()
+    );
+
+    // For this fixture (#93 repro) the pass fully resolves every overlap.
+    // This is a fixture-specific fact, not a general guarantee — if the
+    // layout ever shifts such that zero no longer holds, update this
+    // assertion rather than reading it as an algorithm contract.
+    assert!(
         decl_overlaps.is_empty(),
-        "declustered output still has {} overlapping pair(s)",
+        "declustered output still has {} overlapping pair(s) — the #93 \
+         fixture is expected to fully resolve, but the pass is best-effort",
         decl_overlaps.len()
     );
 

--- a/packages/core/src/ast.ts
+++ b/packages/core/src/ast.ts
@@ -173,6 +173,13 @@ export interface SupramarkDiagramEngineConfig {
   /** 可选：特定引擎的服务端地址（例如 PlantUML server） */
   server?: string;
 
+  /**
+   * 可选：开启 mermaid 边标签去聚簇（#93）。仅 mermaid 引擎消费；
+   * off 时与上游 `mermaid@11.14.0` 字节精确一致，on 时推开重叠的边标签框
+   * 并为 CJK 标签预留真实渲染宽度。其它引擎忽略此字段。
+   */
+  edgeLabelDecluster?: boolean;
+
   /** 缓存配置（仅作为上层参考，具体实现由运行时决定） */
   cache?: {
     enabled?: boolean;

--- a/packages/engines/__tests__/mermaid-label-centering.test.ts
+++ b/packages/engines/__tests__/mermaid-label-centering.test.ts
@@ -48,9 +48,17 @@ mock.module('../src/host-bridge.js', () => ({
   installHostMetricsBridge: () => {},
 }));
 
+// Both entries are tracked so the wiring tests below can assert which wasm
+// entry the engines layer routed through. The same rich RAW_SVG satisfies
+// the #40 content assertions (the post-processing is independent of which
+// entry produced the SVG).
+const convertFn = mock(() => RAW_SVG);
+const convertWithOptionsFn = mock((_mmd: string, _id: string, _flag: boolean) => RAW_SVG);
+
 mock.module('@actrium/mermaid-little-web', () => ({
   __esModule: true,
-  convert: () => RAW_SVG,
+  convert: convertFn,
+  convert_with_options: convertWithOptionsFn,
 }));
 
 const { renderMermaidSvg } = await import('../src/mermaid/index.ts');
@@ -68,9 +76,7 @@ describe('mermaid label centering (#40)', () => {
 
     // The background rect must straddle x=0 (x = -width/2) so it shares
     // the text's centre line. width=88 → x=-44.
-    const rectX = out.match(
-      /<rect class="background"[^>]* x="([^"]+)"/
-    )?.[1];
+    const rectX = out.match(/<rect class="background"[^>]* x="([^"]+)"/)?.[1];
     expect(rectX).toBe('-44');
   });
 
@@ -89,5 +95,33 @@ describe('mermaid label centering (#40)', () => {
     expect(out).toContain('<foreignObject overflow="visible"');
     // <p> default margin collapses (would otherwise re-introduce an offset).
     expect(out).toContain('margin:0');
+  });
+});
+
+describe('mermaid edge-label decluster wiring (#126 item 3)', () => {
+  it('routes through convert_with_options when edgeLabelDecluster is set', async () => {
+    const code = 'flowchart LR\n  A -->|label| B';
+    await renderMermaidSvg(code, { edgeLabelDecluster: true });
+
+    expect(convertWithOptionsFn.mock.calls.at(-1)).toEqual([code, 'mermaid-1', true]);
+  });
+
+  it('does not call the byte-exact convert when decluster is on', async () => {
+    const before = convertFn.mock.calls.length;
+    await renderMermaidSvg('flowchart LR\n  A --> B', { edgeLabelDecluster: true });
+    expect(convertFn.mock.calls.length).toBe(before);
+  });
+
+  it('keeps the default path on convert(code) without the option', async () => {
+    const code = 'flowchart LR\n  A --> B';
+    await renderMermaidSvg(code);
+
+    expect(convertFn.mock.calls.at(-1)).toEqual([code]);
+  });
+
+  it('does not call convert_with_options on the default path', async () => {
+    const before = convertWithOptionsFn.mock.calls.length;
+    await renderMermaidSvg('flowchart LR\n  A --> B');
+    expect(convertWithOptionsFn.mock.calls.length).toBe(before);
   });
 });

--- a/packages/engines/src/mermaid/index.ts
+++ b/packages/engines/src/mermaid/index.ts
@@ -10,6 +10,7 @@ interface MermaidWasmModule {
   default?: unknown;
   init?: unknown;
   convert?: unknown;
+  convert_with_options?: unknown;
   render?: unknown;
 }
 
@@ -426,9 +427,31 @@ async function ensureLoaded(): Promise<
     );
   }
 
-  renderFn = (code: string) => {
-    // Underlying wasm `convert(code)` is synchronous; await tolerates
+  const convertWithOptions =
+    typeof mod.convert_with_options === 'function'
+      ? (mod.convert_with_options as (
+          mmd: string,
+          id: string,
+          edgeLabelDecluster: boolean
+        ) => string)
+      : null;
+
+  renderFn = (code: string, options?: Record<string, unknown>) => {
+    // Underlying wasm convert entries are synchronous; await tolerates
     // both sync and async returns.
+    if (options?.edgeLabelDecluster === true) {
+      if (convertWithOptions) {
+        // `convert_with_options(code, "mermaid-1", true)` matches the id the
+        // default `convert(code)` path uses, with the decluster pass enabled.
+        return convertWithOptions(code, 'mermaid-1', true);
+      }
+      // Older wasm bundle without the options entry — fall back to the
+      // byte-exact convert and warn so the missing wiring is visible.
+      console.warn(
+        '[supramark] @actrium/mermaid-little-web does not export convert_with_options; ' +
+          'edgeLabelDecluster was requested but is ignored. Rebuild the wasm (bun run build:wasm).'
+      );
+    }
     return convert(code);
   };
   return renderFn;
@@ -458,6 +481,12 @@ import { DiagramRenderError } from '../types.js';
 export interface Options extends RenderOptions {
   /** Mermaid 主题（mermaid 自家枚举），默认 'default' */
   mermaidTheme?: 'default' | 'dark' | 'neutral' | 'forest';
+  /**
+   * 开启边标签去聚簇（#93）。off 时与上游 `mermaid@11.14.0` 字节精确一致；
+   * on 时在布局阶段为 CJK 标签预留真实宽度，并在渲染阶段把仍重叠的标签框推开。
+   * 默认 off。仅 web 绑定生效；RN 暂未接通。
+   */
+  edgeLabelDecluster?: boolean;
   /** 传给 mermaid 的其它 style/theme 变量（如 fontFamily, primaryColor 等） */
   [key: string]: unknown;
 }


### PR DESCRIPTION
## Summary
- **Item 2 (#126):** The decluster integration test asserted zero overlaps — a property the pass does not guarantee when `max_displacement` binds (with the #122 config, 9 of 15 co-located pairs still overlap). Replaced with two assertions: "overlap count strictly decreases" (the real, drift-robust guarantee) plus a fixture-specific zero check for the #93 repro. Documented the pass as best-effort in the `edge_label_decluster` module header.
- **Item 3 (#126):** `packages/web/src/lib.rs` only exported `convert` / `convert_with_id` / `version`, so no Supramark host could enable the option — only the CLI. Added a `convert_with_options` wasm export and threaded `edgeLabelDecluster` through `@supramark/engines` and the diagram engine config. A web host now opts in via `config.diagram.engines.mermaid.edgeLabelDecluster`. Default path stays byte-exact; an older wasm bundle without the new export falls back to `convert(code)` with a warning.

Item 1 from #126 was already fixed in `112abd88` (the issue's correction comment confirms). RN wiring is intentionally out of scope here — it is a larger native surface (FFI + iOS/Android + TurboModule spec); #93 stays open until that binding lands.

## Test plan
- [x] `cargo test -p mermaid-little --test edge_label_decluster` — 4 pass
- [x] `cargo test -p mermaid-little --lib edge_label_decluster` — 6 pass
- [x] `cargo check -p mermaid-little-web --target wasm32-unknown-unknown` — new export compiles
- [x] `bun test __tests__` (engines, full suite) — 20 pass / 6 files (wiring assertions merged into `mermaid-label-centering.test.ts` to avoid bun:test cross-file `mock.module` contamination)
- [x] `bun scripts/lint-types.ts packages/engines packages/core crates/mermaid-little/packages/web` — 0 errors
- [x] `cargo fmt` / `prettier` / `eslint` — clean
- [ ] `bun run build:wasm` — produces the new `convert_with_options` entry (run before deploy; not exercised in this worktree)