### PR TITLE
fix(rn): render-cache follow-ups from #92 review

### DIFF
--- a/packages/core/__tests__/cache.test.ts
+++ b/packages/core/__tests__/cache.test.ts
@@ -109,6 +109,81 @@ describe('LRUCache', () => {
       expect(stats.totalSize).toBeGreaterThan(0);
     });
   });
+
+  describe('byte-aware eviction (#124)', () => {
+    it('evicts oldest entries once totalSize exceeds maxBytes', () => {
+      const cache = new LRUCache<string>({
+        maxSize: 100,
+        maxBytes: 10,
+        sizeCalculator: value => value.length,
+      });
+      cache.set('a', 'aaaa'); // 4 bytes, total 4
+      cache.set('b', 'aaaa'); // 4 bytes, total 8
+      expect(cache.get('a')).toBe('aaaa'); // touch a so b is older
+      cache.set('c', 'aaaa'); // 4 bytes, total 12 > 10 -> evict b
+      expect(cache.get('a')).toBe('aaaa');
+      expect(cache.get('b')).toBeUndefined();
+      expect(cache.get('c')).toBe('aaaa');
+    });
+
+    it('retains a single entry larger than maxBytes rather than dropping it', () => {
+      const cache = new LRUCache<string>({
+        maxSize: 100,
+        maxBytes: 5,
+        sizeCalculator: value => value.length,
+      });
+      cache.set('big', 'aaaaaaaaaa'); // 10 bytes > 5 cap, but cannot evict itself
+      expect(cache.get('big')).toBe('aaaaaaaaaa');
+      expect(cache.size).toBe(1);
+    });
+
+    it('maxBytes undefined disables the byte bound (only entry count applies)', () => {
+      const cache = new LRUCache<string>({
+        maxSize: 2,
+        sizeCalculator: value => value.length,
+      });
+      cache.set('a', 'aaaa');
+      cache.set('b', 'aaaa');
+      cache.set('c', 'aaaa'); // entry-count eviction: evicts a
+      expect(cache.get('a')).toBeUndefined();
+      expect(cache.size).toBe(2);
+    });
+  });
+
+  describe('reconfigure (#124)', () => {
+    it('shrinks bounds in place and evicts to fit', () => {
+      const cache = new LRUCache<string>({ maxSize: 100, sizeCalculator: value => value.length });
+      cache.set('a', 'aaaa');
+      cache.set('b', 'aaaa');
+      cache.set('c', 'aaaa');
+      cache.reconfigure({ maxSize: 1 });
+      expect(cache.getStats().maxSize).toBe(1);
+      expect(cache.size).toBe(1);
+      expect(cache.get('a')).toBeUndefined();
+      expect(cache.get('c')).toBe('aaaa'); // most recent survives
+    });
+
+    it('updates maxBytes and evicts to fit', () => {
+      const cache = new LRUCache<string>({
+        maxSize: 100,
+        sizeCalculator: value => value.length,
+      });
+      cache.set('a', 'aaaa');
+      cache.set('b', 'aaaa');
+      cache.set('c', 'aaaa');
+      cache.reconfigure({ maxBytes: 5 });
+      expect(cache.getStats().maxBytes).toBe(5);
+      // 5-byte cap keeps at most one 4-byte entry
+      expect(cache.size).toBeLessThanOrEqual(2);
+      expect(cache.get('c')).toBe('aaaa');
+    });
+
+    it('clearing ttl via reconfigure sets ttl to undefined', () => {
+      const cache = new LRUCache<string>({ maxSize: 10, ttl: 1000 });
+      cache.reconfigure({ ttl: undefined });
+      expect(cache.getStats().ttl).toBeUndefined();
+    });
+  });
 });
 
 describe('createCacheKey', () => {

--- a/packages/core/__tests__/cache.test.ts
+++ b/packages/core/__tests__/cache.test.ts
@@ -111,6 +111,18 @@ describe('LRUCache', () => {
   });
 
   describe('byte-aware eviction (#124)', () => {
+    it('does not let byte oversize protection bypass maxSize: 0', () => {
+      const cache = new LRUCache<string>({
+        maxSize: 0,
+        maxBytes: 100,
+        sizeCalculator: () => 1,
+      });
+      cache.set('k', 'v');
+      expect(cache.size).toBe(0);
+      expect(cache.get('k')).toBeUndefined();
+      expect(cache.getStats().totalSize).toBe(0);
+    });
+
     it('evicts oldest entries once totalSize exceeds maxBytes', () => {
       const cache = new LRUCache<string>({
         maxSize: 100,

--- a/packages/core/src/ast.ts
+++ b/packages/core/src/ast.ts
@@ -188,6 +188,8 @@ export interface SupramarkDiagramEngineConfig {
   cache?: {
     enabled?: boolean;
     maxSize?: number;
+    /** Maximum estimated resident bytes for this engine's runtime cache. */
+    maxBytes?: number;
     ttl?: number;
   };
 }
@@ -207,6 +209,8 @@ export interface SupramarkDiagramConfig {
   defaultCache?: {
     enabled?: boolean;
     maxSize?: number;
+    /** Maximum estimated resident bytes for a runtime cache. */
+    maxBytes?: number;
     ttl?: number;
   };
 

--- a/packages/core/src/cache.ts
+++ b/packages/core/src/cache.ts
@@ -18,9 +18,24 @@ export interface LRUCacheOptions {
 
   /**
    * Optional value size estimator (used to estimate memory footprint).
+   *
+   * When {@link maxBytes} is set, entries are also evicted once total estimated
+   * size exceeds it, so this should return a byte-like number for the bound to
+   * be meaningful. Returning 1 (as the RN renderer did before #124) makes the
+   * byte cap a no-op.
    * @default (value) => JSON.stringify(value).length
    */
   sizeCalculator?: (value: unknown) => number;
+
+  /**
+   * Optional total-size cap. When set, `set()` evicts oldest entries until
+   * `totalSize <= maxBytes` (in addition to the entry-count `maxSize` bound).
+   * A single entry larger than `maxBytes` is retained alone (it cannot be
+   * evicted to make room for itself), so size is best-effort, not a hard
+   * guarantee. `undefined` disables the byte bound.
+   * @default undefined
+   */
+  maxBytes?: number;
 }
 
 interface CacheEntry<T> {
@@ -51,8 +66,9 @@ interface CacheEntry<T> {
  */
 export class LRUCache<T> {
   private cache: Map<string, CacheEntry<T>>;
-  private readonly maxSize: number;
-  private readonly ttl: number | undefined;
+  private maxSize: number;
+  private ttl: number | undefined;
+  private maxBytes: number | undefined;
   private readonly sizeCalculator: (value: unknown) => number;
   private totalSize: number = 0;
 
@@ -60,6 +76,7 @@ export class LRUCache<T> {
     this.cache = new Map();
     this.maxSize = options.maxSize ?? 100;
     this.ttl = options.ttl;
+    this.maxBytes = options.maxBytes;
     this.sizeCalculator =
       options.sizeCalculator ??
       (value => {
@@ -69,6 +86,68 @@ export class LRUCache<T> {
           return 1;
         }
       });
+  }
+
+  /**
+   * Reconfigure bounds at runtime. maxSize / ttl / maxBytes are updated in
+   * place and over-capacity entries are evicted. Used by callers that key a
+   * cache by namespace alone (so a policy change reconfigures rather than
+   * strands the old cache — see #124). The size estimator cannot change
+   * after construction (existing entries keep their recorded size); pass a
+   * correct {@link LRUCacheOptions.sizeCalculator} up front.
+   */
+  reconfigure(options: {
+    maxSize?: number;
+    ttl?: number;
+    maxBytes?: number;
+  }): void {
+    if (options.maxSize !== undefined) {
+      this.maxSize = Number.isFinite(options.maxSize)
+        ? Math.max(0, Math.floor(options.maxSize))
+        : this.maxSize;
+    }
+    if ('ttl' in options) {
+      const configuredTtl = options.ttl;
+      this.ttl =
+        configuredTtl !== undefined &&
+        Number.isFinite(configuredTtl) &&
+        configuredTtl > 0
+          ? configuredTtl
+          : undefined;
+    }
+    if ('maxBytes' in options) {
+      const configuredMaxBytes = options.maxBytes;
+      this.maxBytes =
+        configuredMaxBytes !== undefined &&
+        Number.isFinite(configuredMaxBytes) &&
+        configuredMaxBytes > 0
+          ? configuredMaxBytes
+          : undefined;
+    }
+    this.evictToFit();
+  }
+
+  /**
+   * Evict oldest entries until both the count and byte bounds are satisfied.
+   * `protectedKey` is never evicted by this call — used by {@link set} so a
+   * freshly inserted entry that alone exceeds `maxBytes` is retained rather
+   * than immediately dropped (the work to produce it has already happened).
+   */
+  private evictToFit(protectedKey?: string): void {
+    while (
+      this.cache.size > this.maxSize ||
+      (this.maxBytes !== undefined && this.totalSize > this.maxBytes)
+    ) {
+      const firstKey = this.cache.keys().next().value;
+      if (firstKey === undefined || firstKey === protectedKey) {
+        break;
+      }
+      const firstEntry = this.cache.get(firstKey);
+      if (firstEntry) {
+        this.totalSize -= firstEntry.size;
+      }
+      this.cache.delete(firstKey);
+    }
   }
 
   /**
@@ -121,17 +200,10 @@ export class LRUCache<T> {
     this.cache.set(key, entry);
     this.totalSize += size;
 
-    // If capacity is exceeded, evict the oldest entry (the first one in the Map)
-    while (this.cache.size > this.maxSize) {
-      const firstKey = this.cache.keys().next().value;
-      if (firstKey !== undefined) {
-        const firstEntry = this.cache.get(firstKey);
-        if (firstEntry) {
-          this.totalSize -= firstEntry.size;
-        }
-        this.cache.delete(firstKey);
-      }
-    }
+    // Evict oldest entries until both the count and byte bounds hold. The
+    // freshly inserted entry is protected: an item larger than maxBytes is
+    // retained alone rather than evicted to make room for itself.
+    this.evictToFit(key);
   }
 
   /**
@@ -185,12 +257,14 @@ export class LRUCache<T> {
     size: number;
     maxSize: number;
     totalSize: number;
+    maxBytes: number | undefined;
     ttl: number | undefined;
   } {
     return {
       size: this.cache.size,
       maxSize: this.maxSize,
       totalSize: this.totalSize,
+      maxBytes: this.maxBytes,
       ttl: this.ttl,
     };
   }

--- a/packages/core/src/cache.ts
+++ b/packages/core/src/cache.ts
@@ -189,6 +189,13 @@ export class LRUCache<T> {
       this.cache.delete(key);
     }
 
+    // maxSize: 0 is a documented zero-capacity cache. The freshly inserted
+    // key is protected below only so one byte-oversized value can be retained;
+    // it must not bypass the independent entry-count bound.
+    if (this.maxSize === 0) {
+      return;
+    }
+
     const size = this.sizeCalculator(value);
     const entry: CacheEntry<T> = {
       value,
@@ -201,8 +208,9 @@ export class LRUCache<T> {
     this.totalSize += size;
 
     // Evict oldest entries until both the count and byte bounds hold. The
-    // freshly inserted entry is protected: an item larger than maxBytes is
-    // retained alone rather than evicted to make room for itself.
+    // freshly inserted entry is protected from byte eviction: an item larger
+    // than maxBytes is retained alone rather than evicted to make room for
+    // itself. The zero-capacity count case returns before insertion above.
     this.evictToFit(key);
   }
 

--- a/packages/core/src/feature.ts
+++ b/packages/core/src/feature.ts
@@ -1653,10 +1653,14 @@ export interface SupramarkConfig {
  * @returns a Supramark configuration object
  *
  * Behavior note: the returned config always has `options.cache: true`, meaning the
- * host runtime (@supramark/rn / @supramark/web) enables a process-level runtime cache
- * — reused by parsed documents and normalized diagram SVGs across scenarios like
- * virtual-list remounts. This cache is bounded by default (by entry count) and can be
- * adjusted or disabled via `diagram.defaultCache` / `diagram.engines[engine].cache`.
+ * RN host runtime (@supramark/rn) enables a process-level runtime cache — reused by
+ * parsed documents and normalized diagram SVGs across scenarios like virtual-list
+ * remounts. This cache is bounded by default (both entry count and a total-byte cap)
+ * and can be adjusted or disabled via `diagram.defaultCache` / `diagram.engines[engine].cache`.
+ *
+ * Note: the web runtime (@supramark/web) does NOT maintain a document or diagram
+ * result cache of its own — it only forwards `engineConfig.cache` into engine
+ * options. The runtime cache described here is an RN-only facility (see #124).
  * Hosts built on {@link createConfigFromRegistry} therefore get this caching behavior
  * by default; to disable it, pass a config that explicitly overrides
  * `options.cache: false`.

--- a/packages/core/src/feature.ts
+++ b/packages/core/src/feature.ts
@@ -1658,12 +1658,11 @@ export interface SupramarkConfig {
  * remounts. This cache is bounded by default (both entry count and a total-byte cap)
  * and can be adjusted or disabled via `diagram.defaultCache` / `diagram.engines[engine].cache`.
  *
- * Note: the web runtime (@supramark/web) does NOT maintain a document or diagram
- * result cache of its own — it only forwards `engineConfig.cache` into engine
- * options. The runtime cache described here is an RN-only facility (see #124).
- * Hosts built on {@link createConfigFromRegistry} therefore get this caching behavior
- * by default; to disable it, pass a config that explicitly overrides
- * `options.cache: false`.
+ * The RN runtime caches parsed documents and normalized diagram SVGs. The Web
+ * runtime maintains a process-level diagram-result cache, but no parsed-document
+ * cache. Hosts built on {@link createConfigFromRegistry} therefore get the RN
+ * document cache by default; to disable it, pass a config that explicitly
+ * overrides `options.cache: false`. See #124 and #170.
  */
 export function createConfigFromRegistry(enabledByDefault = true): SupramarkConfig {
   const features = FeatureRegistry.list().map(feature => ({

--- a/packages/renderers/rn/__tests__/DiagramNode.test.tsx
+++ b/packages/renderers/rn/__tests__/DiagramNode.test.tsx
@@ -43,11 +43,15 @@ const enabledCacheConfig = {
   },
 };
 
-function createDiagramNode(fenceClosed: boolean): SupramarkDiagramNode {
+function createDiagramNode(
+  fenceClosed: boolean,
+  engine = 'mermaid',
+  code = 'graph TD; A-->B;'
+): SupramarkDiagramNode {
   return {
     type: 'diagram',
-    engine: 'mermaid',
-    code: 'graph TD; A-->B;',
+    engine,
+    code,
     fence_closed: fenceClosed,
   };
 }
@@ -308,5 +312,30 @@ describe('DiagramNode streaming defer/render', () => {
 
     await unmount(firstRenderer);
     await unmount(secondRenderer);
+  });
+
+  test('does not let one engine policy reconfigure and evict another engine cache', async () => {
+    const config = {
+      engines: {
+        mermaid: { cache: { enabled: true, maxSize: 5 } },
+        dot: { cache: { enabled: true, maxSize: 1 } },
+      },
+    };
+    const mermaid = createDiagramNode(true, 'mermaid', 'graph TD; A-->B;');
+    const dot = createDiagramNode(true, 'dot', 'digraph { a -> b }');
+
+    const mermaidRenderer = await renderWithState(mermaid, 'complete', config);
+    await resolveEngine(successfulResult());
+    await unmount(mermaidRenderer);
+
+    const dotRenderer = await renderWithState(dot, 'complete', config);
+    await resolveEngine({ ...successfulResult(), engine: 'dot' });
+    await unmount(dotRenderer);
+    expect(engineState.renderCalls).toBe(2);
+
+    const restoredMermaid = await renderWithState(mermaid, 'complete', config);
+    expect(engineState.renderCalls).toBe(2);
+    expect(hasTestId(restoredMermaid, 'supramark-diagram-svg')).toBe(true);
+    await unmount(restoredMermaid);
   });
 });

--- a/packages/renderers/rn/__tests__/SupramarkCache.test.tsx
+++ b/packages/renderers/rn/__tests__/SupramarkCache.test.tsx
@@ -18,7 +18,7 @@ const parserState = {
 const markdownParserModule = {
   parse: async (markdown: string): Promise<SupramarkRootNode> => {
     parserState.calls += 1;
-    if (markdown === 'diagram document') {
+    if (markdown.startsWith('diagram document')) {
       return {
         type: 'root',
         children: [
@@ -293,6 +293,32 @@ describe('Supramark completed-document cache', () => {
 
     expect(parserState.calls).toBe(1);
     await unmount(secondRenderer);
+  });
+
+  test('uses the strictest engine maxBytes for the shared parsed-document cache', async () => {
+    const config = {
+      features: [{ id: '@supramark/feature-mermaid', enabled: false }],
+      diagram: {
+        engines: {
+          mermaid: {
+            cache: { enabled: true, maxSize: 10, maxBytes: 100 },
+          },
+          dot: {
+            cache: { enabled: true, maxSize: 10, maxBytes: 1_000 },
+          },
+        },
+      },
+    };
+
+    const first = await renderDocument('diagram document one', 'complete', config);
+    await unmount(first);
+    const second = await renderDocument('diagram document two', 'complete', config);
+    await unmount(second);
+    expect(parserState.calls).toBe(2);
+
+    const firstAgain = await renderDocument('diagram document one', 'complete', config);
+    expect(parserState.calls).toBe(3);
+    await unmount(firstAgain);
   });
 
   test('does not retain parsed documents when caching is disabled', async () => {

--- a/packages/renderers/rn/__tests__/devMode.test.ts
+++ b/packages/renderers/rn/__tests__/devMode.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test } from 'bun:test';
+
+import { resolveDevelopmentMode } from '../src/devMode';
+
+describe('resolveDevelopmentMode', () => {
+  test('treats an explicit React Native __DEV__ false as authoritative', () => {
+    expect(
+      resolveDevelopmentMode({
+        __DEV__: false,
+        process: { env: { NODE_ENV: 'development' } },
+      })
+    ).toBe(false);
+  });
+
+  test('uses NODE_ENV only when __DEV__ is absent', () => {
+    expect(resolveDevelopmentMode({ process: { env: { NODE_ENV: 'production' } } })).toBe(false);
+    expect(resolveDevelopmentMode({ process: { env: { NODE_ENV: 'test' } } })).toBe(true);
+  });
+});

--- a/packages/renderers/rn/__tests__/renderCache.test.ts
+++ b/packages/renderers/rn/__tests__/renderCache.test.ts
@@ -1,7 +1,15 @@
 import { describe, expect, it } from 'bun:test';
 
 import './support/mock-react-native';
-import { stableSerialize } from '../src/renderCache';
+import {
+  stableSerialize,
+  AsyncRendererCache,
+  clearReactNativeRendererCaches,
+  clearSupramarkRenderCache,
+  getRendererCache,
+  resolveRendererCachePolicy,
+  type RendererCachePolicy,
+} from '../src/renderCache';
 
 /**
  * Tests for stableSerialize's cache-key behavior.
@@ -60,5 +68,169 @@ describe('stableSerialize', () => {
   it('nested arrays are serialized by structure', () => {
     expect(stableSerialize([1, [2, 3]])).toBe(stableSerialize([1, [2, 3]]));
     expect(stableSerialize([1, [2, 3]])).not.toBe(stableSerialize([1, [2, 4]]));
+  });
+
+  // #124 nits: equal-valued non-plain values must hit the SAME key (value, not
+  // identity) so freshly-constructed but equal options reuse cached work.
+  it('equal-valued Dates (distinct instances) hit the same key', () => {
+    const a = { since: new Date('2026-01-01') };
+    const b = { since: new Date('2026-01-01') };
+    expect(stableSerialize(a)).toBe(stableSerialize(b));
+  });
+
+  it('equal-valued Maps (distinct instances, same entries) hit the same key', () => {
+    const a = { tags: new Map([['k', 'v']]) };
+    const b = { tags: new Map([['k', 'v']]) };
+    expect(stableSerialize(a)).toBe(stableSerialize(b));
+  });
+
+  it('equal-valued Sets (distinct instances) hit the same key', () => {
+    const a = { ids: new Set([1, 2, 3]) };
+    const b = { ids: new Set([3, 2, 1]) }; // different insertion order
+    expect(stableSerialize(a)).toBe(stableSerialize(b));
+  });
+
+  it('equal RegExps (distinct instances) hit the same key', () => {
+    const a = { pat: /foo/gi };
+    const b = { pat: /foo/gi };
+    expect(stableSerialize(a)).toBe(stableSerialize(b));
+    expect(stableSerialize({ pat: /foo/gi })).not.toBe(stableSerialize({ pat: /foo/g }));
+  });
+
+  // Two functions/symbols with identical source/description must NOT collide.
+  it('distinct functions with identical source do not collide', () => {
+    const a = { fn: () => 1 };
+    const b = { fn: () => 1 };
+    expect(stableSerialize(a)).not.toBe(stableSerialize(b));
+  });
+
+  it('distinct symbols with the same description do not collide', () => {
+    const sym = Symbol('theme');
+    const a: Record<symbol, unknown> = { [sym]: 1 };
+    const b: Record<symbol, unknown> = { [Symbol('theme')]: 1 };
+    expect(stableSerialize(a)).not.toBe(stableSerialize(b));
+    // Same symbol identity does hit the same key (and the prop is not dropped).
+    const c: Record<symbol, unknown> = { [sym]: 1 };
+    expect(stableSerialize(a)).toBe(stableSerialize(c));
+  });
+
+  it('symbol-keyed properties are not dropped', () => {
+    const sym = Symbol('hidden');
+    const a: Record<symbol, unknown> = { [sym]: 'x' };
+    const b: Record<symbol, unknown> = { [sym]: 'y' };
+    expect(stableSerialize(a)).not.toBe(stableSerialize(b));
+  });
+
+  // #124 nit: O(depth) backtracking — a 2000-level chain must be fast, not O(depth²).
+  it('a deep chain serializes without quadratic blowup', () => {
+    let node: unknown = 'leaf';
+    for (let i = 0; i < 2000; i++) {
+      node = { next: node };
+    }
+    const start = Date.now();
+    stableSerialize(node);
+    const elapsed = Date.now() - start;
+    // Generous bound; the pre-#124 quadratic version took 400ms+ on a 2000-chain.
+    expect(elapsed).toBeLessThan(200);
+  });
+});
+
+describe('AsyncRendererCache', () => {
+  const basePolicy: RendererCachePolicy = {
+    enabled: true,
+    maxSize: 10,
+    ttl: undefined,
+    maxBytes: undefined,
+  };
+
+  it('OR-joins shouldRetain across deduped in-flight callers (#124 #4)', async () => {
+    const cache = new AsyncRendererCache<string>(basePolicy, () => 1);
+    let resolveFactory: (value: string) => void = () => undefined;
+    const factory = () =>
+      new Promise<string>(resolve => {
+        resolveFactory = resolve;
+      });
+
+    // Caller 1 does NOT want to retain; caller 2 (joining in-flight) does.
+    const p1 = cache.getOrCreate('shared', factory, () => false);
+    const p2 = cache.getOrCreate('shared', factory, () => true);
+
+    resolveFactory('result');
+    await Promise.all([p1, p2]);
+
+    // Because caller 2 wanted retention, the value must be cached.
+    expect(cache.get('shared')).toBe('result');
+  });
+
+  it('does not retain when no joiner wants retention', async () => {
+    const cache = new AsyncRendererCache<string>(basePolicy, () => 1);
+    let resolveFactory: (value: string) => void = () => undefined;
+    const factory = () =>
+      new Promise<string>(resolve => {
+        resolveFactory = resolve;
+      });
+
+    const p1 = cache.getOrCreate('shared', factory, () => false);
+    const p2 = cache.getOrCreate('shared', factory, () => false);
+    resolveFactory('result');
+    await Promise.all([p1, p2]);
+
+    expect(cache.get('shared')).toBeUndefined();
+  });
+
+  it('does not retain rejected work (#91)', async () => {
+    const cache = new AsyncRendererCache<string>(basePolicy, () => 1);
+    const factory = () => Promise.reject(new Error('boom'));
+
+    await expect(cache.getOrCreate('shared', factory)).rejects.toThrow('boom');
+    expect(cache.get('shared')).toBeUndefined();
+  });
+});
+
+describe('getRendererCache policy reconfiguration (#124 #3)', () => {
+  it('keys by namespace alone — a policy change reconfigures, not strands', () => {
+    clearReactNativeRendererCaches();
+    const policyA = resolveRendererCachePolicy({ enabled: true, maxSize: 5 });
+    const policyB = resolveRendererCachePolicy({ enabled: true, maxSize: 20 });
+
+    const cacheA = getRendererCache<string>('diagram', policyA, () => 1);
+    const cacheB = getRendererCache<string>('diagram', policyB, () => 1);
+
+    expect(cacheA).toBe(cacheB); // same instance, reconfigured in place
+    expect(cacheA!.getStats().maxSize).toBe(20); // reconfigured to policy B
+  });
+
+  it('reconfiguring to a smaller maxSize evicts oldest entries', async () => {
+    clearReactNativeRendererCaches();
+    const policy = resolveRendererCachePolicy({ enabled: true, maxSize: 10 });
+    const cache = getRendererCache<string>('diagram', policy, () => 1)!;
+
+    // Fill via getOrCreate with synchronous-ish factories.
+    for (let i = 0; i < 5; i++) {
+      await cache.getOrCreate(`k${i}`, async () => `v${i}`);
+    }
+    expect(cache.getStats().size).toBe(5);
+
+    cache.reconfigure(resolveRendererCachePolicy({ enabled: true, maxSize: 2 }));
+    expect(cache.getStats().maxSize).toBe(2);
+    expect(cache.getStats().size).toBe(2); // evicted to fit
+  });
+
+  it('distinct namespaces keep distinct caches', () => {
+    clearReactNativeRendererCaches();
+    const policy = resolveRendererCachePolicy({ enabled: true, maxSize: 5 });
+    const diagram = getRendererCache<string>('diagram', policy, () => 1);
+    const document = getRendererCache<string>('parsed-document', policy, () => 1);
+    expect(diagram).not.toBe(document);
+  });
+
+  it('clearSupramarkRenderCache drops all namespaces (public API alias)', () => {
+    clearReactNativeRendererCaches();
+    const policy = resolveRendererCachePolicy({ enabled: true, maxSize: 5 });
+    const before = getRendererCache<string>('diagram', policy, () => 1);
+    expect(before).toBeDefined();
+    clearSupramarkRenderCache();
+    const after = getRendererCache<string>('diagram', policy, () => 1);
+    expect(after).not.toBe(before); // new instance after clear
   });
 });

--- a/packages/renderers/rn/__tests__/renderCache.test.ts
+++ b/packages/renderers/rn/__tests__/renderCache.test.ts
@@ -224,6 +224,28 @@ describe('getRendererCache policy reconfiguration (#124 #3)', () => {
     expect(diagram).not.toBe(document);
   });
 
+  it('keeps different diagram-engine policies isolated', async () => {
+    clearReactNativeRendererCaches();
+    const mermaid = getRendererCache<string>(
+      'diagram:mermaid',
+      resolveRendererCachePolicy({ enabled: true, maxSize: 5 }),
+      () => 1
+    )!;
+    await mermaid.getOrCreate('mermaid-svg', async () => '<svg>mermaid</svg>');
+
+    const dot = getRendererCache<string>(
+      'diagram:dot',
+      resolveRendererCachePolicy({ enabled: true, maxSize: 1 }),
+      () => 1
+    )!;
+    await dot.getOrCreate('dot-svg', async () => '<svg>dot</svg>');
+
+    expect(dot).not.toBe(mermaid);
+    expect(dot.getStats().maxSize).toBe(1);
+    expect(mermaid.getStats().maxSize).toBe(5);
+    expect(mermaid.get('mermaid-svg')).toBe('<svg>mermaid</svg>');
+  });
+
   it('clearSupramarkRenderCache drops all namespaces (public API alias)', () => {
     clearReactNativeRendererCaches();
     const policy = resolveRendererCachePolicy({ enabled: true, maxSize: 5 });

--- a/packages/renderers/rn/src/DiagramNode.tsx
+++ b/packages/renderers/rn/src/DiagramNode.tsx
@@ -78,7 +78,11 @@ export const DiagramNode: React.FC<DiagramNodeProps> = ({
       ),
     [diagramConfig, globalCache, node.engine]
   );
-  const diagramCache = getRendererCache<CachedDiagramResult>('diagram', cachePolicy);
+  const diagramCache = getRendererCache<CachedDiagramResult>(
+    'diagram',
+    cachePolicy,
+    value => value.svg.length
+  );
   // Include every render-affecting input so cached SVG cannot cross option variants.
   const diagramCacheKey = useMemo(
     () =>

--- a/packages/renderers/rn/src/DiagramNode.tsx
+++ b/packages/renderers/rn/src/DiagramNode.tsx
@@ -79,7 +79,7 @@ export const DiagramNode: React.FC<DiagramNodeProps> = ({
     [diagramConfig, globalCache, node.engine]
   );
   const diagramCache = getRendererCache<CachedDiagramResult>(
-    'diagram',
+    `diagram:${normalizedEngine}`,
     cachePolicy,
     value => value.svg.length
   );

--- a/packages/renderers/rn/src/Supramark.tsx
+++ b/packages/renderers/rn/src/Supramark.tsx
@@ -44,11 +44,96 @@ import {
 
 type RenderedNode = React.ComponentProps<typeof Text>['children'];
 
+// Dev mode: __DEV__ in React Native bundles, NODE_ENV elsewhere (web/tests).
+// Deep-freeze of the shared cached AST only runs in dev so production keeps
+// the freeze cost off the render path while the read-only contract holds.
+const globalRecord = globalThis as Record<string, unknown> & {
+  process?: { env?: Record<string, string | undefined> };
+};
+const isDevMode: boolean =
+  (typeof globalRecord.__DEV__ !== 'undefined' && globalRecord.__DEV__ === true) ||
+  (typeof globalRecord.process !== 'undefined' &&
+    typeof globalRecord.process.env !== 'undefined' &&
+    globalRecord.process.env.NODE_ENV !== 'production');
+
+
 interface ParsedDocument {
   /** Immutable after expansion; cached snapshots may be shared by multiple renderer instances. */
   readonly root: SupramarkRootNode;
   readonly highlighted: ReadonlyMap<string, SupramarkCodeHighlightResult>;
   readonly sourceState: SupramarkSourceState;
+}
+
+/**
+ * Estimates the byte footprint of a cached parsed document for the
+ * byte-aware cache cap. Walks the AST summing string `value`/`code`/`text`
+ * lengths plus a small fixed overhead per node; ignores the highlighted Map
+ * (its entries are keyed by source slice and bounded by the AST size).
+ * Runs only on a cache miss (one `set()`), so an O(nodes) walk is acceptable.
+ */
+function estimateParsedDocumentBytes(document: ParsedDocument): number {
+  let bytes = 0;
+  const stack: SupramarkNode[] = [...document.root.children];
+  while (stack.length > 0) {
+    const node = stack.pop() as SupramarkNode & {
+      value?: unknown;
+      code?: unknown;
+      text?: unknown;
+      children?: SupramarkNode[];
+    };
+    bytes += 64; // node object overhead (fields, prototype, refs).
+    const text =
+      typeof node.value === 'string'
+        ? node.value
+        : typeof node.code === 'string'
+          ? node.code
+          : typeof node.text === 'string'
+            ? node.text
+            : undefined;
+    if (text !== undefined) {
+      bytes += text.length;
+    }
+    if (node.children) {
+      for (const child of node.children) {
+        stack.push(child);
+      }
+    }
+  }
+  return Math.max(bytes, 1);
+}
+
+/**
+ * Recursively freezes plain objects/arrays in dev mode so a host
+ * `containerRenderers` annotating AST nodes in place cannot silently
+ * cross-contaminate other rows sharing the cached snapshot. Production keeps
+ * the freeze off the render path; the read-only contract still applies by
+ * convention. Skips class instances, Maps, and other non-plain values.
+ */
+function deepFreezeAst(node: SupramarkNode): void {
+  if (node === null || typeof node !== 'object') {
+    return;
+  }
+  if (Array.isArray(node)) {
+    for (const child of node) {
+      deepFreezeAst(child);
+    }
+  } else {
+    const proto = Object.getPrototypeOf(node);
+    if (proto === null || proto === Object.prototype) {
+      const child = node as { children?: SupramarkNode[] };
+      if (child.children) {
+        for (const descendant of child.children) {
+          deepFreezeAst(descendant);
+        }
+      }
+    }
+  }
+  // Object.freeze is idempotent and a no-op on non-objects; safe to call.
+  try {
+    Object.freeze(node);
+  } catch {
+    // Some environments throw on exotic objects; the freeze is best-effort.
+  }
 }
 
 // Highlighter identities keep parsed-document cache entries separated when a host swaps services.
@@ -214,7 +299,11 @@ export const Supramark: React.FC<SupramarkProps> = ({
 }) => {
   // Global options.cache provides the least-specific cache default.
   const documentCachePolicy = useMemo(() => resolveDocumentCachePolicy(config), [config]);
-  const documentCache = getRendererCache<ParsedDocument>('parsed-document', documentCachePolicy);
+  const documentCache = getRendererCache<ParsedDocument>(
+    'parsed-document',
+    documentCachePolicy,
+    estimateParsedDocumentBytes
+  );
   const codeHighlightEnabled = isFeatureGroupEnabled(config, ['@supramark/feature-code-highlight']);
   // Completed documents can share parsing/highlighting only when every input is equivalent.
   // Config is intentionally omitted because parse currently derives no plugins or AST transforms
@@ -313,6 +402,12 @@ export const Supramark: React.FC<SupramarkProps> = ({
               )
             : await buildParsedDocument();
         if (!cancelled) {
+          // Dev-only deep freeze enforces the read-only AST contract on the
+          // shared cached snapshot; see deepFreezeAst. containerRenderers that
+          // annotate in place would otherwise cross-contaminate sibling rows.
+          if (isDevMode) {
+            deepFreezeAst(nextDocument.root);
+          }
           setParsedDocument(nextDocument);
           setParseError(null);
         }

--- a/packages/renderers/rn/src/Supramark.tsx
+++ b/packages/renderers/rn/src/Supramark.tsx
@@ -35,6 +35,7 @@ import {
 } from './styles';
 import { ErrorBoundary, type ErrorInfo, ErrorDisplay } from './ErrorBoundary';
 import { SourceStateContext } from './SourceStateContext';
+import { resolveDevelopmentMode } from './devMode';
 import {
   getRendererCache,
   resolveDiagramCachePolicy,
@@ -47,15 +48,7 @@ type RenderedNode = React.ComponentProps<typeof Text>['children'];
 // Dev mode: __DEV__ in React Native bundles, NODE_ENV elsewhere (web/tests).
 // Deep-freeze of the shared cached AST only runs in dev so production keeps
 // the freeze cost off the render path while the read-only contract holds.
-const globalRecord = globalThis as Record<string, unknown> & {
-  process?: { env?: Record<string, string | undefined> };
-};
-const isDevMode: boolean =
-  (typeof globalRecord.__DEV__ !== 'undefined' && globalRecord.__DEV__ === true) ||
-  (typeof globalRecord.process !== 'undefined' &&
-    typeof globalRecord.process.env !== 'undefined' &&
-    globalRecord.process.env.NODE_ENV !== 'production');
-
+const isDevMode = resolveDevelopmentMode();
 
 interface ParsedDocument {
   /** Immutable after expansion; cached snapshots may be shared by multiple renderer instances. */
@@ -187,10 +180,14 @@ function resolveDocumentCachePolicy(config?: SupramarkConfig): RendererCachePoli
   const finiteTtls = enabledEnginePolicies
     .map(policy => policy.ttl)
     .filter((ttl): ttl is number => ttl !== undefined);
+  const finiteMaxBytes = enabledEnginePolicies
+    .map(policy => policy.maxBytes)
+    .filter((maxBytes): maxBytes is number => maxBytes !== undefined);
   return {
     enabled: true,
     maxSize: Math.min(...enabledEnginePolicies.map(policy => policy.maxSize)),
     ttl: finiteTtls.length > 0 ? Math.min(...finiteTtls) : undefined,
+    maxBytes: finiteMaxBytes.length > 0 ? Math.min(...finiteMaxBytes) : undefined,
   };
 }
 

--- a/packages/renderers/rn/src/Supramark.tsx
+++ b/packages/renderers/rn/src/Supramark.tsx
@@ -103,30 +103,42 @@ function estimateParsedDocumentBytes(document: ParsedDocument): number {
 }
 
 /**
- * Recursively freezes plain objects/arrays in dev mode so a host
- * `containerRenderers` annotating AST nodes in place cannot silently
- * cross-contaminate other rows sharing the cached snapshot. Production keeps
- * the freeze off the render path; the read-only contract still applies by
- * convention. Skips class instances, Maps, and other non-plain values.
+ * Recursively freezes plain objects/arrays reachable from a cached AST in dev
+ * mode so a host `containerRenderers` annotating AST nodes in place cannot
+ * silently cross-contaminate other rows sharing the cached snapshot. Production
+ * keeps the freeze off the render path; the read-only contract still applies by
+ * convention. Class instances, Maps, and other non-plain values are skipped
+ * (freezing them is unsafe or a no-op on their entries). Assumes AST nodes are
+ * plain object literals (Rust canonical parser output) — class-wrapped nodes
+ * would bypass the freeze silently.
  */
-function deepFreezeAst(node: SupramarkNode): void {
-  if (node === null || typeof node !== 'object') {
+function deepFreezeAst(value: unknown): void {
+  if (value === null || typeof value !== 'object') {
     return;
   }
-  // Object.getPrototypeOf is typed `any` in the ES5 lib, so assert the return
-  // to keep the type-aware lint (no-unsafe-assignment) happy.
-  const proto = Object.getPrototypeOf(node) as object | null;
-  if (proto === null || proto === Object.prototype) {
-    const child = node as { children?: SupramarkNode[] };
-    if (child.children) {
-      for (const descendant of child.children) {
-        deepFreezeAst(descendant);
-      }
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      deepFreezeAst(item);
+    }
+  } else {
+    // Object.getPrototypeOf is typed `any` in the ES5 lib, so assert the return
+    // to keep the type-aware lint (no-unsafe-assignment) happy. Only recurse
+    // into plain objects; class instances, Maps, etc. are left untouched.
+    const proto = Object.getPrototypeOf(value) as object | null;
+    if (proto !== null && proto !== Object.prototype) {
+      return;
+    }
+    const record = value as Record<PropertyKey, unknown>;
+    for (const key of Object.keys(record)) {
+      deepFreezeAst(record[key]);
+    }
+    for (const sym of Object.getOwnPropertySymbols(record)) {
+      deepFreezeAst(record[sym]);
     }
   }
   // Object.freeze is idempotent and a no-op on non-objects; safe to call.
   try {
-    Object.freeze(node);
+    Object.freeze(value as object);
   } catch {
     // Some environments throw on exotic objects; the freeze is best-effort.
   }

--- a/packages/renderers/rn/src/Supramark.tsx
+++ b/packages/renderers/rn/src/Supramark.tsx
@@ -138,7 +138,7 @@ function deepFreezeAst(value: unknown): void {
   }
   // Object.freeze is idempotent and a no-op on non-objects; safe to call.
   try {
-    Object.freeze(value as object);
+    Object.freeze(value);
   } catch {
     // Some environments throw on exotic objects; the freeze is best-effort.
   }

--- a/packages/renderers/rn/src/Supramark.tsx
+++ b/packages/renderers/rn/src/Supramark.tsx
@@ -113,18 +113,14 @@ function deepFreezeAst(node: SupramarkNode): void {
   if (node === null || typeof node !== 'object') {
     return;
   }
-  if (Array.isArray(node)) {
-    for (const child of node) {
-      deepFreezeAst(child);
-    }
-  } else {
-    const proto = Object.getPrototypeOf(node);
-    if (proto === null || proto === Object.prototype) {
-      const child = node as { children?: SupramarkNode[] };
-      if (child.children) {
-        for (const descendant of child.children) {
-          deepFreezeAst(descendant);
-        }
+  // Object.getPrototypeOf is typed `any` in the ES5 lib, so assert the return
+  // to keep the type-aware lint (no-unsafe-assignment) happy.
+  const proto = Object.getPrototypeOf(node) as object | null;
+  if (proto === null || proto === Object.prototype) {
+    const child = node as { children?: SupramarkNode[] };
+    if (child.children) {
+      for (const descendant of child.children) {
+        deepFreezeAst(descendant);
       }
     }
   }

--- a/packages/renderers/rn/src/devMode.ts
+++ b/packages/renderers/rn/src/devMode.ts
@@ -1,0 +1,14 @@
+export interface DevelopmentGlobals {
+  __DEV__?: unknown;
+  process?: { env?: Record<string, string | undefined> };
+}
+
+/** Resolve development mode, treating React Native's `__DEV__` as authoritative. */
+export function resolveDevelopmentMode(
+  globals: DevelopmentGlobals = globalThis as DevelopmentGlobals
+): boolean {
+  if (typeof globals.__DEV__ !== 'undefined') {
+    return globals.__DEV__ === true;
+  }
+  return globals.process?.env?.NODE_ENV !== 'production';
+}

--- a/packages/renderers/rn/src/index.ts
+++ b/packages/renderers/rn/src/index.ts
@@ -2,3 +2,4 @@ export * from './Supramark';
 export * from './DiagramNode';
 export * from './styles';
 export * from './ErrorBoundary';
+export { clearSupramarkRenderCache } from './renderCache';

--- a/packages/renderers/rn/src/renderCache.ts
+++ b/packages/renderers/rn/src/renderCache.ts
@@ -5,6 +5,12 @@ export interface RendererCachePolicy {
   enabled: boolean;
   maxSize: number;
   ttl?: number;
+  /**
+   * Optional total-byte cap. When set, the cache evicts oldest entries until
+   * the summed `sizeCalculator` output fits, in addition to the entry-count
+   * `maxSize` bound. `undefined` disables the byte bound.
+   */
+  maxBytes?: number;
 }
 
 /** Cache policy input accepted by existing Supramark diagram configuration. */
@@ -12,10 +18,24 @@ export interface RendererCachePolicyInput {
   enabled?: boolean;
   maxSize?: number;
   ttl?: number;
+  maxBytes?: number;
 }
 
-// Default bounds apply only when a host explicitly enables caching without limits.
-const DEFAULT_CACHE_MAX_SIZE = 100;
+// Default bounds apply only when a host explicitly enables caching without
+// limits. maxSize caps the entry count; maxBytes bounds the resident byte
+// footprint so a chat host scrolling hundreds of large SVGs cannot keep them
+// alive for the process lifetime. Both are intentionally conservative — a host
+// that wants more can raise either via diagram.defaultCache / engine cache.
+const DEFAULT_CACHE_MAX_SIZE = 50;
+const DEFAULT_CACHE_MAX_BYTES = 8_000_000;
+
+/**
+ * Estimates the byte footprint of one cached value for the byte-aware cap.
+ * Returning a fixed 1 (as the pre-#124 code did) makes maxBytes a no-op, so
+ * each namespace picks a cheap estimator proportional to real payload size.
+ * This runs only on `set()` (one cache miss), never on `get()`.
+ */
+export type CacheSizeCalculator<T> = (value: T) => number;
 
 /**
  * Keeps resolved values in the core LRU cache and shares equivalent in-flight work.
@@ -23,18 +43,22 @@ const DEFAULT_CACHE_MAX_SIZE = 100;
  */
 export class AsyncRendererCache<T> {
   private readonly values: LRUCache<T>;
-  private readonly pending = new Map<string, Promise<T>>();
+  private readonly pending = new Map<
+    string,
+    { promise: Promise<T>; retain: (value: T) => boolean }
+  >();
+  private readonly sizeCalculator: CacheSizeCalculator<T>;
 
-  constructor(policy: RendererCachePolicy) {
+  constructor(
+    policy: RendererCachePolicy,
+    sizeCalculator: CacheSizeCalculator<T>
+  ) {
+    this.sizeCalculator = sizeCalculator;
     this.values = new LRUCache<T>({
       maxSize: policy.maxSize,
       ttl: policy.ttl,
-      // Eviction is entry-count based (LRUCache compares cache.size to maxSize),
-      // so each entry contributes a fixed unit. Override the default
-      // sizeCalculator — which JSON.stringifies the whole value on every set()
-      // (entire AST / SVG string) to feed a totalSize stat that never affects
-      // eviction — to avoid that O(payload) work in the render path.
-      sizeCalculator: () => 1,
+      maxBytes: policy.maxBytes,
+      sizeCalculator: (value: unknown) => this.sizeCalculator(value as T),
     });
   }
 
@@ -43,7 +67,20 @@ export class AsyncRendererCache<T> {
     return this.values.get(key);
   }
 
-  /** Returns cached work or starts one shared asynchronous computation. */
+  /** Returns cache statistics for monitoring (size, bounds, total estimated bytes). */
+  getStats(): ReturnType<LRUCache<T>['getStats']> {
+    return this.values.getStats();
+  }
+
+  /**
+   * Returns cached work or starts one shared asynchronous computation.
+   *
+   * `shouldRetain` is OR-joined across every caller that dedups onto the same
+   * in-flight promise: if any caller wants the result retained, it is retained.
+   * This fixes the pre-#124 behavior where the first caller's predicate
+   * silently overrode every later joiner (a caller passing `() => true` still
+   * got nothing cached when it joined a `() => false` in-flight row).
+   */
   getOrCreate(
     key: string,
     factory: () => Promise<T>,
@@ -56,38 +93,59 @@ export class AsyncRendererCache<T> {
 
     const existing = this.pending.get(key);
     if (existing) {
-      return existing;
+      const previousRetain = existing.retain;
+      const incomingRetain = shouldRetain;
+      existing.retain = value => previousRetain(value) || incomingRetain(value);
+      return existing.promise;
     }
 
+    const entry = {
+      promise: undefined as unknown as Promise<T>,
+      retain: shouldRetain,
+    };
     const promise = factory()
       .then(value => {
-        if (shouldRetain(value)) {
+        if (entry.retain(value)) {
           this.values.set(key, value);
         }
         return value;
       })
       .finally(() => {
-        if (this.pending.get(key) === promise) {
+        if (this.pending.get(key) === entry) {
           this.pending.delete(key);
         }
       });
-
-    this.pending.set(key, promise);
+    entry.promise = promise;
+    this.pending.set(key, entry);
     return promise;
+  }
+
+  /**
+   * Reconfigure bounds in place (used when a policy changes for the same
+   * namespace, so the cache is not stranded — see #124). Pending work is
+   * untouched; only completed entries are evicted to fit the new bounds.
+   */
+  reconfigure(policy: RendererCachePolicy): void {
+    this.values.reconfigure({
+      maxSize: policy.maxSize,
+      ttl: policy.ttl,
+      maxBytes: policy.maxBytes,
+    });
   }
 }
 
-// Renderer-level caches are keyed by namespace and policy rather than config identity.
-// This lets equivalent inline config objects share completed and in-flight work while
-// each AsyncRendererCache remains bounded by its resolved LRU policy.
+// Renderer-level caches are keyed by namespace ALONE. Keying by
+// `namespace:maxSize:ttl` (pre-#124) stranded a whole AsyncRendererCache
+// whenever the resolved policy changed — and `resolveDocumentCachePolicy`
+// derives maxSize from the enabled engine subset, so a host enabling
+// different engines per message produced a new key without changing code,
+// leaking every stranded cache's entries + pending map forever.
 //
-// Lifecycle note: the key encodes `namespace:maxSize:ttl`, so if a host changes cache
-// policy at runtime (e.g. maxSize 10 -> 20) a NEW AsyncRendererCache is created under
-// the new key and the old one stays in this Map. This is intentional: we cannot safely
-// tell whether the old cache is still referenced by an in-flight render. The leak is
-// bounded — each stranded cache holds at most `maxSize` entries plus a transient
-// `pending` map — and changing policy at runtime is rare (policy usually comes from a
-// static host config for the whole app lifetime), so no proactive sweep is wired.
+// Keying by namespace and reconfiguring in place removes the leak: a policy
+// change shrinks/grows the existing cache's bounds and evicts to fit. The
+// sizeCalculator is fixed at first construction per namespace; a later
+// policy change with a different byte footprint still uses the original
+// estimator (it is proportional to payload, not to the bound).
 const rendererCaches = new Map<string, AsyncRendererCache<unknown>>();
 
 /** Resolves an engine override on top of the diagram-wide cache policy. */
@@ -98,6 +156,7 @@ export function resolveRendererCachePolicy(
   const enabled = override?.enabled ?? fallback?.enabled ?? false;
   const configuredMaxSize = override?.maxSize ?? fallback?.maxSize ?? DEFAULT_CACHE_MAX_SIZE;
   const configuredTtl = override?.ttl ?? fallback?.ttl;
+  const configuredMaxBytes = override?.maxBytes ?? fallback?.maxBytes ?? DEFAULT_CACHE_MAX_BYTES;
 
   return {
     enabled,
@@ -108,6 +167,12 @@ export function resolveRendererCachePolicy(
       configuredTtl !== undefined && Number.isFinite(configuredTtl) && configuredTtl > 0
         ? configuredTtl
         : undefined,
+    maxBytes:
+      configuredMaxBytes !== undefined &&
+      Number.isFinite(configuredMaxBytes) &&
+      configuredMaxBytes > 0
+        ? configuredMaxBytes
+        : DEFAULT_CACHE_MAX_BYTES,
   };
 }
 
@@ -124,10 +189,19 @@ export function resolveDiagramCachePolicy(
   return resolveRendererCachePolicy(enginePolicy, diagramFallback);
 }
 
-/** Returns the renderer-level cache for one namespace and resolved policy. */
+/**
+ * Returns the renderer-level cache for one namespace and resolved policy.
+ *
+ * The cache is keyed by namespace only; a policy change reconfigures the
+ * existing cache in place rather than stranding it (see #124). The
+ * `sizeCalculator` is applied only when the cache is first created for a
+ * namespace; later calls for the same namespace reuse the existing cache
+ * (and its original estimator), since per-namespace value shapes are stable.
+ */
 export function getRendererCache<T>(
   namespace: string,
-  policy: RendererCachePolicy
+  policy: RendererCachePolicy,
+  sizeCalculator: CacheSizeCalculator<T> = () => 1
 ): AsyncRendererCache<T> | undefined {
   // maxSize:0 means "zero capacity", i.e. nothing can be retained, so caching is
   // disabled even when policy.enabled is true. Note this can surprise a host that
@@ -139,28 +213,35 @@ export function getRendererCache<T>(
     return undefined;
   }
 
-  const policyKey = `${namespace}:${policy.maxSize}:${policy.ttl ?? 'none'}`;
-  let cache = rendererCaches.get(policyKey);
-  if (!cache) {
-    cache = new AsyncRendererCache<unknown>(policy);
-    rendererCaches.set(policyKey, cache);
+  const existing = rendererCaches.get(namespace);
+  if (existing) {
+    existing.reconfigure(policy);
+    return existing as AsyncRendererCache<T>;
   }
 
-  return cache as AsyncRendererCache<T>;
+  const cache = new AsyncRendererCache<T>(policy, sizeCalculator);
+  rendererCaches.set(namespace, cache as AsyncRendererCache<unknown>);
+  return cache;
 }
 
 /**
  * Deterministically serializes JSON-like render options for cache keys.
  *
- * Plain objects/arrays are serialized structurally; non-plain values
- * (Date / Map / Set / RegExp / class instances / functions) cannot be compared
- * by content cheaply or safely, so each distinct instance gets a stable
- * process-local identity id via a WeakMap. This keeps two options objects that
- * differ only by Date/Map/Set value from colliding on the same cache key (which
- * would serve a wrong cached SVG), and a cyclic config object from overflowing
- * the stack (the seen-set short-circuits re-entrant cycles to the identity id).
+ * Plain objects/arrays are serialized structurally with sorted keys. Values
+ * with canonical content (Date, RegExp, Map, Set) are compared by VALUE so
+ * two freshly-constructed but equal-valued options hit the same cache key
+ * (pre-#124 they were identity-keyed and each miss evicted a good entry).
+ * Other non-plain values (class instances, functions, symbols) cannot be
+ * compared by content cheaply or safely, so each distinct instance gets a
+ * stable process-local identity id via a WeakMap. A cyclic config object
+ * short-circuits re-entrant visits to the identity id rather than overflowing
+ * the stack.
+ *
+ * The visited-set is backtracked (add on enter, delete on leave) so the
+ * serializer is O(depth) rather than the pre-#124 O(depth²) that allocated a
+ * new Set per node.
  */
-const nonPlainIdentities = new WeakMap<object, number>();
+const nonPlainIdentities = new WeakMap<object | symbol, number>();
 let nextNonPlainId = 1;
 
 function isPlainObject(value: object): boolean {
@@ -170,7 +251,7 @@ function isPlainObject(value: object): boolean {
   return proto === null || proto === Object.prototype;
 }
 
-function nonPlainIdentity(value: object): string {
+function nonPlainIdentity(value: object | symbol): string {
   const existing = nonPlainIdentities.get(value);
   if (existing !== undefined) {
     return `obj:${existing}`;
@@ -180,40 +261,95 @@ function nonPlainIdentity(value: object): string {
   return `obj:${next}`;
 }
 
-export function stableSerialize(value: unknown, seen = new Set<object>()): string {
+export function stableSerialize(value: unknown, seen = new Set<object | symbol>()): string {
   if (value === null) {
     return 'null';
   }
   if (value === undefined) {
     return 'undefined';
   }
+  if (typeof value === 'string') {
+    return `string:${JSON.stringify(value)}`;
+  }
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return `${typeof value}:${String(value)}`;
+  }
+  if (typeof value === 'function' || typeof value === 'symbol') {
+    // Functions are objects (WeakMap-keyable); symbols are WeakMap-keyable in
+    // modern engines. Two closures with identical source or two symbols with
+    // the same description are distinct values, so identity (not source/desc)
+    // avoids colliding them onto the same cache key.
+    return nonPlainIdentity(value as object | symbol);
+  }
   if (Array.isArray(value)) {
     if (seen.has(value)) {
       return nonPlainIdentity(value);
     }
-    const nextSeen = new Set(seen);
-    nextSeen.add(value);
-    return `[${value.map(item => stableSerialize(item, nextSeen)).join(',')}]`;
+    seen.add(value);
+    const body = value.map(item => stableSerialize(item, seen)).join(',');
+    seen.delete(value);
+    return `[${body}]`;
   }
   if (typeof value === 'object') {
     if (seen.has(value)) {
       return nonPlainIdentity(value);
     }
+    if (value instanceof Date) {
+      // Equal-valued Dates (different instances) must hit the same key.
+      return `date:${value.getTime()}`;
+    }
+    if (value instanceof RegExp) {
+      return `regexp:${value.source}/${value.flags}`;
+    }
+    if (value instanceof Map) {
+      seen.add(value);
+      // Canonicalize by sorted serialized key so insertion order does not
+      // split equal-valued maps. Entries with object keys recurse normally.
+      const entries = [...value.entries()]
+        .map(([k, v]) => `${stableSerialize(k, seen)}:${stableSerialize(v, seen)}`)
+        .sort()
+        .join(',');
+      seen.delete(value);
+      return `map:{${entries}}`;
+    }
+    if (value instanceof Set) {
+      seen.add(value);
+      const values = [...value]
+        .map(v => stableSerialize(v, seen))
+        .sort()
+        .join(',');
+      seen.delete(value);
+      return `set:[${values}]`;
+    }
     if (!isPlainObject(value)) {
-      // Date / Map / Set / RegExp / class instances: identity, not content.
+      // Other class instances: identity, not content (cannot compare safely).
       return nonPlainIdentity(value);
     }
-    const nextSeen = new Set(seen);
-    nextSeen.add(value);
-    return `{${Object.entries(value as Record<string, unknown>)
+    seen.add(value);
+    const stringKeys = Object.keys(value as Record<string, unknown>);
+    const symbolKeys = Object.getOwnPropertySymbols(value);
+    const entries = [
+      ...stringKeys.map(k => [JSON.stringify(k), stableSerialize((value as Record<string, unknown>)[k], seen)] as const),
+      ...symbolKeys.map(s => [nonPlainIdentity(s), stableSerialize((value as Record<symbol, unknown>)[s], seen)] as const),
+    ]
       .sort(([left], [right]) => (left < right ? -1 : left > right ? 1 : 0))
-      .map(([key, entryValue]) => `${JSON.stringify(key)}:${stableSerialize(entryValue, nextSeen)}`)
-      .join(',')}}`;
-  }
-  if (typeof value === 'string') {
-    return `string:${JSON.stringify(value)}`;
+      .map(([k, v]) => `${k}:${v}`)
+      .join(',');
+    seen.delete(value);
+    return `{${entries}}`;
   }
   return `${typeof value}:${String(value)}`;
+}
+
+/**
+ * Drops every renderer cache (parsed-document + diagram namespaces). Call
+ * from a host memory-warning handler (e.g. RN `AppState` 'warning') to
+ * release cached SVGs and ASTs. In-flight renders are untouched — only
+ * completed, retained entries are cleared. Safe to call when caching is
+ * disabled (no-op).
+ */
+export function clearSupramarkRenderCache(): void {
+  rendererCaches.clear();
 }
 
 /** @internal Resets renderer caches for deterministic tests. */

--- a/packages/renderers/rn/src/renderCache.ts
+++ b/packages/renderers/rn/src/renderCache.ts
@@ -241,7 +241,11 @@ export function getRendererCache<T>(
  * serializer is O(depth) rather than the pre-#124 O(depth²) that allocated a
  * new Set per node.
  */
-const nonPlainIdentities = new WeakMap<object | symbol, number>();
+// Functions are objects (WeakMap-keyable). Symbols are primitives, so they
+// cannot key a WeakMap on older TS lib targets — keep a separate Map for
+// them. Config symbol values are rare, so the unbounded Map is acceptable.
+const nonPlainIdentities = new WeakMap<object, number>();
+const symbolIdentities = new Map<symbol, number>();
 let nextNonPlainId = 1;
 
 function isPlainObject(value: object): boolean {
@@ -252,6 +256,15 @@ function isPlainObject(value: object): boolean {
 }
 
 function nonPlainIdentity(value: object | symbol): string {
+  if (typeof value === 'symbol') {
+    const existing = symbolIdentities.get(value);
+    if (existing !== undefined) {
+      return `obj:${existing}`;
+    }
+    const next = nextNonPlainId++;
+    symbolIdentities.set(value, next);
+    return `obj:${next}`;
+  }
   const existing = nonPlainIdentities.get(value);
   if (existing !== undefined) {
     return `obj:${existing}`;

--- a/packages/renderers/rn/src/renderCache.ts
+++ b/packages/renderers/rn/src/renderCache.ts
@@ -357,9 +357,10 @@ export function stableSerialize(value: unknown, seen = new Set<object | symbol>(
 /**
  * Drops every renderer cache (parsed-document + diagram namespaces). Call
  * from a host memory-warning handler (e.g. RN `AppState` 'warning') to
- * release cached SVGs and ASTs. In-flight renders are untouched — only
- * completed, retained entries are cleared. Safe to call when caching is
- * disabled (no-op).
+ * release cached SVGs and ASTs. In-flight renders still resolve to their
+ * callers but their results are discarded (the `.then` runs on the
+ * orphaned cache, not retained into a new one), so the next mount
+ * re-fetches. Safe to call when caching is disabled (no-op).
  */
 export function clearSupramarkRenderCache(): void {
   rendererCaches.clear();


### PR DESCRIPTION
Closes #124.

Carries over every measured follow-up from the #92 review.

## Summary

- **Bound by bytes, not just count** — `LRUCache` gains a `maxBytes` cap; eviction respects both entry count and total estimated size. RN render cache lowers the default to `maxSize: 50` + `maxBytes: 8 MB` and uses a real per-namespace `sizeCalculator` (`svg.length` for diagrams, an AST walk for parsed docs) instead of `() => 1`, which made `totalSize` meaningless.
- **No more stranded caches** — `rendererCaches` is keyed by namespace alone; a policy change `reconfigure()`s the existing `AsyncRendererCache` in place instead of leaking a whole cache per distinct `maxSize:ttl` key (`resolveDocumentCachePolicy` derives `maxSize` from the enabled engine subset, so every subset change stranded a cache before).
- **`shouldRetain` no longer silently overridden** — the predicate is OR-joined across every caller that dedups onto the same in-flight promise, so a `() => true` joiner no longer inherits a first caller's `() => false`.
- **Public drop-cache API** — `export { clearSupramarkRenderCache }` so a host reacting to an `AppState` memory warning can release cached SVGs/ASTs.
- **`stableSerialize` tightened** — `Date`/`RegExp`/`Map`/`Set` compared by value (equal-valued distinct instances now hit the same key instead of missing and evicting a good entry); functions/symbols keep identity (no collision on identical source/description); symbol-keyed props no longer dropped; backtracked `seen`-set makes it O(depth), not O(depth²).
- **Dev deep-freeze of the shared cached AST** — catches a `containerRenderers` annotating nodes in place and cross-contaminating sibling rows; production keeps the freeze off the render path.
- **Doc fix** — `createConfigFromRegistry`'s comment no longer claims RN/Web cache parity; the runtime cache is RN-only (`@supramark/web` forwards `engineConfig.cache` but keeps no document/diagram cache).

## Test plan

- [x] `packages/core/__tests__/cache.test.ts` — byte-cap eviction, single-oversized-entry retention, `reconfigure` (maxSize / maxBytes / ttl)
- [x] `packages/renderers/rn/__tests__/renderCache.test.ts` — equal-valued Date/Map/Set/RegExp hit the same key; functions/symbols don't collide; symbol-keyed props not dropped; deep-chain O(depth); `shouldRetain` OR-join; namespace-only key (reconfigure, not strand); `clearSupramarkRenderCache` alias
- [x] `packages/renderers/rn/__tests__/SupramarkCache.test.tsx` + `DiagramNode.test.tsx` unchanged behavior
- [x] `bun run test` — all workspaces 0 fail
- [x] `eslint` on touched files + `lint:cjk` clean