### PR TITLE
refactor(weather): dedup getMockWeather across web and RN runtimes

### DIFF
--- a/packages/features/containers/weather/src/mock-weather.ts
+++ b/packages/features/containers/weather/src/mock-weather.ts
@@ -1,0 +1,59 @@
+/**
+ * Weather mock data derivation (shared layer)
+ *
+ * Contains only platform-agnostic derivation logic (temperature / humidity /
+ * wind / condition index). The concrete condition representation (web semantic
+ * key / RN emoji) is mapped by each runtime and is intentionally not coupled
+ * here — see WEB_CONDITIONS in runtime.web.tsx and RN_CONDITIONS in
+ * runtime.rn.tsx.
+ *
+ * A real app should replace this with a real weather API call.
+ *
+ * @packageDocumentation
+ */
+
+/**
+ * Return type of getMockWeather
+ */
+export interface MockWeather {
+  /** Temperature (already converted per units) */
+  temp: number;
+  /** Temperature unit label, e.g. '°C' / '°F' */
+  unit: string;
+  /**
+   * Condition index (0..2), derived from the location hash.
+   * Each runtime maps it to its own platform representation.
+   */
+  conditionIndex: number;
+  /** Humidity (%) */
+  humidity: number;
+  /** Wind speed (already converted per units) */
+  wind: number;
+  /** Wind unit label, e.g. 'km/h' / 'mph' */
+  windUnit: string;
+}
+
+/**
+ * Derive deterministic mock weather data from a location name.
+ *
+ * The same location always derives the same result (pure function, no side
+ * effects).
+ */
+export function getMockWeather(
+  location: string,
+  units: 'metric' | 'imperial' = 'metric',
+): MockWeather {
+  // Derive a pseudo-random temperature from the location name
+  const hash = location.split('').reduce((acc, c) => acc + c.charCodeAt(0), 0);
+  const baseTemp = 15 + (hash % 20);
+  const temp = units === 'imperial' ? Math.round(baseTemp * 1.8 + 32) : baseTemp;
+  const unit = units === 'imperial' ? '°F' : '°C';
+
+  const conditionIndex = hash % 3;
+
+  const humidity = 40 + (hash % 40);
+  const wind = 5 + (hash % 20);
+  const windUnit = units === 'imperial' ? 'mph' : 'km/h';
+
+  return { temp, unit, conditionIndex, humidity, wind, windUnit };
+}

--- a/packages/features/containers/weather/src/runtime.rn.tsx
+++ b/packages/features/containers/weather/src/runtime.rn.tsx
@@ -8,27 +8,17 @@
 
 import React from 'react';
 import { View, Text, StyleSheet } from 'react-native';
+import { getMockWeather } from './mock-weather.js';
 import type { ContainerRNRenderArgs } from '@supramark/core';
 import type { WeatherData } from './feature.js';
 
 /**
- * Mock weather data (a real app should call a weather API)
+ * condition index → RN emoji (platform-specific, not in shared layer)
+ *
+ * Shared derivation (temp/humidity/wind/conditionIndex) lives in
+ * mock-weather.ts; this only maps the condition for this platform.
  */
-function getMockWeather(location: string, units: 'metric' | 'imperial' = 'metric') {
-  const hash = location.split('').reduce((acc, c) => acc + c.charCodeAt(0), 0);
-  const baseTemp = 15 + (hash % 20);
-  const temp = units === 'imperial' ? Math.round(baseTemp * 1.8 + 32) : baseTemp;
-  const unit = units === 'imperial' ? '°F' : '°C';
-
-  const conditions = ['☀️', '☁️', '🌧️'] as const;
-  const condition = conditions[hash % 3];
-
-  const humidity = 40 + (hash % 40);
-  const wind = 5 + (hash % 20);
-  const windUnit = units === 'imperial' ? 'mph' : 'km/h';
-
-  return { temp, unit, condition, humidity, wind, windUnit };
-}
+const RN_CONDITIONS = ['☀️', '☁️', '🌧️'] as const;
 
 const localStyles = StyleSheet.create({
   container: {
@@ -153,7 +143,7 @@ export function renderWeatherContainerRN({
         <Text style={localStyles.format}>{format.toUpperCase()}</Text>
       </View>
       <View style={localStyles.main}>
-        <Text style={localStyles.icon}>{weather.condition}</Text>
+        <Text style={localStyles.icon}>{RN_CONDITIONS[weather.conditionIndex]}</Text>
         <Text style={localStyles.temp}>
           {weather.temp}
           <Text style={localStyles.unit}>{weather.unit}</Text>

--- a/packages/features/containers/weather/src/runtime.web.tsx
+++ b/packages/features/containers/weather/src/runtime.web.tsx
@@ -7,6 +7,7 @@
  */
 
 import React from 'react';
+import { getMockWeather } from './mock-weather.js';
 import type { ContainerWebRenderArgs } from '@supramark/core';
 import type { WeatherData } from './feature.js';
 
@@ -52,24 +53,12 @@ function WeatherIcon({ type }: { type: 'sunny' | 'cloudy' | 'rainy' }) {
 }
 
 /**
- * Mock weather data (a real app should call a weather API)
+ * condition index → web semantic key (platform-specific, not in shared layer)
+ *
+ * Shared derivation (temp/humidity/wind/conditionIndex) lives in
+ * mock-weather.ts; this only maps the condition for this platform.
  */
-function getMockWeather(location: string, units: 'metric' | 'imperial' = 'metric') {
-  // Derive a pseudo-random temperature from the location name
-  const hash = location.split('').reduce((acc, c) => acc + c.charCodeAt(0), 0);
-  const baseTemp = 15 + (hash % 20);
-  const temp = units === 'imperial' ? Math.round(baseTemp * 1.8 + 32) : baseTemp;
-  const unit = units === 'imperial' ? '°F' : '°C';
-
-  const conditions = ['sunny', 'cloudy', 'rainy'] as const;
-  const condition = conditions[hash % 3];
-
-  const humidity = 40 + (hash % 40);
-  const wind = 5 + (hash % 20);
-  const windUnit = units === 'imperial' ? 'mph' : 'km/h';
-
-  return { temp, unit, condition, humidity, wind, windUnit };
-}
+const WEB_CONDITIONS = ['sunny', 'cloudy', 'rainy'] as const;
 
 const styles: Record<string, React.CSSProperties> = {
   container: {
@@ -181,7 +170,7 @@ export function renderWeatherContainerWeb({
         <span style={styles.format}>{format.toUpperCase()}</span>
       </div>
       <div style={styles.main}>
-        <WeatherIcon type={weather.condition} />
+        <WeatherIcon type={WEB_CONDITIONS[weather.conditionIndex]} />
         <p style={styles.temp}>
           {weather.temp}
           <span style={{ fontSize: '24px' }}>{weather.unit}</span>


### PR DESCRIPTION
## Summary

Closes #147.

The weather feature's `getMockWeather` was duplicated verbatim between `runtime.web.tsx` and `runtime.rn.tsx`, with the `condition` field silently drifted between them — web returns a semantic key (`'sunny'|'cloudy'|'rainy'`) consumed by `WeatherIcon`; RN returns the emoji glyph directly. Per the issue's suggested fix, this factors the platform-agnostic derivation logic into a shared module and lets each runtime keep its own condition representation.

## Changes

- **New** `src/mock-weather.ts` — shared `getMockWeather(location, units)` returning `{ temp, unit, conditionIndex, humidity, wind, windUnit }`. Pure function, no platform imports (no React / DOM / RN), safe to consume from both runtimes. `condition` is intentionally **not** part of the shared contract — only its index is.
- `runtime.web.tsx` — drops the local `getMockWeather`; keeps its local `WEB_CONDITIONS = ['sunny','cloudy','rainy']` and maps `conditionIndex` → semantic key for `WeatherIcon`. The existing `|| icons.sunny` fallback is preserved.
- `runtime.rn.tsx` — drops the local `getMockWeather`; keeps its local `RN_CONDITIONS = ['☀️','☁️','🌧️']` and maps `conditionIndex` → emoji.

Each platform still owns its condition presentation; only the derivation logic (and the `hash % 3` index) is now single-sourced.

## Behavior

Zero behavior change. `hash`, `temp`, `humidity`, `wind`, `windUnit` are identical, and `conditionIndex = hash % 3` matches the previous `hash % 3` indexing on both sides, with condition-array order unchanged.

## Test plan

- [x] `bun --filter @supramark/feature-weather build` — tsc passes (exit 0)
- [x] `bun --filter @supramark/feature-weather test` — 5 pass / 0 fail (8 expect calls)
- [x] `bun run feature:lint weather` — 14/14 checks pass, score 100/100
- [ ] Web runtime visual check (`:::weather` container renders same SVG icon + temp/details) — needs host app
- [ ] RN runtime visual check (emoji + temp/details) — needs host app / device
