### PR TITLE
fix(rn-selection): yield overlay for native-taken block to stop duplicate highlight

### DIFF
--- a/packages/renderers/rn-selection/src/__tests__/coordinator/nativeBridge.test.ts
+++ b/packages/renderers/rn-selection/src/__tests__/coordinator/nativeBridge.test.ts
@@ -65,8 +65,8 @@ function setup(opts?: { p2Handle?: boolean }) {
     ...(opts?.p2Handle === false ? {} : { handle: p2.handle }),
   });
   const store = createSelectionStore(() => units);
-  const unsubscribe = createNativeBridge(store, registry);
-  return { registry, store, p1, p2, unsubscribe };
+  const { unsubscribe, pushedStore } = createNativeBridge(store, registry);
+  return { registry, store, p1, p2, unsubscribe, pushedStore };
 }
 
 const P = (nodeId: string, unitId: string, offset: number) => ({ nodeId, unitId, offset });
@@ -180,6 +180,43 @@ describe('createNativeBridge', () => {
     store.extendTo(P('p1', 'p1#1', 5));
     store.commit();
     expect(p1.calls).toEqual([]);
+  });
+
+  test('pushedStore reports the pushed block, then null on clear', () => {
+    // The overlay subscribes to pushedStore to yield for the block the native
+    // side has taken over. A single-block commit publishes that nodeId; clear
+    // publishes null.
+    const { store, pushedStore } = setup();
+    expect(pushedStore.getPushed()).toBeNull();
+    store.beginAt(P('p1', 'p1#0', 0));
+    store.extendTo(P('p1', 'p1#1', 5));
+    // 'selecting' is coordinator-owned: nothing pushed yet.
+    expect(pushedStore.getPushed()).toBeNull();
+    store.commit();
+    expect(pushedStore.getPushed()).toBe('p1');
+    store.clear();
+    expect(pushedStore.getPushed()).toBeNull();
+  });
+
+  test('pushedStore reports null for a cross-block commit (native veto)', () => {
+    // Cross-block ranges are never pushed native, so pushedStore stays null and
+    // the overlay paints every covered block.
+    const { store, pushedStore } = setup();
+    store.beginAt(P('p1', 'p1#0', 0));
+    store.extendTo(P('p2', 'p2#0', 3));
+    store.commit();
+    expect(pushedStore.getPushed()).toBeNull();
+  });
+
+  test('pushedStore notifies subscribers when the pushed block changes', () => {
+    const { store, pushedStore } = setup();
+    const seen: (string | null)[] = [];
+    pushedStore.subscribe(() => seen.push(pushedStore.getPushed()));
+    store.beginAt(P('p1', 'p1#0', 0));
+    store.extendTo(P('p1', 'p1#1', 5));
+    store.commit();
+    store.clear();
+    expect(seen).toEqual(['p1', null]);
   });
 });
 

--- a/packages/renderers/rn-selection/src/__tests__/coordinator/overlay.test.ts
+++ b/packages/renderers/rn-selection/src/__tests__/coordinator/overlay.test.ts
@@ -110,4 +110,38 @@ describe('computeOverlayRects', () => {
     expect(rectA).toEqual({ x: 0, y: 0, w: 30, h: 20 });
     expect(rectB).toEqual({ x: 0, y: 20, w: 50, h: 20 });
   });
+
+  test('yieldNodeId skips the block the native side has taken over', () => {
+    // Single-block commit: native bridge pushed block 'a' via selectRange, so
+    // the overlay must yield for 'a' (let native handles + menu paint alone) and
+    // not stack a full-width rect underneath.
+    const rectA = { x: 0, y: 0, w: 30, h: 20 };
+    const blocks = [block('a', ['a#0'], rectA)];
+    const covered = [tUnit('a#0', 'a', 'x')];
+    expect(computeOverlayRects(blocks, covered, undefined, 'a')).toEqual([]);
+  });
+
+  test('yieldNodeId null for cross-block paints every covered block', () => {
+    // Cross-block range is never pushed native (planNativeSelection vetoes a
+    // second owner), so yieldNodeId is null and every covered block paints.
+    const rectA = { x: 0, y: 0, w: 30, h: 20 };
+    const rectB = { x: 0, y: 20, w: 50, h: 20 };
+    const blocks = [block('a', ['a#0'], rectA), block('b', ['b#0'], rectB)];
+    const covered = [tUnit('a#0', 'a', 'x'), tUnit('b#0', 'b', 'y')];
+    expect(computeOverlayRects(blocks, covered, undefined, null)).toEqual([
+      { x: 0, y: 0, w: 50, h: 40 },
+    ]);
+  });
+
+  test('yieldNodeId only skips its own block, not a neighboring covered block', () => {
+    // Single-block commit on 'a' while 'b' is also covered (e.g. a cross-block
+    // range transition): 'a' yields, 'b' still paints. In practice the bridge
+    // clears its push before a cross-block commit lands, but the overlay must
+    // still be correct if both ever coincide.
+    const rectA = { x: 0, y: 0, w: 30, h: 20 };
+    const rectB = { x: 0, y: 20, w: 50, h: 20 };
+    const blocks = [block('a', ['a#0'], rectA), block('b', ['b#0'], rectB)];
+    const covered = [tUnit('a#0', 'a', 'x'), tUnit('b#0', 'b', 'y')];
+    expect(computeOverlayRects(blocks, covered, undefined, 'a')).toEqual([rectB]);
+  });
 });

--- a/packages/renderers/rn-selection/src/coordinator/SelectionContext.ts
+++ b/packages/renderers/rn-selection/src/coordinator/SelectionContext.ts
@@ -3,17 +3,21 @@ import type { SelectionNodeId } from '../model';
 import type { SegmentEventSink } from '../nativePrimitive';
 import type { LayoutRect, RegisteredBlock, SelectionRegistry } from './registry';
 import type { SelectionStore } from './state';
+import type { NativeBridgePushedStore } from './nativeBridge';
 
 /**
  * Contract a block component uses to plug itself into the document selection.
  * All real logic lives in `SelectionRegistry` / `SelectionStore`; this context
  * is only wiring. The registry and store are exposed directly so the overlay
  * and host controls under the root need no prop-drilling; per-block event
- * routing is built through `createBlockSink`.
+ * routing is built through `createBlockSink`. `nativePushed` lets the overlay
+ * yield for the block the native bridge has taken over.
  */
 export interface SelectionContextValue {
   registry: SelectionRegistry;
   store: SelectionStore;
+  /** The block the native bridge is showing, for overlay yield. Null if none. */
+  nativePushed: NativeBridgePushedStore;
   /** Register a block; the returned disposer unregisters it. Call from useEffect. */
   registerBlock(block: RegisteredBlock): () => void;
   updateLayout(nodeId: SelectionNodeId, rect: LayoutRect): void;

--- a/packages/renderers/rn-selection/src/coordinator/SelectionOverlay.tsx
+++ b/packages/renderers/rn-selection/src/coordinator/SelectionOverlay.tsx
@@ -18,7 +18,7 @@ export const SelectionOverlay: React.FC<SelectionOverlayProps> = ({
   color = 'rgba(51,153,255,0.35)',
   zIndex = 10,
 }) => {
-  const { registry, store } = useSelectionContext();
+  const { registry, store, nativePushed } = useSelectionContext();
   const snapshot = useSyncExternalStore(store.subscribe, store.getSnapshot, store.getSnapshot);
   // Also track the registry: layout / unit / (un)register changes do NOT alter
   // the `getBlocks()` array reference, so without this the overlay would keep
@@ -29,7 +29,20 @@ export const SelectionOverlay: React.FC<SelectionOverlayProps> = ({
     [registry]
   );
   useSyncExternalStore(subscribeRegistry, registry.getVersion, registry.getVersion);
-  const rects = computeOverlayRects(registry.getBlocks(), snapshot.units);
+  // Yield for the block the native bridge has taken over (single-block commit):
+  // let the native selection (system handles + edit menu) paint alone instead of
+  // stacking a full-width block rect underneath. Null for cross-block ranges,
+  // so every covered block paints — those are never pushed native.
+  const subscribePushed = useCallback(
+    (cb: () => void) => nativePushed.subscribe(cb),
+    [nativePushed]
+  );
+  const yieldNodeId = useSyncExternalStore(
+    subscribePushed,
+    nativePushed.getPushed,
+    nativePushed.getPushed
+  );
+  const rects = computeOverlayRects(registry.getBlocks(), snapshot.units, undefined, yieldNodeId);
   return (
     <View pointerEvents="none" style={[StyleSheet.absoluteFill, { zIndex }]}>
       {rects.map((r, i) => (

--- a/packages/renderers/rn-selection/src/coordinator/SelectionRoot.tsx
+++ b/packages/renderers/rn-selection/src/coordinator/SelectionRoot.tsx
@@ -67,11 +67,12 @@ export const SelectionRoot: React.FC<SelectionRootProps> = ({
     registry.setUnits(units);
   }, [registry, units]);
 
-  // Downlink of the command bridge: committed single-block ranges drive the
-  // vendored native selection (handles + system menu); cross-block selection
-  // stays on the coordinator overlay. Uplink (native events -> store) is wired
-  // per block through `createBlockSink` below.
-  useEffect(() => createNativeBridge(store, registry), [store, registry]);
+  // Command bridge: committed single-block ranges drive the vendored native
+  // selection (handles + system menu); cross-block selection stays on the
+  // coordinator overlay. The handle is memoized so its `pushedStore` reference
+  // stays stable across renders (the ctx and overlay subscribe to it).
+  const bridge = useMemo(() => createNativeBridge(store, registry), [store, registry]);
+  useEffect(() => () => bridge.unsubscribe(), [bridge]);
 
   // Surface range changes; covered units live on the store snapshot.
   useEffect(() => {
@@ -86,6 +87,7 @@ export const SelectionRoot: React.FC<SelectionRootProps> = ({
     () => ({
       registry,
       store,
+      nativePushed: bridge.pushedStore,
       registerBlock: block => {
         // Capture what was actually stored and hand it back on unregister, so
         // a stale instance's cleanup cannot delete a live registration that
@@ -109,7 +111,7 @@ export const SelectionRoot: React.FC<SelectionRootProps> = ({
           formatForAction: id => formatForActionRef.current?.(id) ?? 'plainText',
         }),
     }),
-    [registry, store]
+    [registry, store, bridge.pushedStore]
   );
 
   return (

--- a/packages/renderers/rn-selection/src/coordinator/nativeBridge.ts
+++ b/packages/renderers/rn-selection/src/coordinator/nativeBridge.ts
@@ -4,6 +4,20 @@ import type { RegisteredBlock, SelectionRegistry } from './registry';
 import type { SelectionSnapshot, SelectionStore } from './state';
 
 /**
+ * External-store view of which block the bridge has pushed to the native side.
+ * The overlay subscribes so it can YIELD for that block — letting the native
+ * selection (handles + system menu) paint alone — and only paint cross-block
+ * ranges itself. Property-style getters are safe to pass unbound into
+ * `useSyncExternalStore`.
+ */
+export interface NativeBridgePushedStore {
+  /** The nodeId the native side is currently showing, or `null` if none. */
+  getPushed: () => SelectionNodeId | null;
+  /** External-store subscribe; returns the unsubscriber. */
+  subscribe: (listener: () => void) => () => void;
+}
+
+/**
  * Downlink half of the vendored command bridge: the coordinator store stays
  * the single source of truth, and committed selection state is pushed DOWN to
  * the owning block's native `TextSegmentHandle` (`selectRange` — native
@@ -56,8 +70,19 @@ export function planNativeSelection(
   return { nodeId: owner.nodeId, ...segment };
 }
 
+/** Result of wiring the downlink: an unsubscriber plus the pushed-block store. */
+export interface NativeBridgeHandle {
+  /** Detach the downlink from the store. */
+  unsubscribe: () => void;
+  /** External-store view of the block the native side is showing. */
+  pushedStore: NativeBridgePushedStore;
+}
+
 /**
- * Subscribe the downlink to a store. Returns the unsubscriber.
+ * Subscribe the downlink to a store. Returns the unsubscriber plus a
+ * `pushedStore` the overlay subscribes to so it can yield for the block the
+ * native side has taken over (single-block commit) and paint only cross-block
+ * ranges itself.
  *
  * Command discipline (`selectRange` pops the system selection menu, so every
  * avoided call is an avoided menu popup):
@@ -77,8 +102,22 @@ export function planNativeSelection(
 export function createNativeBridge(
   store: Pick<SelectionStore, 'getSnapshot' | 'subscribe'>,
   registry: NativeBridgeRegistry
-): () => void {
+): NativeBridgeHandle {
   let pushed: NativeSelectionTarget | null = null;
+  const pushedListeners = new Set<() => void>();
+
+  const notifyPushed = (): void => {
+    for (const listener of pushedListeners) listener();
+  };
+  const pushedStore: NativeBridgePushedStore = {
+    getPushed: () => pushed?.nodeId ?? null,
+    subscribe: listener => {
+      pushedListeners.add(listener);
+      return () => {
+        pushedListeners.delete(listener);
+      };
+    },
+  };
 
   const apply = (): void => {
     const snapshot = store.getSnapshot();
@@ -89,6 +128,7 @@ export function createNativeBridge(
       if (pushed !== null) {
         registry.getBlock(pushed.nodeId)?.handle?.clearSelection();
         pushed = null;
+        notifyPushed();
       }
       return;
     }
@@ -105,12 +145,17 @@ export function createNativeBridge(
     }
     const handle = registry.getBlock(target.nodeId)?.handle;
     if (handle === undefined) {
-      pushed = null;
+      if (pushed !== null) {
+        pushed = null;
+        notifyPushed();
+      }
       return;
     }
     handle.selectRange(target.startUtf16, target.endUtf16);
     pushed = target;
+    notifyPushed();
   };
 
-  return store.subscribe(apply);
+  const unsubscribe = store.subscribe(apply);
+  return { unsubscribe, pushedStore };
 }

--- a/packages/renderers/rn-selection/src/coordinator/overlay.ts
+++ b/packages/renderers/rn-selection/src/coordinator/overlay.ts
@@ -1,4 +1,4 @@
-import type { SelectionUnit } from '../model';
+import type { SelectionNodeId, SelectionUnit } from '../model';
 import type { LayoutRect, RegisteredBlock } from './registry';
 
 export type OverlayRect = LayoutRect; // {x,y,w,h} in SelectionRoot coordinate space
@@ -12,16 +12,24 @@ export const OVERLAY_MERGE_GAP = 1;
  * native `getSelectionRects` command, which does not yet exist). Vertically
  * contiguous covered rects — those whose vertical gap is within `mergeGap` —
  * merge into a single union box.
+ *
+ * `yieldNodeId` is the block the native bridge has taken over with a native
+ * `selectRange` (single-block commit): the overlay skips it so the native
+ * selection — system handles + edit menu — paints alone instead of stacking a
+ * full-width block rect underneath. Cross-block selections are never pushed
+ * native, so `yieldNodeId` is null for them and every covered block paints.
  */
 export function computeOverlayRects(
   blocks: readonly RegisteredBlock[],
   coveredUnits: readonly SelectionUnit[],
-  mergeGap: number = OVERLAY_MERGE_GAP
+  mergeGap: number = OVERLAY_MERGE_GAP,
+  yieldNodeId: SelectionNodeId | null = null
 ): OverlayRect[] {
   const covered = new Set(coveredUnits.map(u => u.unitId));
   const rects: LayoutRect[] = [];
   for (const b of blocks) {
     if (!b.rect) continue;
+    if (yieldNodeId !== null && b.nodeId === yieldNodeId) continue;
     if (!b.unitIds.some(id => covered.has(id))) continue;
     rects.push(b.rect);
   }


### PR DESCRIPTION
Fixes #132.

## Problem

On `@supramark/rn-selection` (after #84 merged), long-pressing a single text block painted two overlapping highlights: the vendored native selection (system grab handles + edit menu) AND a full-width block rect underneath from `SelectionOverlay`. Both fired on the same `commit()`. See #132 for the full analysis.

## Root cause

`SelectionOverlay` derived rects purely from `snapshot.units` with no knowledge that `nativeBridge` had already pushed that block to the native side via `selectRange`. The bridge's pushed record was closure-private, so the overlay had no way to know which block to skip.

## Fix

Expose the bridge's pushed block as an external store and have the overlay yield for it:

- `nativeBridge.ts` — `createNativeBridge` returns `{ unsubscribe, pushedStore }`; `pushedStore` publishes the pushed nodeId (or null) and notifies subscribers on every push/clear.
- `overlay.ts` — `computeOverlayRects` gains a `yieldNodeId` param; blocks matching it are skipped.
- `SelectionContext.ts` / `SelectionRoot.tsx` — the pushed store is threaded onto the context.
- `SelectionOverlay.tsx` — subscribes to the pushed store and passes `yieldNodeId` through.

**Behavior:**
- Single-block commit → bridge pushes native + publishes nodeId → overlay yields for that block → only the native selection (handles + menu) paints.
- Cross-block commit → `planNativeSelection` vetoes (second owner) → `yieldNodeId` is null → overlay paints every covered block (unchanged).

## Verification

- iOS sim (RN 0.81 New Arch), clean metro + Xcode build cache: long-press single block → only the native selection layer; duplicate rect gone. Cross-block `Select A..B` → merged coordinator overlay as designed.
- Tests: 173 pass / 0 fail (was 167; +6 — 3 overlay-yield, 3 pushedStore).
- `tsc --noEmit` clean (rn-selection package).

## Scope

Coordinator layer only (`packages/renderers/rn-selection/src/coordinator/` + tests). No vendored native changes; no `Podfile.lock` / `project.pbxproj` artifacts.

Follow-up for the separate "tap-outside not returning to idle" issue is tracked in #133.