### PR TITLE
fix(footnote,emoji): re-export feature config helpers from index.ts

### DIFF
--- a/packages/features/main/emoji/src/index.ts
+++ b/packages/features/main/emoji/src/index.ts
@@ -4,7 +4,13 @@
  * @packageDocumentation
  */
 
-export { emojiFeature } from './feature.js';
+export {
+  emojiFeature,
+  type EmojiFeatureOptions,
+  type EmojiFeatureConfig,
+  createEmojiFeatureConfig,
+  getEmojiFeatureOptions,
+} from './feature.js';
 export { emojiExamples } from './examples.js';
 
 // Note: the Emoji Feature uses the standard SupramarkTextNode.

--- a/packages/features/main/footnote/src/index.ts
+++ b/packages/features/main/footnote/src/index.ts
@@ -4,7 +4,13 @@
  * @packageDocumentation
  */
 
-export { footnoteFeature } from './feature.js';
+export {
+  footnoteFeature,
+  type FootnoteFeatureOptions,
+  type FootnoteFeatureConfig,
+  createFootnoteFeatureConfig,
+  getFootnoteFeatureOptions,
+} from './feature.js';
 export { footnoteExamples } from './examples.js';
 
 // Re-export core types (for user convenience)


### PR DESCRIPTION
## Summary

- `footnote` and `emoji` feature packages define their config helpers (`createFootnoteFeatureConfig` / `getFootnoteFeatureOptions` and emoji equivalents) plus `*FeatureOptions` / `*FeatureConfig` types in `feature.ts`, but their package entry `index.ts` did not re-export them.
- Consumers importing from the package root (`@supramark/feature-footnote` / `@supramark/feature-emoji`) could not reach these helpers — inconsistent with every sibling feature (`math`, `gfm`, `core-markdown`, `definition-list`, `html-page`, `map`).
- Mirrors the re-export pattern already used in `packages/features/main/math/src/index.ts`.

## Test plan

- [x] `bun run build` (tsc --emitDeclarationOnly) passes for both packages
- [x] `bun run features:lint` — 21/21 features pass

Closes #146