### PR TITLE
ci: put integration tests on the PR-gating path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,28 @@ on:
   pull_request:
     branches: [main, develop]
 
+# KNOWN GAP -- needs a repository setting, not a change in this file.
+#
+# On `pull_request`, actions/checkout already builds the PR merged into its
+# base (refs/pull/N/merge), so every job below runs against the merge result
+# rather than the PR head. What is missing is a re-run when the base moves:
+# a green check stays green after main advances underneath it, and nothing
+# re-evaluates it before merge.
+#
+# #105 is the worked example. It was cut on 2026-07-24 and went green. #92
+# then landed on main and narrowed `highlighted` to ReadonlyMap across the
+# RN render chain. #105's own helper still declared a mutable Map, so the
+# two together did not type-check -- while #105 sat green, because its
+# checks were computed against the pre-#92 main and never recomputed. The
+# break only surfaced when the branch was explicitly updated.
+#
+# The fix is the "Require branches to be up to date before merging" toggle
+# on the `main` ruleset (`strict_required_status_checks_policy: true`),
+# which forces a re-run against current main before the merge button
+# unlocks. That is admin-only -- write access cannot set it. Until an admin
+# turns it on, treat a long-lived green PR as unverified and update its
+# branch before merging.
+
 jobs:
   # License compliance — REUSE spec + cargo-deny over the Rust workspace.
   # The workspace-internal SPDX field check runs in the test job

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,12 +102,24 @@ jobs:
         with:
           targets: wasm32-unknown-unknown
 
-      - name: Run supramark-markdown lib tests
+      - name: Run supramark-markdown tests (lib + integration)
         # Unit tests for the canonical parser's AST v2 mapping (autolink → Link,
         # HTML block type-6 paragraph interruption, fence info unescaping,
-        # punctuation classification). Single matrix entry is enough.
+        # punctuation classification), plus tests/public_api.rs — the contract
+        # suite for what `parse()` hands the renderers.
+        #
+        # This used to be `--lib`, which left tests/public_api.rs running in
+        # exactly one place: the `cargo test -p supramark-markdown --test
+        # public_api` step of commonmark-conformance.yml, a workflow with no
+        # `pull_request` trigger. #121 changed HTML-block line-terminator
+        # semantics without updating two assertions there, so main merged red
+        # and stayed red for three pushes — and because that step runs before
+        # the CLI build and the conformance comparison, those were skipped on
+        # every run, so the CommonMark comparison never actually executed.
+        # Dropping `--lib` puts the contract suite on the PR-gating path where
+        # a break is caught before merge.
         if: matrix.node-version == '20.x'
-        run: cargo test -p supramark-markdown --lib
+        run: cargo test -p supramark-markdown
 
       - name: Install wasm-pack
         uses: taiki-e/install-action@v2
@@ -315,6 +327,47 @@ jobs:
 
       - name: cargo test -p d2-little (lib unit tests)
         run: cargo test -p d2-little --lib
+
+  # mermaid-little had no CI job at all (#123). The "Test & Build" job only
+  # builds the wasm bundle via `bun run build:wasm`, which compiles
+  # mermaid-little-web for wasm32 but never compiles or runs the crate's own
+  # tests — so a change that breaks `cargo test -p mermaid-little`, or breaks
+  # the crate's native build entirely, lands with every check green. The
+  # decluster work in #122 / #128 touches layout code whose only regression
+  # coverage lives in these suites.
+  #
+  # Unlike plantuml-little (graphviz native lib) and d2-little (heavy e2e),
+  # mermaid-little needs no native deps and no submodules, and the default
+  # feature set (`cli`, `metrics-ttf-parser`) is what the byte-exact suites
+  # want, so the full `cargo test -p mermaid-little` runs here rather than
+  # just `--lib`. The `katex` / `cose_bilkent` features stay off — they
+  # vendor QuickJS and are a separate, much slower tier.
+  #
+  # Runtime is ~3.5 min of test execution on top of the build (the lib suite
+  # and the reference suite dominate at ~100 s and ~85 s), which is why this
+  # is its own job rather than a step in "Test & Build".
+  mermaid-rust-tests:
+    name: mermaid-little Rust tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo build
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: mermaid-little-cargo-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}
+          restore-keys: mermaid-little-cargo-
+
+      - name: cargo test -p mermaid-little (lib + integration)
+        run: cargo test -p mermaid-little
 
   # plantuml-little byte-exact reference-SVG suite (issue #46, "Full" tier).
   # The committed goldens in tests/reference/ are byte-exact against the wasm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -391,6 +391,42 @@ jobs:
       - name: cargo test -p mermaid-little (lib + integration)
         run: cargo test -p mermaid-little
 
+  # mermaid-little fmt + clippy gate, mirroring `d2-little-full` (the second
+  # half of #123's "Suggested shape"). Clippy is non-blocking for now
+  # (`continue-on-error`) because the crate has 19 pre-existing warnings
+  # (12 × redundant `&` in `format!`, 7 × `?` operator, per #123), so
+  # `-D warnings` would fail the step on a clean tree. Once those are
+  # cleaned up, drop `continue-on-error` to make clippy gating. rustfmt is
+  # gating today — an unformatted PR should not merge.
+  mermaid-little-lint:
+    name: mermaid-little Rust (fmt + clippy)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - name: Cache cargo build
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: mermaid-little-cargo-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}
+          restore-keys: mermaid-little-cargo-
+
+      - name: rustfmt
+        run: cargo fmt -p mermaid-little --check
+
+      - name: clippy (deny warnings, non-blocking — see #123)
+        continue-on-error: true
+        run: cargo clippy -p mermaid-little --all-targets -- -D warnings
+
   # plantuml-little byte-exact reference-SVG suite (issue #46, "Full" tier).
   # The committed goldens in tests/reference/ are byte-exact against the wasm
   # Graphviz build (@kookyleo/graphviz-anywhere-web@0.1.8), so the suite runs

--- a/.github/workflows/commonmark-conformance.yml
+++ b/.github/workflows/commonmark-conformance.yml
@@ -28,6 +28,22 @@ on:
       - "crates/supramark-markdown/**"
       - "packages/core/**"
       - "packages/renderers/web/**"
+  # Same paths as the push trigger, so a PR that can change conformance is
+  # checked before it merges rather than after. Without this, the workflow
+  # only ever ran post-merge: #121 landed a parser change that broke
+  # tests/public_api.rs, main went red, and nothing had told the PR.
+  #
+  # The issue-filing step already carries a `github.event_name !=
+  # 'pull_request'` guard (dead until now), so PR runs report through the
+  # check and the run artifacts, and never open or update an issue.
+  pull_request:
+    paths:
+      - ".github/workflows/commonmark-conformance.yml"
+      - "tests/cases/**"
+      - "tests/markdown-conformance/**"
+      - "crates/supramark-markdown/**"
+      - "packages/core/**"
+      - "packages/renderers/web/**"
 
 permissions:
   contents: read


### PR DESCRIPTION
Three crates or suites could break with every check green. #121 and #105 are the two worked examples, both from the last four days.

## What was missing

**`tests/public_api.rs` never ran on a PR.** `ci.yml` ran `cargo test -p supramark-markdown --lib`, so the contract suite for what `parse()` hands the renderers only ran inside `commonmark-conformance.yml` — a workflow with no `pull_request` trigger. #121 changed HTML-block line-terminator semantics without updating two assertions there. The PR was green, main went red, and because that step runs before the CLI build and the conformance comparison, **the CommonMark comparison was skipped on every run from #121 until #127 landed**. Fixed by dropping `--lib`.

**`mermaid-little` had no CI job at all (#123).** The Test & Build job compiles `mermaid-little-web` for wasm32 via `bun run build:wasm`, but never builds or runs the crate's own tests — a native build break or a layout regression lands unnoticed. The decluster work in #122 / #128 touches layout code whose only regression coverage lives in these suites. Added a dedicated job: no native deps, no submodules, full `cargo test -p mermaid-little` (703 lib + integration tests, ~3.5 min of execution, cached). `katex` / `cose_bilkent` stay off — they vendor QuickJS and belong in a separate tier.

**Conformance only ran post-merge.** Added a `pull_request` trigger with the same path filter as the push trigger. The issue-filing step already carries a `github.event_name != 'pull_request'` guard that was dead code until now, so PR runs report through the check and the uploaded artifacts and never open or update an issue. This is one of #106's asks.

## Verified locally before enabling the PR trigger

The concern with adding the trigger is turning every touching PR red. It does not:

```
CommonMark 语义对照：通过 652/652，未通过 0
CommonMark 视觉对照：通过 652/652，未通过 0
```

That is `run-commonmark-visual.mjs`, the path the workflow runs by default. The non-visual path is 640/652 — tracked on #106, along with that path's baseline ratchet being inert due to `comparisonTarget` mismatch. Neither is touched here.

Also verified: `cargo test -p mermaid-little` 703 pass / 0 fail; `cargo test -p supramark-markdown` clean on this branch; both workflow files parse.

## Known gap this does NOT close — needs an admin

Documented in a comment under `on:` in `ci.yml` rather than silently left out.

Jobs already run against `refs/pull/N/merge`, so the merge result is what gets tested. What is missing is a **re-run when the base moves**: a green check stays green after main advances underneath it.

#105 is the worked example. Cut 2026-07-24 and green. #92 then landed on main and narrowed `highlighted` to `ReadonlyMap` across the RN render chain; #105's own helper still declared a mutable `Map`, so the two together did not type-check — while #105 sat green, because its checks were computed against the pre-#92 main and never recomputed. It only surfaced when the branch was explicitly updated, and needed `b4e41680` to fix.

Closing that needs **"Require branches to be up to date before merging"** (`strict_required_status_checks_policy: true`) on the `main` ruleset. That is admin-only — write access cannot set it. @g65537 @Camel9527, this is the ask.

Note it will immediately require #84 (37 commits behind main) to update its branch before merging.

Closes #123
Refs #106