### PR TITLE
fix(parser): match emphasis in content coordinates

### DIFF
--- a/crates/supramark-markdown/src/generics/inline/emph_pair.rs
+++ b/crates/supramark-markdown/src/generics/inline/emph_pair.rs
@@ -82,6 +82,17 @@ pub struct EmphMarker {
     // an emphasis.
     pub open: bool,
     pub close: bool,
+
+    // Byte range of the still-unmatched part of this delimiter run, in
+    // `InlineState::src` coordinates.
+    //
+    // `Node::srcmap` cannot be reused for this: it holds offsets into the *original* markdown
+    // source, which is a different (and possibly longer) coordinate space. A table cell hands
+    // the inline parser `_x|y_` for the source text `_x\|y_`, because the cell scanner drops
+    // the backslash. Matching delimiters has to be done in `src` coordinates, and only the
+    // final span is translated to source coordinates via `InlineState::get_map`.
+    pub content_start: usize,
+    pub content_end: usize,
 }
 
 // this node is supposed to be replaced by actual emph or text node
@@ -127,19 +138,27 @@ impl<const MARKER: char, const CAN_SPLIT_WORD: bool> InlineRule
         }
 
         let scanned = state.scan_delims(state.pos, CAN_SPLIT_WORD);
+        let content_end = state.pos + scanned.length;
         let mut node = Node::new(EmphMarker {
             marker: MARKER,
             length: scanned.length,
             remaining: scanned.length,
             open: scanned.can_open,
             close: scanned.can_close,
+            content_start: state.pos,
+            content_end,
         });
-        node.srcmap = state.get_map(state.pos, state.pos + scanned.length);
-        node = scan_and_match_delimiters::<MARKER>(state, node);
-        let map = node.srcmap.unwrap().get_byte_offsets();
-        // backtrack to keep correct source maps
-        state.pos += scanned.length;
-        let token_len = map.1 - map.0;
+        node.srcmap = state.get_map(state.pos, content_end);
+        let token_start;
+        (node, token_start) = scan_and_match_delimiters::<MARKER>(state, node);
+
+        // Backtrack to keep correct source maps: `InlineParser::tokenize` overwrites the srcmap
+        // of whatever we return with `get_map(state.pos - len, state.pos)`. So `len` has to be
+        // the token's length in `state.src` coordinates, and `state.pos` has to end up just
+        // past the closing marker run.
+        state.pos = content_end;
+        debug_assert!(token_start <= state.pos);
+        let token_len = state.pos - token_start;
         state.pos -= token_len;
         Some((node, token_len))
     }
@@ -147,17 +166,24 @@ impl<const MARKER: char, const CAN_SPLIT_WORD: bool> InlineRule
 
 /// Assuming last token is a closing delimiter we just inserted,
 /// try to find opener(s). If any are found, move stuff to nested emph node.
+///
+/// Returns the token to hand back to the tokenizer, plus that token's start offset in
+/// `InlineState::src` coordinates (see [`EmphMarker::content_start`]).
 fn scan_and_match_delimiters<const MARKER: char>(
     state: &mut InlineState,
     mut closer_token: Node,
-) -> Node {
+) -> (Node, usize) {
+    let mut closer = closer_token.cast::<EmphMarker>().unwrap().clone();
+    // Start of the closer run before any of it gets matched; also the fallback token start for
+    // every path that leaves the run untouched.
+    let unmatched_token_start = closer.content_start;
+
     if state.node.children.is_empty() {
-        return closer_token;
+        return (closer_token, unmatched_token_start);
     } // must have at least opener and closer
 
-    let mut closer = closer_token.cast_mut::<EmphMarker>().unwrap().clone();
     if !closer.close {
-        return closer_token;
+        return (closer_token, unmatched_token_start);
     }
 
     // Previously calculated lower bounds (previous fails)
@@ -174,6 +200,8 @@ fn scan_and_match_delimiters<const MARKER: char>(
 
     let mut idx = state.node.children.len() - 1;
     let mut new_min_opener_idx = idx;
+    // Start of the most recently created emph node, in `state.src` coordinates.
+    let mut matched_token_start = unmatched_token_start;
     while idx > min_opener_idx {
         idx -= 1;
 
@@ -206,27 +234,27 @@ fn scan_and_match_delimiters<const MARKER: char>(
                 closer.remaining -= marker_len;
                 opener.remaining -= marker_len;
 
+                // Cut marker_len bytes off the start of the closer run ("12345" -> "345") and
+                // off the end of the opener run ("12345" -> "123"). Markers are always ASCII,
+                // so byte and char counts agree. The emph node then spans exactly the gap the
+                // two cuts opened up.
+                closer.content_start += marker_len;
+                opener.content_end -= marker_len;
+
+                // All three spans are in `state.src` coordinates and are translated to source
+                // coordinates here, exactly once. Computed before taking a mutable borrow of
+                // `state.node`.
+                let closer_map = state.get_map(closer.content_start, closer.content_end);
+                let opener_map = state.get_map(opener.content_start, opener.content_end);
+                let new_token_map = state.get_map(opener.content_end, closer.content_start);
+
+                closer_token.srcmap = closer_map;
+
                 let mut new_token = marker_fn();
                 new_token.children = state.node.children.split_off(idx + 1);
+                new_token.srcmap = new_token_map;
 
-                // cut marker_len chars from start, i.e. "12345" -> "345"
-                let mut end_map_pos = 0;
-                if let Some(map) = closer_token.srcmap {
-                    let (start, end) = map.get_byte_offsets();
-                    closer_token.srcmap = Some(SourcePos::new(start + marker_len, end));
-                    end_map_pos = start + marker_len;
-                }
-
-                // cut marker_len chars from end, i.e. "12345" -> "123"
-                let mut start_map_pos = 0;
-                let opener_token = state.node.children.last_mut().unwrap();
-                if let Some(map) = opener_token.srcmap {
-                    let (start, end) = map.get_byte_offsets();
-                    opener_token.srcmap = Some(SourcePos::new(start, end - marker_len));
-                    start_map_pos = end - marker_len;
-                }
-
-                new_token.srcmap = state.get_map(start_map_pos, end_map_pos);
+                state.node.children.last_mut().unwrap().srcmap = opener_map;
 
                 // remove empty node as a small optimization so we can do less work later
                 if opener.remaining == 0 {
@@ -234,6 +262,7 @@ fn scan_and_match_delimiters<const MARKER: char>(
                 }
 
                 new_min_opener_idx = 0;
+                matched_token_start = opener.content_end;
                 state.node.children.push(new_token);
             }
         }
@@ -260,10 +289,11 @@ fn scan_and_match_delimiters<const MARKER: char>(
 
     // remove empty node as a small optimization so we can do less work later
     if closer.remaining > 0 {
+        let token_start = closer.content_start;
         closer_token.replace(closer);
-        closer_token
+        (closer_token, token_start)
     } else {
-        state.node.children.pop().unwrap()
+        (state.node.children.pop().unwrap(), matched_token_start)
     }
 }
 

--- a/crates/supramark-markdown/src/parser/inline/state.rs
+++ b/crates/supramark-markdown/src/parser/inline/state.rs
@@ -243,6 +243,27 @@ impl<'a, 'b> InlineState<'a, 'b> {
         self.srcmap[line].1 + (pos - self.srcmap[line].0)
     }
 
+    /// Inverse of [`Self::get_source_pos_for`]: translate a byte offset in the original
+    /// markdown source back into a byte offset in [`Self::src`].
+    ///
+    /// The two coordinate spaces are not interchangeable. `src` is the *content* the inline
+    /// parser walks, and it can be shorter than the source range it came from — a table cell
+    /// hands over `_x|y_` for the source text `_x\|y_`, because the cell scanner drops the
+    /// backslash. Mixing the two spaces silently corrupts source maps and, when the source
+    /// range is the longer one, underflows any offset arithmetic. Rules that read a byte
+    /// offset back out of a [`SourcePos`] must come through here first.
+    #[must_use]
+    pub fn get_pos_for_source(&self, source_pos: usize) -> usize {
+        let line = match self.srcmap.binary_search_by(|x| x.1.cmp(&source_pos)) {
+            Ok(x) => x,
+            Err(x) => x.saturating_sub(1),
+        };
+        let (pos, mapped_source_pos) = self.srcmap[line];
+        // `source_pos` can land inside a byte range that has no counterpart in `src` (the
+        // dropped backslash above). Saturating keeps the result monotonic instead of wrapping.
+        pos + source_pos.saturating_sub(mapped_source_pos)
+    }
+
     #[must_use]
     pub fn get_map(&self, start_pos: usize, end_pos: usize) -> Option<SourcePos> {
         debug_assert!(start_pos <= end_pos);

--- a/crates/supramark-markdown/tests/public_api.rs
+++ b/crates/supramark-markdown/tests/public_api.rs
@@ -664,3 +664,44 @@ fn nests_footnote_definition_inside_blockquote() {
     };
     assert_eq!(label, "a");
 }
+
+#[test]
+fn public_api_maps_emphasis_spanning_an_escape_inside_a_table_cell() {
+    // The table cell scanner hands the inline parser the *unescaped* cell content (`_x|y_`),
+    // which is shorter than the source range it came from (`_x\|y_`). Emphasis matching used to
+    // measure the token in source coordinates and apply it to content coordinates, which
+    // underflowed and aborted the parse. Regression guard for cmark-gfm's "Embedded pipes" case.
+    let source = "| a |\n| - |\n| _x\\|y_ |\n";
+    let ast = parse(source);
+
+    let SupramarkNode::Root { children, .. } = &ast else {
+        panic!("expected root");
+    };
+    let SupramarkNode::Table { children, .. } = &children[0] else {
+        panic!("expected table, got {:?}", &children[0]);
+    };
+    let SupramarkNode::TableRow { children, .. } = &children[1] else {
+        panic!("expected body row, got {:?}", &children[1]);
+    };
+    let SupramarkNode::TableCell { children, .. } = &children[0] else {
+        panic!("expected cell, got {:?}", &children[0]);
+    };
+    let SupramarkNode::Emphasis {
+        children, position, ..
+    } = &children[0]
+    else {
+        panic!("expected emphasis, got {:?}", &children[0]);
+    };
+
+    // The emphasis must be mapped back onto the escaped source text, not the unescaped content.
+    let position = position.as_ref().expect("emphasis position");
+    assert_eq!(
+        &source[position.start.byte_offset..position.end.byte_offset],
+        "_x\\|y_"
+    );
+
+    let SupramarkNode::Text { value, .. } = &children[0] else {
+        panic!("expected text, got {:?}", &children[0]);
+    };
+    assert_eq!(value, "x|y");
+}


### PR DESCRIPTION
Found while looking into the one red check on #130. The `cmark-gfm 语义与视觉对照` job reports `Rust parser did not produce an AST` for the "Embedded pipes" case — that is not a harness problem, the parser panics.

## The bug

```
thread 'main' panicked at crates/supramark-markdown/src/generics/inline/emph_pair.rs:143:
attempt to subtract with overflow
```

Three lines are enough:

```markdown
| a |
| - |
| _x\|y_ |
```

The table cell scanner hands the inline parser the **unescaped** cell content, so `state.src` holds `_x|y_` (5 bytes) for the source text `_x\|y_` (6 bytes), with a `(content_pos, source_pos)` mapping table bridging the two. `InlineState::pos` indexes the content; `Node::srcmap` holds source offsets. They are different coordinate spaces and the sizes do not agree.

`EmphPairScanner::run` mixed them:

```rust
let map = node.srcmap.unwrap().get_byte_offsets();  // source coordinates
state.pos += scanned.length;                        // content coordinates
let token_len = map.1 - map.0;                      // a source-space length
state.pos -= token_len;                             // 5 - 6
```

The escape is the only thing needed to make the two spaces disagree — `| x\|y |` alone is fine, and `~x\|y~` is fine, because only this rule reads a length back out of a srcmap.

Severity is not limited to the test harness. `usize` subtraction overflow only panics in debug builds; a release build wraps to a value near `usize::MAX` and carries on with that as `state.pos`, so the napi and wasm paths get either a panic on the next slice or silently wrong output. cmark-gfm's own test suite is what surfaced it, but nothing about the input is exotic — an escaped pipe inside emphasis inside a table cell is ordinary GFM.

## The fix

Delimiter matching now stays in content coordinates from start to finish, and crosses into source coordinates exactly once, at the end, through `get_map`.

- `EmphMarker` carries `content_start` / `content_end` for the still-unmatched part of its delimiter run. `Node::srcmap` cannot be reused for this, which is the whole point.
- `scan_and_match_delimiters` cuts `marker_len` off those offsets rather than off srcmaps, and returns the resulting token's content start. `run` no longer reads a length back out of a srcmap, so there is nothing left to underflow.
- `InlineState::get_pos_for_source` inverts the existing `get_source_pos_for`, for callers that genuinely need to cross between the spaces.

This also corrects the source maps of the emph nodes created inside the matching loop. They were being mapped twice — `state.get_map` was called with offsets that were already in source coordinates. That was harmless in practice only because the old code used their *difference*, where a constant per-line offset cancels out; the absolute values were wrong for any emphasis not at offset 0. Those maps are now single-mapped and correct.

## Verification

Everything below was run, not reasoned about.

**No behaviour drift on CommonMark.** Failure sets compared case-by-case with and without the patch on the same tree:

| Path | Before | After |
|---|---|---|
| `run-commonmark.mjs` (ast-projection) | 640/652, 12 failures | 640/652, **same 12 ids** — `newly broken: []`, `newly fixed: []` |
| `run-commonmark-visual.mjs` (production-web-renderer-dom) | — | **652/652 semantic, 652/652 visual** |

The visual numbers match what CI reports green on `main`, which is the target `baselines/commonmark.json` is keyed to.

**cmark-gfm goes from 1 execution error to 0.** Run against #130's fixtures, same comparison target CI uses:

| | #130 CI, no patch | local, with patch |
|---|---|---|
| semantic | 644 passed / 57 failed / **1 error** | 644 passed / 58 failed / **0 errors** |
| visual | 672 passed / 29 failed / **1 error** | **673 passed** / 29 failed / **0 errors** |

The case stops crashing and becomes an ordinary semantic mismatch; visually it now actually renders correctly, hence 672 → 673.

**Source maps are right, not just non-crashing.** For the minimal case, `emphasis` maps to `[14,20)` = `_x\|y_` and the inner `text` (`x|y`) maps to `[15,19)` = `x\|y` — i.e. onto the escaped source, which is the point of the mapping table.

**Suite:** `cargo test -p supramark-markdown` — 59 + 27 passing, including a new `public_api` regression test that asserts both the position mapping and the unescaped text value. `cargo fmt --check` clean. `cargo clippy -D warnings` leaves 4 findings in `full_link.rs`, `list.rs` and `reference.rs` that are present on `main` unchanged and untouched by this patch.

## Why this matters for #130

#130 ships no `baselines/cmark-gfm.json`, so its report says `baseline: { configured: false, reason: "baseline-missing" }`. With `FAIL_WORKFLOW` defaulting to true, merging it makes the conformance workflow red on every push to `main` — as a flat "58 not passing", not as "regressed against a baseline".

The normal way out is to record a baseline and ratchet from there, but `update-baseline.mjs` refuses:

```js
if (!summary.visual?.enabled || summary.errors !== 0 || summary.visual.errors !== 0) {
  throw new Error('拒绝更新异常运行基线：必须完成视觉测试且语义、视觉执行错误均为 0。');
}
```

`errors` was exactly 1, and it was this panic. With it fixed both counts are 0 and a baseline can be recorded, so #130 can land green with a working ratchet instead of a permanently red workflow. Landing this first is the cheaper order; nothing here depends on #130.
