### PR TITLE
fix(mermaid-little): clear 19 clippy warnings to unblock gating

### DIFF
--- a/crates/mermaid-little/src/parser/gantt.rs
+++ b/crates/mermaid-little/src/parser/gantt.rs
@@ -475,10 +475,9 @@ fn scan_str_after(s: &str, key: &str) -> Option<String> {
     let rest = rest.strip_prefix(':')?.trim_start();
     let (open, close) = if let Some(r) = rest.strip_prefix('"') {
         (r, '"')
-    } else if let Some(r) = rest.strip_prefix('\'') {
-        (r, '\'')
     } else {
-        return None;
+        let r = rest.strip_prefix('\'')?;
+        (r, '\'')
     };
     let end = open.find(close)?;
     Some(open[..end].to_string())

--- a/crates/mermaid-little/src/parser/requirement.rs
+++ b/crates/mermaid-little/src/parser/requirement.rs
@@ -508,11 +508,10 @@ fn parse_relationship(line: &str) -> Option<Relation> {
     //   A <- verb - B   (B is src, A is dst)  (upstream: yy.addRelationship($3,$5,$1))
     let (left_end, op_start) = if let Some(idx) = line.find(" - ") {
         (idx, idx + 1)
-    } else if let Some(idx) = line.find("- ") {
+    } else {
+        let idx = line.find("- ")?;
         // start-of-line tolerance
         (idx, idx)
-    } else {
-        return None;
     };
     // Determine direction.
     let rest_after_dash = &line[op_start + 1..];

--- a/crates/mermaid-little/src/parser/sequence.rs
+++ b/crates/mermaid-little/src/parser/sequence.rs
@@ -811,10 +811,9 @@ fn parse_note(s: &str) -> Option<Note> {
         (NotePlacement::LeftOf, r)
     } else if let Some(r) = s.strip_prefix("right of ") {
         (NotePlacement::RightOf, r)
-    } else if let Some(r) = s.strip_prefix("over ") {
-        (NotePlacement::Over, r)
     } else {
-        return None;
+        let r = s.strip_prefix("over ")?;
+        (NotePlacement::Over, r)
     };
     let (anchors_str, body) = rest.split_once(':')?;
     let anchors: Vec<String> = anchors_str
@@ -1110,10 +1109,9 @@ fn sniff_bool(block: &str, key: &str) -> Option<bool> {
         (i, dq.len())
     } else if let Some(i) = block.find(&sq) {
         (i, sq.len())
-    } else if let Some(i) = block.find(&bare) {
-        (i, key.len())
     } else {
-        return None;
+        let i = block.find(&bare)?;
+        (i, key.len())
     };
     let after = &block[p + key_len..];
     let after = after.trim_start_matches(|c: char| c.is_whitespace() || c == ':');

--- a/crates/mermaid-little/src/parser/state.rs
+++ b/crates/mermaid-little/src/parser/state.rs
@@ -1186,10 +1186,9 @@ fn parse_note_header(line: &str) -> Option<(String, NotePosition)> {
         (NotePosition::RightOf, r)
     } else if let Some(r) = rest.strip_prefix("above of ") {
         (NotePosition::Above, r)
-    } else if let Some(r) = rest.strip_prefix("below of ") {
-        (NotePosition::Below, r)
     } else {
-        return None;
+        let r = rest.strip_prefix("below of ")?;
+        (NotePosition::Below, r)
     };
     // Trailing colon / inline content indicates it's actually the
     // one-liner form; caller handles that.
@@ -1207,10 +1206,9 @@ fn parse_inline_note(line: &str) -> Option<(String, NotePosition, String)> {
         (NotePosition::RightOf, r)
     } else if let Some(r) = rest.strip_prefix("above of ") {
         (NotePosition::Above, r)
-    } else if let Some(r) = rest.strip_prefix("below of ") {
-        (NotePosition::Below, r)
     } else {
-        return None;
+        let r = rest.strip_prefix("below of ")?;
+        (NotePosition::Below, r)
     };
     let (target, text) = split_once_colon(rest)?;
     Some((target.trim().to_string(), pos, text.trim().to_string()))

--- a/crates/mermaid-little/src/parser/timeline.rs
+++ b/crates/mermaid-little/src/parser/timeline.rs
@@ -352,10 +352,9 @@ fn scan_str_after(s: &str, key: &str) -> Option<String> {
     let rest = rest.strip_prefix(':')?.trim_start();
     let (open, close) = if let Some(r) = rest.strip_prefix('"') {
         (r, '"')
-    } else if let Some(r) = rest.strip_prefix('\'') {
-        (r, '\'')
     } else {
-        return None;
+        let r = rest.strip_prefix('\'')?;
+        (r, '\'')
     };
     let end = open.find(close)?;
     Some(open[..end].to_string())

--- a/crates/mermaid-little/src/render/svg_journey.rs
+++ b/crates/mermaid-little/src/render/svg_journey.rs
@@ -185,8 +185,8 @@ pub fn render(
         out.push_str(&format!(
             r#"<text x="{x}" font-size="{fs}" font-weight="bold" y="25" fill="{fill}" font-family="{ff}">{title}</text>"#,
             x = fmt_num(l.left_margin),
-            fs = &l.title_font_size,
-            fill = &l.title_color,
+            fs = l.title_font_size,
+            fill = l.title_color,
             ff = escape_attr_family(&l.title_font_family),
             title = escape_text(&l.title),
         ));
@@ -212,7 +212,7 @@ fn render_actor_legend(out: &mut String, a: &JourneyActorLegend) {
         "<circle cx=\"20\" cy=\"{cy}\" class=\"actor-{pos}\" fill=\"{fill}\" stroke=\"#000\" r=\"7\"></circle>",
         cy = fmt_num(a.circle_cy),
         pos = a.pos,
-        fill = &a.colour,
+        fill = a.colour,
     ));
     // Each line: <text x="40" y="{ly}" class="legend"><tspan x="50">{line}</tspan></text>
     for line in &a.lines {
@@ -241,7 +241,7 @@ fn render_section(
         "<rect x=\"{x}\" y=\"{sy}\" fill=\"{fill}\" stroke=\"#666\" width=\"{w}\" height=\"{h}\" rx=\"3\" ry=\"3\" class=\"journey-section section-type-{n}\"></rect>",
         x = fmt_num(sec.x),
         sy = fmt_num(sec_y),
-        fill = &sec.fill,
+        fill = sec.fill,
         w = fmt_num(sec.width),
         h = fmt_num(sec_h),
         n = sec.num,
@@ -284,7 +284,7 @@ fn render_task(out: &mut String, task: &JourneyTaskLayout, l: &JourneyLayout, id
         "<rect x=\"{x}\" y=\"{y}\" fill=\"{fill}\" stroke=\"#666\" width=\"{w}\" height=\"{h}\" rx=\"3\" ry=\"3\" class=\"task task-type-{n}\"></rect>",
         x = fmt_num(task.x),
         y = fmt_num(task.y),
-        fill = &task.fill,
+        fill = task.fill,
         w = fmt_num(w),
         h = fmt_num(h),
         n = task.num,
@@ -298,7 +298,7 @@ fn render_task(out: &mut String, task: &JourneyTaskLayout, l: &JourneyLayout, id
             cx = fmt_num(chip.cx),
             cy = fmt_num(task.y),
             pos = chip.pos,
-            fill = &chip.colour,
+            fill = chip.colour,
             title = escape_text(&chip.title),
         ));
     }

--- a/crates/mermaid-little/src/render/svg_requirement.rs
+++ b/crates/mermaid-little/src/render/svg_requirement.rs
@@ -819,7 +819,7 @@ fn render_edge(id_prefix: &str, e: &UEdge) -> String {
         r#"<path d="{d}" id="{id_prefix}-{eid}" class="{cls}" style="{st}" data-edge="true" data-et="edge" data-id="{did}" data-points="{b64}" data-look="classic"{ma}></path>"#,
         d = d,
         eid = xml_escape(&e.id),
-        cls = &classes,
+        cls = classes,
         st = style,
         did = edge_data_id,
         b64 = data_points_b64,

--- a/crates/mermaid-little/src/render/svg_sankey.rs
+++ b/crates/mermaid-little/src/render/svg_sankey.rs
@@ -87,7 +87,7 @@ pub fn render(
             y = js_num(y0),
             h = js_num(node.y1 - node.y0),
             w = js_num(node.x1 - node.x0),
-            color = &l.node_colors[i],
+            color = l.node_colors[i],
         ));
     }
     out.push_str("</g>");
@@ -163,8 +163,8 @@ pub fn render(
                 uid = uid,
                 x1 = js_num(x0),
                 x2 = js_num(x1),
-                c1 = &l.node_colors[link.source],
-                c2 = &l.node_colors[link.target],
+                c1 = l.node_colors[link.source],
+                c2 = l.node_colors[link.target],
             ));
         }
         let path = sankey_link_horizontal(x0, link.y0, x1, link.y1);
@@ -251,7 +251,7 @@ fn compute_bbox(d: &SankeyDiagram, l: &SankeyLayout) -> (f64, f64, f64, f64) {
             let rounded = (node.value * 100.0).round() / 100.0;
             format!(
                 "{id}\n{p}{v}{s}",
-                id = &d.nodes[i],
+                id = d.nodes[i],
                 p = d.config.prefix,
                 v = js_num(rounded),
                 s = d.config.suffix

--- a/crates/mermaid-little/src/render/svg_xychart.rs
+++ b/crates/mermaid-little/src/render/svg_xychart.rs
@@ -49,7 +49,7 @@ pub fn render(
         r#"<rect width="{w}" height="{h}" class="background" fill="{bg}"></rect>"#,
         w = fmt_int(l.width),
         h = fmt_int(l.height),
-        bg = &l.background_color,
+        bg = l.background_color,
     ));
 
     // 4b. Drawable elements — upstream uses getGroup() which re-uses


### PR DESCRIPTION
## Summary

Clears the 19 pre-existing clippy warnings in `mermaid-little` that **#123** flagged as the blocker for making the clippy step gating. Unblocks the `continue-on-error` in PR **#129**.

- 12 × `redundant reference in format!` — `svg_journey` / `svg_sankey` / `svg_requirement` / `svg_xychart`
- 7 × `?` operator rewrite — `gantt` / `requirement` / `sequence` / `state` / `timeline`

All applied via `cargo clippy --fix --lib -p mermaid-little`. The `?` rewrites are semantically equivalent: the trailing `else { return None; }` branch moves onto the final `else if`'s pattern as a `?`, so the no-match path still returns `None` exactly as before.

## Verification

- `cargo clippy -p mermaid-little --all-targets -- -D warnings` — clean
- `cargo test -p mermaid-little` — **1031 passed / 0 failed** (9 ignored)
- `cargo fmt -p mermaid-little --check` — clean

Diff: 9 files, +26 / -33.

## Follow-up

Once this lands, PR #129 drops `continue-on-error: true` on the `mermaid-little Rust (fmt + clippy)` clippy step to make it gating.

Refs #123