### PR TITLE
fix(core): treat missing renderers as production-mode validation failure

### DIFF
--- a/packages/core/__tests__/validateFeature.test.ts
+++ b/packages/core/__tests__/validateFeature.test.ts
@@ -186,6 +186,27 @@ describe('validateFeature', () => {
       const result = validateFeature(feature as unknown as Parameters<typeof validateFeature>[0]);
       expect(result.errors.some(e => e.code === 'ast-interface-fields-defined')).toBe(true);
     });
+
+    it('warns when renderers is missing or has no platform renderer', () => {
+      const feature = {
+        metadata: {
+          id: '@supramark/feature-test',
+          name: 'Test Feature',
+          version: '1.0.0',
+        },
+        syntax: {
+          ast: {
+            type: 'test_node',
+          },
+        },
+        // renderers key omitted entirely
+      };
+
+      const result = validateFeature(feature as unknown as Parameters<typeof validateFeature>[0]);
+      expect(result.errors.some(e => e.code === 'renderers-required')).toBe(true);
+      // basic mode treats it as a warning, not a failure
+      expect(result.valid).toBe(true);
+    });
   });
 
   describe('info-level checks', () => {
@@ -264,6 +285,7 @@ describe('validateFeature', () => {
             type: 'test_node',
           },
         },
+        renderers: { rn: { Component: () => null } },
       };
 
       const result = validateFeature(feature as unknown as Parameters<typeof validateFeature>[0], { strict: true });

--- a/packages/core/__tests__/validateFeature.test.ts
+++ b/packages/core/__tests__/validateFeature.test.ts
@@ -318,6 +318,32 @@ describe('validateFeature', () => {
       expect(result.errors.some(e => e.code === 'renderers-required-production')).toBe(true);
     });
 
+    it('fails production mode when renderers is omitted entirely', () => {
+      const feature = {
+        metadata: {
+          id: '@supramark/feature-test',
+          name: 'Test Feature',
+          version: '1.0.0',
+        },
+        syntax: {
+          ast: {
+            type: 'test_node',
+            interface: {
+              required: ['type'],
+              fields: {
+                type: { type: 'string', description: 'Node type' },
+              },
+            },
+          },
+        },
+        // renderers key omitted entirely
+      };
+
+      const result = validateFeature(feature as unknown as Parameters<typeof validateFeature>[0], { production: true });
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.code === 'renderers-required-production')).toBe(true);
+    });
+
     it('suggests providing tests in production mode', () => {
       const feature = {
         metadata: {

--- a/packages/core/src/feature.ts
+++ b/packages/core/src/feature.ts
@@ -1490,6 +1490,19 @@ export function validateFeature<TNode extends SupramarkNode = SupramarkNode>(
     });
   }
 
+  // renderers-required
+  // A Feature without any platform renderer cannot be rendered. Treat absence
+  // the same as an empty `renderers` object. Emitted as `warning` here so strict
+  // mode fails on it; production mode upgrades it to `error` below.
+  const renderers = feature.renderers as RendererDefinitions<SupramarkNode> | undefined;
+  if (!renderers || !(renderers.rn || renderers.web || renderers.cli)) {
+    errors.push({
+      code: 'renderers-required',
+      message: 'Feature must define at least one platform renderer (rn, web, or cli)',
+      severity: 'warning',
+    });
+  }
+
   // ============================================================================
   // Info Rules (info severity) - best practices
   // ============================================================================
@@ -1526,9 +1539,10 @@ export function validateFeature<TNode extends SupramarkNode = SupramarkNode>(
       });
     }
 
-    // In production mode, at least one renderer should be defined.
-    // Absence is treated as a defect (mirroring the `testing` check below) so that a
-    // Partial feature omitting `renderers` cannot slip through the production gate.
+    // In production mode, at least one renderer must be defined. Absence is a
+    // defect, not a skip — a Partial feature omitting `renderers` must not slip
+    // through the production gate. Structurally mirrors the `testing` check below,
+    // but emits `error` (vs `testing`'s `warning`) because renderers are required.
     const renderers = feature.renderers as RendererDefinitions<SupramarkNode> | undefined;
     const hasRenderer = Boolean(renderers && (renderers.rn || renderers.web || renderers.cli));
     if (!hasRenderer) {

--- a/packages/core/src/feature.ts
+++ b/packages/core/src/feature.ts
@@ -1490,12 +1490,11 @@ export function validateFeature<TNode extends SupramarkNode = SupramarkNode>(
     });
   }
 
-  // renderers-required
-  // A Feature without any platform renderer cannot be rendered. Treat absence
-  // the same as an empty `renderers` object. Emitted as `warning` here so strict
-  // mode fails on it; production mode upgrades it to `error` below.
+  // renderers-required (basic + strict). Production mode skips this and emits
+  // the stricter `renderers-required-production` error below.
   const renderers = feature.renderers as RendererDefinitions<SupramarkNode> | undefined;
-  if (!renderers || !(renderers.rn || renderers.web || renderers.cli)) {
+  const hasAnyRenderer = Boolean(renderers && (renderers.rn || renderers.web || renderers.cli));
+  if (!options.production && !hasAnyRenderer) {
     errors.push({
       code: 'renderers-required',
       message: 'Feature must define at least one platform renderer (rn, web, or cli)',
@@ -1541,11 +1540,8 @@ export function validateFeature<TNode extends SupramarkNode = SupramarkNode>(
 
     // In production mode, at least one renderer must be defined. Absence is a
     // defect, not a skip — a Partial feature omitting `renderers` must not slip
-    // through the production gate. Structurally mirrors the `testing` check below,
-    // but emits `error` (vs `testing`'s `warning`) because renderers are required.
-    const renderers = feature.renderers as RendererDefinitions<SupramarkNode> | undefined;
-    const hasRenderer = Boolean(renderers && (renderers.rn || renderers.web || renderers.cli));
-    if (!hasRenderer) {
+    // through the production gate.
+    if (!hasAnyRenderer) {
       errors.push({
         code: 'renderers-required-production',
         message: 'A production Feature must define at least one platform renderer (rn, web, or cli)',

--- a/packages/core/src/feature.ts
+++ b/packages/core/src/feature.ts
@@ -1530,7 +1530,7 @@ export function validateFeature<TNode extends SupramarkNode = SupramarkNode>(
     // Absence is treated as a defect (mirroring the `testing` check below) so that a
     // Partial feature omitting `renderers` cannot slip through the production gate.
     const renderers = feature.renderers as RendererDefinitions<SupramarkNode> | undefined;
-    const hasRenderer = !!renderers && (renderers.rn || renderers.web || renderers.cli);
+    const hasRenderer = Boolean(renderers && (renderers.rn || renderers.web || renderers.cli));
     if (!hasRenderer) {
       errors.push({
         code: 'renderers-required-production',

--- a/packages/core/src/feature.ts
+++ b/packages/core/src/feature.ts
@@ -1526,17 +1526,17 @@ export function validateFeature<TNode extends SupramarkNode = SupramarkNode>(
       });
     }
 
-    // In production mode, at least one renderer should be defined
-    if ('renderers' in feature) {
-      const renderers = feature.renderers as RendererDefinitions<SupramarkNode>;
-      const hasRenderer = renderers && (renderers.rn || renderers.web || renderers.cli);
-      if (!hasRenderer) {
-        errors.push({
-          code: 'renderers-required-production',
-          message: 'A production Feature must define at least one platform renderer (rn, web, or cli)',
-          severity: 'error',
-        });
-      }
+    // In production mode, at least one renderer should be defined.
+    // Absence is treated as a defect (mirroring the `testing` check below) so that a
+    // Partial feature omitting `renderers` cannot slip through the production gate.
+    const renderers = feature.renderers as RendererDefinitions<SupramarkNode> | undefined;
+    const hasRenderer = !!renderers && (renderers.rn || renderers.web || renderers.cli);
+    if (!hasRenderer) {
+      errors.push({
+        code: 'renderers-required-production',
+        message: 'A production Feature must define at least one platform renderer (rn, web, or cli)',
+        severity: 'error',
+      });
     }
 
     // In production mode, tests are recommended


### PR DESCRIPTION
## Summary

- `validateFeature` gated its only renderer check on `if ('renderers' in feature)`, so a `Partial<SupramarkFeature>` omitting the `renderers` key passed production validation with zero renderers.
- The adjacent `testing` check already treats absence as a defect (`!('testing' in feature) || !feature.testing`). This PR makes `renderers` consistent: absence now fires `renderers-required-production`.
- Adds a regression test covering a feature with no `renderers` key submitted in production mode.

Closes #164.

## Test plan

- [x] `bun test packages/core/__tests__/validateFeature.test.ts` — 16 pass
- [x] `tsc --noEmit` (core) — clean
- [ ] CI: `bun run quality`