### PR TITLE
chore(metadata): sweep remaining dead Actrium/* URLs (package.json, docs, source comments)

### DIFF
--- a/crates/d2-little/packages/web/package.json
+++ b/crates/d2-little/packages/web/package.json
@@ -6,12 +6,12 @@
   "license": "MPL-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/Actrium/d2-little.git",
+    "url": "https://github.com/Actrium/supramark.git",
     "directory": "packages/web"
   },
-  "homepage": "https://github.com/Actrium/d2-little",
+  "homepage": "https://github.com/Actrium/supramark",
   "bugs": {
-    "url": "https://github.com/Actrium/d2-little/issues"
+    "url": "https://github.com/Actrium/supramark/issues"
   },
   "author": "kookyleo <kookyleo@gmail.com>",
   "main": "dist/index.js",

--- a/crates/graphviz-anywhere/CHANGELOG.md
+++ b/crates/graphviz-anywhere/CHANGELOG.md
@@ -184,9 +184,9 @@ Target version: **0.2.0** (cross-target build.rs + asset coverage)
 
 [Unreleased]: https://github.com/Actrium/supramark/compare/v0.2.4...HEAD
 [0.2.4]: https://github.com/Actrium/supramark/compare/v0.2.3...v0.2.4
-[0.2.1]: https://github.com/Actrium/graphviz-anywhere/compare/v0.2.0...v0.2.1
-[0.2.0]: https://github.com/Actrium/graphviz-anywhere/compare/v0.1.8...v0.2.0
-[0.1.8]: https://github.com/Actrium/graphviz-anywhere/releases/tag/v0.1.8
-[0.1.7]: https://github.com/Actrium/graphviz-anywhere/releases/tag/v0.1.7
-[0.1.6]: https://github.com/Actrium/graphviz-anywhere/releases/tag/v0.1.6
-[0.1.5]: https://github.com/Actrium/graphviz-anywhere/releases/tag/v0.1.5
+[0.2.1]: https://github.com/kookyleo/graphviz-anywhere/compare/v0.2.0...v0.2.1
+[0.2.0]: https://github.com/kookyleo/graphviz-anywhere/compare/v0.1.8...v0.2.0
+[0.1.8]: https://github.com/kookyleo/graphviz-anywhere/releases/tag/v0.1.8
+[0.1.7]: https://github.com/kookyleo/graphviz-anywhere/releases/tag/v0.1.7
+[0.1.6]: https://github.com/kookyleo/graphviz-anywhere/releases/tag/v0.1.6
+[0.1.5]: https://github.com/kookyleo/graphviz-anywhere/releases/tag/v0.1.5

--- a/crates/graphviz-anywhere/README.md
+++ b/crates/graphviz-anywhere/README.md
@@ -67,7 +67,7 @@ divergence, see **[docs/cross-compile.md](docs/cross-compile.md)**.
 ### Native build
 
 ```bash
-git clone --recursive https://github.com/Actrium/graphviz-anywhere.git
+git clone --recursive https://github.com/kookyleo/graphviz-anywhere.git
 cd graphviz-anywhere
 
 ./scripts/build-linux.sh
@@ -85,7 +85,7 @@ Build outputs land in `output/<platform>/`.
 > the script otherwise expects `make` and `pkg-config` on `PATH`.
 
 Prebuilt native binaries are published from the current repository namespace:
-[GitHub Releases](https://github.com/Actrium/graphviz-anywhere/releases).
+[GitHub Releases](https://github.com/kookyleo/graphviz-anywhere/releases).
 
 ## C API
 

--- a/crates/graphviz-anywhere/docs/cross-compile.md
+++ b/crates/graphviz-anywhere/docs/cross-compile.md
@@ -173,7 +173,7 @@ GRAPHVIZ_ANYWHERE_DIR=/path/to/lib-dir cargo build --target <triple>
 
 ## Sandboxed / airgapped builds
 
-1. Download the required asset from the [GitHub Release](https://github.com/Actrium/graphviz-anywhere/releases) on a connected machine.
+1. Download the required asset from the [GitHub Release](https://github.com/kookyleo/graphviz-anywhere/releases) on a connected machine.
 2. Extract and place the library where `build.rs` can find it — either:
    - Set `GRAPHVIZ_ANYWHERE_DIR=/path/to/extracted/dir`, or
    - Place `libgraphviz_api.a` (or `.lib` on Windows) under `packages/rust/prebuilt/<os>/`.

--- a/crates/graphviz-anywhere/docs/progress.md
+++ b/crates/graphviz-anywhere/docs/progress.md
@@ -165,7 +165,7 @@ Captured here so they don't get forgotten:
 After 0.2.0 ships on `kookyleo/graphviz-anywhere`:
 
 1. Pull updated subtree into supramark: `git subtree pull --prefix
-   crates/graphviz-anywhere https://github.com/Actrium/graphviz-anywhere
+   crates/graphviz-anywhere https://github.com/kookyleo/graphviz-anywhere
    main`
 2. Update `crates/graphviz-anywhere/UPSTREAM.zh.md` pin (currently
    `436fe2f00bf099416a3e6eea6d1012911d4f7435` / `v0.1.7` — bump to

--- a/crates/graphviz-anywhere/packages/react-native/package.json
+++ b/crates/graphviz-anywhere/packages/react-native/package.json
@@ -9,7 +9,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/Actrium/graphviz-anywhere.git",
+    "url": "https://github.com/Actrium/supramark.git",
     "directory": "packages/react-native"
   },
   "author": "kookyleo <kookyleo@gmail.com>",

--- a/crates/mermaid-little/FEATURES.md
+++ b/crates/mermaid-little/FEATURES.md
@@ -18,7 +18,7 @@ reports **1200 / 1328 byte-exact ≈ 90.4%**.
 | Byte-exact (≥99% pass) | 22 / 25 |
 | Reference tests | 1328 (cypress 1126 + demos 202); `known_ignored.txt` is now empty |
 | Lib unit tests | 666 / 0 / 0 |
-| Layout backend | [`dagre-rs`](https://github.com/Actrium/dagre-rs) (pinned, complete dagre.js port) |
+| Layout backend | [`dagre-rs`](https://github.com/kookyleo/dagre-rs) (pinned, complete dagre.js port) |
 | Tracking doc | [PROGRESS.zh.md](PROGRESS.zh.md) (Chinese only, by project rule) |
 
 ## Upstream Dependency Survey
@@ -28,7 +28,7 @@ Rust side:
 
 | Upstream JS dep | Used for | mermaid-little strategy |
 |---|---|---|
-| `dagre-d3-es` | default flowchart / class / state / er layout | **Use [`dagre-rs`](https://github.com/Actrium/dagre-rs)** — complete Rust port, cross-validated byte-exact against dagre.js. Plus 2 small geometric helpers (`intersectPolygon`, `intersectRect`) to port. |
+| `dagre-d3-es` | default flowchart / class / state / er layout | **Use [`dagre-rs`](https://github.com/kookyleo/dagre-rs)** — complete Rust port, cross-validated byte-exact against dagre.js. Plus 2 small geometric helpers (`intersectPolygon`, `intersectRect`) to port. |
 | `@mermaid-js/parser` | langium grammars for 7 newer diagrams | Rewrite each grammar as a hand-written Rust parser (nom / chumsky style). |
 | Jison files under `packages/mermaid/src/diagrams/*/parser/` | jison grammars for 18 legacy diagrams | Same — port each jison grammar to a hand-written Rust parser. |
 | `d3` + submodules | generic SVG primitives, drag / zoom | **Not needed** — we emit SVG strings directly, no runtime DOM. |

--- a/crates/mermaid-little/FEATURES.zh.md
+++ b/crates/mermaid-little/FEATURES.zh.md
@@ -15,7 +15,7 @@
 | 已 byte-exact（≥99% pass） | 22 / 25 |
 | Reference 测试 | 1328 条（cypress 1126 + demos 202），known_ignored 已清空 |
 | Lib unit tests | 666 / 0 / 0 |
-| Layout 后端 | [`dagre-rs`](https://github.com/Actrium/dagre-rs)（pinned，完整 dagre.js port） |
+| Layout 后端 | [`dagre-rs`](https://github.com/kookyleo/dagre-rs)（pinned，完整 dagre.js port） |
 | 详细进展 | 见 [PROGRESS.zh.md](PROGRESS.zh.md) |
 
 ## 上游依赖勘察
@@ -24,7 +24,7 @@
 
 | 上游 JS 依赖 | 用途 | mermaid-little 策略 |
 |---|---|---|
-| `dagre-d3-es` | flowchart / class / state / er 默认 layout | **使用 [`dagre-rs`](https://github.com/Actrium/dagre-rs)** —— 完整 Rust port，已对 dagre.js byte-exact 交叉验证通过。外加两个小几何辅助函数（`intersectPolygon`、`intersectRect`）需要补齐。 |
+| `dagre-d3-es` | flowchart / class / state / er 默认 layout | **使用 [`dagre-rs`](https://github.com/kookyleo/dagre-rs)** —— 完整 Rust port，已对 dagre.js byte-exact 交叉验证通过。外加两个小几何辅助函数（`intersectPolygon`、`intersectRect`）需要补齐。 |
 | `@mermaid-js/parser` | 7 种较新 diagram 的 langium grammar | 每个 grammar 重写成手写 Rust parser（nom / chumsky 风格）。 |
 | `packages/mermaid/src/diagrams/*/parser/*.jison` | 18 种老 diagram 的 jison grammar | 同上，每个 jison 规则都手动 port。 |
 | `d3` 及子模块 | 通用 SVG 原语、拖拽、缩放 | **不需要** —— 我们直接拼 SVG 字符串，零运行时 DOM。 |

--- a/crates/mermaid-little/README.md
+++ b/crates/mermaid-little/README.md
@@ -10,9 +10,9 @@ targeting byte-exact SVG output parity with upstream `mermaid@11.14.0`.
 mermaid-little takes `.mmd` source text and produces `.svg` output —
 the same as Mermaid, but as a native Rust library + CLI with **zero
 JS / DOM dependency at runtime**. Sibling project to
-[plantuml-little](https://github.com/Actrium/plantuml-little) and built
+[plantuml-little](https://github.com/kookyleo/plantuml-little) and built
 on top of the complete dagre.js port at
-[dagre-rs](https://github.com/Actrium/dagre-rs).
+[dagre-rs](https://github.com/kookyleo/dagre-rs).
 
 ## Status
 
@@ -45,10 +45,10 @@ deeply appreciate the Mermaid team's work in making diagram-as-code
 accessible to everyone. All specification-level behavior follows the
 upstream standard.
 
-The layout backend is [`dagre-rs`](https://github.com/Actrium/dagre-rs),
+The layout backend is [`dagre-rs`](https://github.com/kookyleo/dagre-rs),
 a complete Rust port of dagre.js. The font metric pipeline
 (`src/font_data.rs`, `src/font_metrics.rs`) is vendored from the sister
-project [plantuml-little](https://github.com/Actrium/plantuml-little) —
+project [plantuml-little](https://github.com/kookyleo/plantuml-little) —
 the same DejaVu Sans glyph advance tables anchor both projects, which
 keeps byte-exact output consistent across the two codebases.
 

--- a/crates/mermaid-little/README.zh.md
+++ b/crates/mermaid-little/README.zh.md
@@ -6,7 +6,7 @@
 
 ## 这是什么
 
-mermaid-little 读取 `.mmd` 源文本，输出 `.svg` —— 与 Mermaid 功能相同，但以原生 Rust 库 + CLI 形态运行，**运行时零 JS / DOM 依赖**。姊妹项目是 [plantuml-little](https://github.com/Actrium/plantuml-little)，布局后端构建在完整的 dagre.js port [dagre-rs](https://github.com/Actrium/dagre-rs) 之上。
+mermaid-little 读取 `.mmd` 源文本，输出 `.svg` —— 与 Mermaid 功能相同，但以原生 Rust 库 + CLI 形态运行，**运行时零 JS / DOM 依赖**。姊妹项目是 [plantuml-little](https://github.com/kookyleo/plantuml-little)，布局后端构建在完整的 dagre.js port [dagre-rs](https://github.com/kookyleo/dagre-rs) 之上。
 
 ## 当前状态
 
@@ -18,7 +18,7 @@ mermaid-little 读取 `.mmd` 源文本，输出 `.svg` —— 与 Mermaid 功能
 | `convert_with_id` 已接线 | **25 / 25** diagram |
 | 已 byte-exact (≥99%) | 22 / 25（pie / packet / radar / ishikawa / journey / timeline / quadrant / xychart / wardley / sankey / treemap / kanban / c4 / er / block / requirement / class / state / gitGraph / gantt / venn / flowchart） |
 | 主要剩余阻塞 | sequence (51/150)、mindmap multi-node (7/25)、KaTeX × 6、icon shapes × 1、handDrawn venn × 3 |
-| Layout 后端 | [`dagre-rs`](https://github.com/Actrium/dagre-rs) |
+| Layout 后端 | [`dagre-rs`](https://github.com/kookyleo/dagre-rs) |
 | Reference 测试 | `cargo run --bin sweep_all` 单文件全量 sweep；known_ignored 列表已清空，所有失败均暴露 |
 | 跟踪文档 | [PROGRESS.zh.md](PROGRESS.zh.md)、[docs/stratum3_execution_guide.zh.md](docs/stratum3_execution_guide.zh.md) |
 
@@ -33,7 +33,7 @@ mermaid-little 读取 `.mmd` 源文本，输出 `.svg` —— 与 Mermaid 功能
 
 本项目是 [Mermaid](https://mermaid.js.org/) 的独立 Rust 重新实现，原作者为 Knut Sveidqvist。我们对 Mermaid 团队在 diagram-as-code 领域的贡献深表敬意。所有规范性内容以上游为标准。
 
-布局后端使用 [`dagre-rs`](https://github.com/Actrium/dagre-rs)——dagre.js 的完整 Rust port。字体度量管线（`src/font_data.rs`、`src/font_metrics.rs`）vendor 自姊妹项目 [plantuml-little](https://github.com/Actrium/plantuml-little)——两个项目共用同一张 DejaVu Sans glyph advance 表，保证两处输出的 byte-exact 一致。
+布局后端使用 [`dagre-rs`](https://github.com/kookyleo/dagre-rs)——dagre.js 的完整 Rust port。字体度量管线（`src/font_data.rs`、`src/font_metrics.rs`）vendor 自姊妹项目 [plantuml-little](https://github.com/kookyleo/plantuml-little)——两个项目共用同一张 DejaVu Sans glyph advance 表，保证两处输出的 byte-exact 一致。
 
 同时感谢社区已有的 Rust mermaid port 作为 prior art：[mermaid-rs-renderer (mmdr)](https://github.com/1jehuang/mermaid-rs-renderer)、[selkie](https://github.com/btucker/selkie)、[mmdflux](https://github.com/kevinswiber/mmdflux)。mermaid-little 选的 trade-off 点不同（先追求与上游 byte-exact 一致，再谈性能），但具体 diagram 卡壳时我们会参考他们的源码实现，参考时会在相关 commit message 里明确声明。
 

--- a/crates/mermaid-little/UPSTREAM.md
+++ b/crates/mermaid-little/UPSTREAM.md
@@ -62,7 +62,7 @@ sub-tree to bring it into structural parity with `plantuml-little` and
 | `Cargo.toml` (root crate) | edited | added `version = "0.1"` constraint to the `dagre` git dep so cargo-deny accepts it as a non-wildcard. Net behaviour identical because the supramark workspace root `[patch."https://github.com/Actrium/dagre-rs.git"]` redirects to in-tree `crates/dagre`. |
 
 **Upstream PR plan:** open a PR against
-`https://github.com/Actrium/mermaid-little` proposing this directory
+`https://github.com/kookyleo/mermaid-little` proposing this directory
 verbatim. When upstream merges, we resolve any `subtree pull` conflict
 by accepting upstream's version. If upstream takes a different shape
 (e.g. different package name), align supramark to match.

--- a/crates/mermaid-little/docs/dagre_rs_inconsistency_report.zh.md
+++ b/crates/mermaid-little/docs/dagre_rs_inconsistency_report.zh.md
@@ -2,7 +2,7 @@
 
 > 基于 mermaid-little 项目测试结果，截至 Wave 6 初期。
 > 上游参照：mermaid@11.14.0 使用 dagre-d3-es@7.0.14（dagre.js 的特定封装版本）。
-> 本项目使用：[dagre-rs](https://github.com/Actrium/dagre-rs)（dagre.js 的 Rust port）。
+> 本项目使用：[dagre-rs](https://github.com/kookyleo/dagre-rs)（dagre.js 的 Rust port）。
 
 ---
 

--- a/crates/mermaid-little/packages/web/README.md
+++ b/crates/mermaid-little/packages/web/README.md
@@ -1,7 +1,7 @@
 # `@actrium/mermaid-little-web`
 
 wasm-bindgen wrapper around the
-[`mermaid-little`](https://github.com/Actrium/mermaid-little) Rust crate.
+[`mermaid-little`](https://github.com/kookyleo/mermaid-little) Rust crate.
 Run [Mermaid](https://mermaid.js.org/) diagrams to SVG in the browser,
 Web Workers, or any wasm-capable runtime — no DOM, no headless browser,
 no JS-side Mermaid bundle.
@@ -44,6 +44,6 @@ This package is part of the
 [supramark](https://github.com/Actrium/supramark) super-monorepo (path:
 `crates/mermaid-little/packages/web/`). It originated **inside the
 super-monorepo as a downstream patch** to the
-[`mermaid-little`](https://github.com/Actrium/mermaid-little) sub-tree;
+[`mermaid-little`](https://github.com/kookyleo/mermaid-little) sub-tree;
 see `crates/mermaid-little/UPSTREAM.md` for the contribution path back
 to the standalone repo.

--- a/crates/mermaid-little/packages/web/package.json
+++ b/crates/mermaid-little/packages/web/package.json
@@ -6,12 +6,12 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/Actrium/mermaid-little.git",
+    "url": "https://github.com/Actrium/supramark.git",
     "directory": "packages/web"
   },
-  "homepage": "https://github.com/Actrium/mermaid-little",
+  "homepage": "https://github.com/Actrium/supramark",
   "bugs": {
-    "url": "https://github.com/Actrium/mermaid-little/issues"
+    "url": "https://github.com/Actrium/supramark/issues"
   },
   "author": "kookyleo <kookyleo@gmail.com>",
   "main": "dist/index.js",

--- a/crates/mermaid-little/src/config/directive.rs
+++ b/crates/mermaid-little/src/config/directive.rs
@@ -23,7 +23,7 @@
 //! quote- and brace-depth aware so a directive body containing an
 //! embedded `}%%` inside a string literal isn't severed mid-block.
 //!
-//! Portions adapted from mmdflux (<https://github.com/Actrium/mmdflux>,
+//! Portions adapted from mmdflux (<https://github.com/kevinswiber/mmdflux>,
 //! MIT license). Specifically: the realisation that handling quoted
 //! strings vs. brace-depth by hand — instead of via regex backrefs — is
 //! the only way to stay sane when a directive body contains nested

--- a/crates/mermaid-little/src/config/frontmatter.rs
+++ b/crates/mermaid-little/src/config/frontmatter.rs
@@ -12,7 +12,7 @@
 //! matching upstream's behaviour of only lifting `parsed.title` /
 //! `parsed.displayMode` / `parsed.config` into the metadata struct.
 //!
-//! Portions adapted from mmdflux (<https://github.com/Actrium/mmdflux>,
+//! Portions adapted from mmdflux (<https://github.com/kevinswiber/mmdflux>,
 //! MIT license). Specifically: the intuition around hand-scanning
 //! `---\n...\n---` blocks when the wrapping regex misbehaves on CRLF /
 //! indented-`---` edge cases — though this file uses a regex that

--- a/crates/mermaid-little/src/model/richtext.rs
+++ b/crates/mermaid-little/src/model/richtext.rs
@@ -1,7 +1,7 @@
 //! Rich-text span types used by label parsers.
 //!
 //! `TextSpan` enum adapted from plantuml-little
-//! (https://github.com/Actrium/plantuml-little) at commit b32d6aa,
+//! (https://github.com/kookyleo/plantuml-little) at commit b32d6aa,
 //! MIT-compatible multi-license. Trimmed to the subset mermaid's
 //! label markup exercises.
 

--- a/crates/mermaid-little/src/text.rs
+++ b/crates/mermaid-little/src/text.rs
@@ -1,6 +1,6 @@
 //! Text helpers — CJK double-width classification etc.
 //!
-//! Vendored from plantuml-little (https://github.com/Actrium/plantuml-little)
+//! Vendored from plantuml-little (https://github.com/kookyleo/plantuml-little)
 //! at commit b32d6aa, MIT-compatible multi-license.
 
 /// Extract the plain-text content that `markdownToHTML` would produce from a

--- a/crates/plantuml-little/README.md
+++ b/crates/plantuml-little/README.md
@@ -27,7 +27,7 @@ Reference tests compare the SVG plantuml-little emits against an upstream-genera
 
 Two Graphviz execution modes are supported:
 
-- `native` (default): links against [`graphviz-anywhere`](https://github.com/Actrium/graphviz-anywhere)'s prebuilt `libgraphviz_api` — fast, no Node required; recommended for `cargo test --lib` / day-to-day development.
+- `native` (default): links against [`graphviz-anywhere`](https://github.com/kookyleo/graphviz-anywhere)'s prebuilt `libgraphviz_api` — fast, no Node required; recommended for `cargo test --lib` / day-to-day development.
 - `wasm` (opt-in via `PLANTUML_LITTLE_TEST_BACKEND=wasm`): spawns the same Node/wasm runner the Java reference pipeline uses; this is what CI runs for `test-reference` to guarantee cross-platform determinism.
 
 > **Font prerequisite for the `native` backend on non-Linux hosts.** The native Graphviz build measures real text through pango/fontconfig, so the reference baselines only reproduce byte-exact on a machine where fontconfig resolves `DejaVu Sans` to the same font the baselines were generated with. A fresh macOS has no DejaVu installed, so fontconfig silently falls back to a system face (e.g. Hiragino Sans) — that shifts `textLength` and layout coordinates by a pixel or two and the reference tests fail even though nothing is wrong with the code. Install DejaVu before running the native reference suite:
@@ -138,7 +138,7 @@ let svg = plantuml_little::convert(puml_source)?;
 ## Prerequisites
 
 - Rust 1.82+
-- [`graphviz-anywhere`](https://github.com/Actrium/graphviz-anywhere) prebuilt native lib (fetched automatically in CI; locally point `GRAPHVIZ_ANYWHERE_DIR` at an extracted release tarball)
+- [`graphviz-anywhere`](https://github.com/kookyleo/graphviz-anywhere) prebuilt native lib (fetched automatically in CI; locally point `GRAPHVIZ_ANYWHERE_DIR` at an extracted release tarball)
 - For the wasm test backend (`PLANTUML_LITTLE_TEST_BACKEND=wasm`): Node 22+ and `cd tests/support && npm install`
 - For regenerating reference SVGs locally: JDK 21+, DejaVu Sans fonts (`apt install fonts-dejavu-core` on Linux), and a `plantuml-1.2026.2.jar` — or use the `regenerate-refs.yml` workflow which sets all of that up on `ubuntu-latest`
 

--- a/crates/plantuml-little/README.zh.md
+++ b/crates/plantuml-little/README.zh.md
@@ -27,7 +27,7 @@ Reference 测试对 `tests/fixtures/` 下每个 puml 用例的实际 SVG 输出�
 
 Graphviz 有两种执行模式：
 
-- `native`（默认）：链接 [`graphviz-anywhere`](https://github.com/Actrium/graphviz-anywhere) 的预编译 `libgraphviz_api`，速度快、无需 Node；日常 `cargo test --lib` / 开发调试推荐此模式。
+- `native`（默认）：链接 [`graphviz-anywhere`](https://github.com/kookyleo/graphviz-anywhere) 的预编译 `libgraphviz_api`，速度快、无需 Node；日常 `cargo test --lib` / 开发调试推荐此模式。
 - `wasm`（通过 `PLANTUML_LITTLE_TEST_BACKEND=wasm` 开启）：启动与 Java reference 管线相同的 Node/wasm runner；CI 的 `test-reference` 任务采用这种模式以保证跨平台可重放。
 
 > **非 Linux 主机上跑 `native` 后端的字体前置条件。** native 的 Graphviz 构建会经 pango/fontconfig 真实测量文本，因此只有当 fontconfig 把 `DejaVu Sans` 解析到与基线生成时相同的字体，reference 基线才能逐字复现。全新的 macOS 没装 DejaVu，fontconfig 会静默回落到系统字体（例如 Hiragino Sans）——这会让 `textLength` 与布局坐标偏移一两个像素，于是代码明明没问题、reference 测试却挂掉。跑 native reference 套件前先装 DejaVu：
@@ -136,7 +136,7 @@ let svg = plantuml_little::convert(puml_source)?;
 ## 前置条件
 
 - Rust 1.82+
-- [`graphviz-anywhere`](https://github.com/Actrium/graphviz-anywhere) 预编译原生库（CI 自动拉取；本地将 `GRAPHVIZ_ANYWHERE_DIR` 指向解压后的 release tarball）
+- [`graphviz-anywhere`](https://github.com/kookyleo/graphviz-anywhere) 预编译原生库（CI 自动拉取；本地将 `GRAPHVIZ_ANYWHERE_DIR` 指向解压后的 release tarball）
 - 启用 wasm 测试后端（`PLANTUML_LITTLE_TEST_BACKEND=wasm`）时：Node 22+，并执行 `cd tests/support && npm install`
 - 本地重新生成 reference SVG 时：JDK 21+、DejaVu Sans 字体（Linux 上 `apt install fonts-dejavu-core`）、以及一份 `plantuml-1.2026.2.jar`——或直接使用 `regenerate-refs.yml` 工作流在 `ubuntu-latest` 上一键搞定
 

--- a/crates/plantuml-little/packages/web/package.json
+++ b/crates/plantuml-little/packages/web/package.json
@@ -6,12 +6,12 @@
   "license": "GPL-3.0-or-later OR LGPL-3.0-or-later OR Apache-2.0 OR EPL-2.0 OR MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/Actrium/plantuml-little.git",
+    "url": "https://github.com/Actrium/supramark.git",
     "directory": "packages/web"
   },
-  "homepage": "https://github.com/Actrium/plantuml-little",
+  "homepage": "https://github.com/Actrium/supramark",
   "bugs": {
-    "url": "https://github.com/Actrium/plantuml-little/issues"
+    "url": "https://github.com/Actrium/supramark/issues"
   },
   "author": "kookyleo <kookyleo@gmail.com>",
   "main": "dist/index.js",

--- a/crates/vison/vison-renderers/rn/package.json
+++ b/crates/vison/vison-renderers/rn/package.json
@@ -6,10 +6,10 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/Actrium/vison.git",
+    "url": "https://github.com/Actrium/supramark.git",
     "directory": "vison-renderers/rn"
   },
-  "homepage": "https://github.com/Actrium/vison",
+  "homepage": "https://github.com/Actrium/supramark",
   "author": "kookyleo <kookyleo@gmail.com>",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/crates/vison/vison-renderers/web/package.json
+++ b/crates/vison/vison-renderers/web/package.json
@@ -6,10 +6,10 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/Actrium/vison.git",
+    "url": "https://github.com/Actrium/supramark.git",
     "directory": "vison-renderers/web"
   },
-  "homepage": "https://github.com/Actrium/vison",
+  "homepage": "https://github.com/Actrium/supramark",
   "author": "kookyleo <kookyleo@gmail.com>",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/packages/features/cards/vison/README.md
+++ b/packages/features/cards/vison/README.md
@@ -1,7 +1,7 @@
 # `@supramark/feature-card-vison`
 
 Renders `:::vison` container blocks in Markdown as
-[Vison](https://github.com/Actrium/vison) cards — a JSON visual
+[Vison](https://github.com/kookyleo/vison) cards — a JSON visual
 description spec for AI chat UIs.
 
 ## Install

--- a/packages/features/cards/vison/src/feature.ts
+++ b/packages/features/cards/vison/src/feature.ts
@@ -13,7 +13,7 @@ import { visonExamples } from './examples.js';
  *
  * Adds support for `:::vison` container blocks. The body of the
  * container is parsed as a Vison JSON spec
- * (see https://github.com/Actrium/vison) and exposed on the AST node
+ * (see https://github.com/kookyleo/vison) and exposed on the AST node
  * as `data.spec`. Hosts pair this feature with the `vison`
  * containerRenderer entry from `runtime.web` / `runtime.rn` to render
  * the spec as a card.
@@ -183,7 +183,7 @@ export const visonFeature: SupramarkFeature<SupramarkVisonContainerNode> = {
 
 Renders \`:::vison\` container blocks as Vison cards. The body of the
 container is parsed as Vison JSON (see
-[vison spec](https://github.com/Actrium/vison)) and exposed on the
+[vison spec](https://github.com/kookyleo/vison)) and exposed on the
 AST node as \`data.spec\`.
 
 ## Wiring


### PR DESCRIPTION
Follow-up to #142 (3b840fc1), which fixed the published `Cargo.toml` metadata and five `UPSTREAM.md` files. This completes the remaining source-side sweep items from #138.

## What changed

- **package.json** `repository`/`homepage`/`bugs.url` in `d2-little`, `mermaid-little`, `plantuml-little` (web), `vison` (web + rn), and `graphviz-anywhere` (rn) now point at `Actrium/supramark`, matching the `Cargo.toml` fix.
- **README / FEATURES / docs** sibling-project references (`dagre-rs`, `plantuml-little`, `mermaid-little`, `graphviz-anywhere`, `vison`) now point at the archived `kookyleo/{repo}` upstreams, whose descriptions carry a "Moved to Actrium/supramark" pointer — links resolve and provenance is preserved.
- **CHANGELOG** compare/release links in `graphviz-anywhere` → `kookyleo/graphviz-anywhere` (archived repo retains tags).
- **`mmdflux` attribution** in `mermaid-little/src/config/{directive,frontmatter}.rs` corrected to its real upstream `kevinswiber/mmdflux` — verified `src/mermaid/theme_hint.rs::split_top_level_members` exists there, matching the existing comment.

## Left untouched on purpose

- The quoted `[patch."https://github.com/Actrium/dagre-rs.git"]` directive in `mermaid-little/UPSTREAM.md:62` — it's a historical record of the upstream's manifest, not a browsable link.
- Functional fetch URLs in `build.rs` (already `Actrium/supramark`) and root `README.md` CI/codecov badges.
- `Cargo.toml` `[patch]`/git-dep URLs (already handled by #142).

## Verification

```
# dead-URL sweep — only the intentionally-preserved UPSTREAM.md:62 quote remains
git grep -nE 'Actrium/(dagre-rs|d2-little|mermaid-little|plantuml-little|vison|graphviz-anywhere|mmdflux)' -- '*.json' '*.md' '*.rs' '*.ts'

cargo metadata --no-deps --format-version 1 >/dev/null   # OK
# all touched package.json validated as JSON
```

Diff: 25 files, 50/50 insertions/deletions (pure URL string swaps — no behaviour change).

## Issue #138 status

Source-side sweep is now complete. **The issue should stay open until the affected crates are republished** so crates.io picks up the corrected metadata (crates.io metadata is immutable per published version). That republish step is out of scope for this PR.

Refs #138 (not `Closes` — republish pending)