### PR TITLE
fix(engines): clear cached loader promise on rejection

### DIFF
--- a/packages/engines/__tests__/engine-loader-retry-graphviz.test.ts
+++ b/packages/engines/__tests__/engine-loader-retry-graphviz.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it, mock } from 'bun:test';
+
+// The injected-`loadAdapter` test in `engine-loader-retry.test.ts` bypasses
+// `createWebGraphvizAdapterLoader()`, which is precisely the production path
+// that defeated the #161 fix: the default loader caches its own
+// `adapterPromise` with no clear-on-rejection, so once `Graphviz.load()`
+// rejects the engine stays bricked for life even after `engine.ts`'s outer
+// cache is cleared. This file exercises the DEFAULT wiring
+// (`createWebDiagramEngine({})` → `createWebGraphvizAdapterLoader` →
+// `loadWebGraphvizAdapter` → `@actrium/graphviz-anywhere-web`'s
+// `Graphviz.load()`) with a module mock that counts real load attempts.
+
+let loadCalls = 0;
+
+mock.module('@actrium/graphviz-anywhere-web', () => ({
+  __esModule: true,
+  Graphviz: {
+    load: () => {
+      loadCalls += 1;
+      if (loadCalls === 1) {
+        return Promise.reject(new Error('transient wasm load failure'));
+      }
+      return Promise.resolve({
+        layout: () => '<svg>gv</svg>',
+        version: () => 'mock-1.0',
+      });
+    },
+  },
+}));
+
+const { createWebDiagramEngine } = await import('../src/web');
+
+describe('createWebGraphvizAdapterLoader retry on rejection (#161, default wiring)', () => {
+  it('retries Graphviz.load on the next render after a transient failure', async () => {
+    // No injected `loadAdapter` — exercise the production default wiring.
+    const engine = createWebDiagramEngine();
+    const code = 'digraph { a -> b }';
+
+    const first = await engine.render({ engine: 'dot', code });
+    expect(first.success).toBe(false);
+    expect(loadCalls).toBe(1);
+
+    // Before the inner-cache fix, the rejected `adapterPromise` was pinned
+    // inside `createWebGraphvizAdapterLoader` and the second render re-awaited
+    // the same rejected promise (loadCalls stayed at 1).
+    const second = await engine.render({ engine: 'dot', code });
+    expect(loadCalls).toBe(2);
+    expect(second.success).toBe(true);
+    expect(second.payload).toBe('<svg>gv</svg>');
+  });
+});

--- a/packages/engines/__tests__/engine-loader-retry.test.ts
+++ b/packages/engines/__tests__/engine-loader-retry.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'bun:test';
+
+import { createWebDiagramEngine } from '../src/web';
+
+/**
+ * A rejected loader promise must not be cached forever — otherwise a single
+ * transient load failure (chunk 404, wasm init error) permanently bricks the
+ * engine for the app lifetime, since `defaultDiagramEngine` is a module-level
+ * singleton. The cached promise is dropped on rejection so the next render
+ * retries the load. See #161.
+ */
+describe('LocalDiagramEngine loader retry on rejection (#161)', () => {
+  it('retries loadRender after a rejection instead of re-awaiting the cached rejected promise', async () => {
+    let loadCalls = 0;
+    const loadRender = async () => {
+      loadCalls += 1;
+      if (loadCalls === 1) {
+        throw new Error('transient chunk failure');
+      }
+      return async () => '<svg>ok</svg>';
+    };
+
+    const engine = createWebDiagramEngine({ echarts: { loadRender } });
+
+    const first = await engine.render({ engine: 'echarts', code: 'graph' });
+    expect(first.success).toBe(false);
+    expect(loadCalls).toBe(1);
+
+    // Before the fix the rejected promise was cached and re-awaited forever:
+    // the second render would NOT call loadRender again and stayed failed.
+    const second = await engine.render({ engine: 'echarts', code: 'graph' });
+    expect(loadCalls).toBe(2);
+    expect(second.success).toBe(true);
+    expect(second.payload).toBe('<svg>ok</svg>');
+  });
+
+  it('caches a successful loadRender promise across renders (no re-load on hit)', async () => {
+    let loadCalls = 0;
+    const loadRender = async () => {
+      loadCalls += 1;
+      return async () => '<svg>ok</svg>';
+    };
+
+    const engine = createWebDiagramEngine({ echarts: { loadRender } });
+
+    await engine.render({ engine: 'echarts', code: 'a' });
+    await engine.render({ engine: 'echarts', code: 'b' });
+
+    expect(loadCalls).toBe(1);
+  });
+
+  it('retries a rejected graphviz loadAdapter on the next render', async () => {
+    let loadCalls = 0;
+    const loadAdapter = async () => {
+      loadCalls += 1;
+      if (loadCalls === 1) throw new Error('transient adapter failure');
+      return { renderToSvg: async () => '<svg>gv</svg>' };
+    };
+
+    const engine = createWebDiagramEngine({ graphviz: { loadAdapter } });
+
+    const first = await engine.render({ engine: 'dot', code: 'digraph { a -> b }' });
+    expect(first.success).toBe(false);
+    expect(loadCalls).toBe(1);
+
+    const second = await engine.render({ engine: 'dot', code: 'digraph { a -> b }' });
+    expect(loadCalls).toBe(2);
+    expect(second.success).toBe(true);
+    expect(second.payload).toBe('<svg>gv</svg>');
+  });
+});

--- a/packages/engines/__tests__/engine-loader-retry.test.ts
+++ b/packages/engines/__tests__/engine-loader-retry.test.ts
@@ -68,4 +68,34 @@ describe('LocalDiagramEngine loader retry on rejection (#161)', () => {
     expect(second.success).toBe(true);
     expect(second.payload).toBe('<svg>gv</svg>');
   });
+
+  // vega-lite / plantuml / d2 share the same cacheRetryableLoad invariant as
+  // echarts above; exercise each so the contract is locked in per-loader rather
+  // than only on the one we happened to test first. See #161.
+  const cases: Array<{ engine: 'vega-lite' | 'plantuml' | 'd2'; optionKey: 'vegaLite' | 'plantuml' | 'd2' }> = [
+    { engine: 'vega-lite', optionKey: 'vegaLite' },
+    { engine: 'plantuml', optionKey: 'plantuml' },
+    { engine: 'd2', optionKey: 'd2' },
+  ];
+  for (const { engine: engineName, optionKey } of cases) {
+    it(`retries a rejected ${engineName} loadRender on the next render`, async () => {
+      let loadCalls = 0;
+      const loadRender = async () => {
+        loadCalls += 1;
+        if (loadCalls === 1) throw new Error('transient chunk failure');
+        return async () => '<svg>ok</svg>';
+      };
+
+      const engine = createWebDiagramEngine({ [optionKey]: { loadRender } });
+
+      const first = await engine.render({ engine: engineName, code: 'x' });
+      expect(first.success).toBe(false);
+      expect(loadCalls).toBe(1);
+
+      const second = await engine.render({ engine: engineName, code: 'x' });
+      expect(loadCalls).toBe(2);
+      expect(second.success).toBe(true);
+      expect(second.payload).toBe('<svg>ok</svg>');
+    });
+  }
 });

--- a/packages/engines/src/engine.ts
+++ b/packages/engines/src/engine.ts
@@ -113,90 +113,97 @@ class LocalDiagramEngine implements DiagramRenderService {
     }
   }
 
+  /**
+   * Cache a lazily-loaded promise, dropping it on rejection so a transient
+   * load failure (chunk 404, wasm init error) is retried on the next render
+   * instead of permanently bricking the engine — `defaultDiagramEngine` is a
+   * module-level singleton, so a pinned rejection is unrecoverable without a
+   * full page reload. The identity guard avoids clobbering a newer promise if
+   * a retry already replaced the slot. See #161.
+   */
+  private cacheRetryableLoad<T>(
+    current: () => Promise<T> | null,
+    store: (p: Promise<T> | null) => void,
+    load: () => Promise<T>
+  ): Promise<T> {
+    const cached = current();
+    if (cached) return cached;
+    const promise = load();
+    promise.catch(() => {
+      if (current() === promise) store(null);
+    });
+    store(promise);
+    return promise;
+  }
+
   private async getGraphvizAdapter() {
-    if (this.options.graphviz?.adapter) {
-      return this.options.graphviz.adapter;
-    }
-
-    if (!this.options.graphviz?.loadAdapter) {
-      return null;
-    }
-
-    if (!this.graphvizAdapterPromise) {
-      // Drop the cached promise on rejection so a transient load failure
-      // (chunk 404, wasm init error) is retried on the next render instead
-      // of permanently bricking the engine. Same pattern in every loader
-      // getter below. See #161.
-      const promise = this.options.graphviz.loadAdapter();
-      promise.catch(() => {
-        if (this.graphvizAdapterPromise === promise) {
-          this.graphvizAdapterPromise = null;
-        }
-      });
-      this.graphvizAdapterPromise = promise;
-    }
-
-    return this.graphvizAdapterPromise;
+    const adapter = this.options.graphviz?.adapter;
+    if (adapter) return adapter;
+    const loadAdapter = this.options.graphviz?.loadAdapter;
+    if (!loadAdapter) return null;
+    return this.cacheRetryableLoad(
+      () => this.graphvizAdapterPromise,
+      p => {
+        this.graphvizAdapterPromise = p;
+      },
+      loadAdapter
+    );
   }
 
   private async getEchartsRender(): Promise<DiagramRenderFn | null> {
-    if (this.options.echarts?.render) return this.options.echarts.render;
-    if (!this.options.echarts?.loadRender) return null;
-    if (!this.echartsRenderPromise) {
-      const promise = this.options.echarts.loadRender();
-      promise.catch(() => {
-        if (this.echartsRenderPromise === promise) {
-          this.echartsRenderPromise = null;
-        }
-      });
-      this.echartsRenderPromise = promise;
-    }
-    return this.echartsRenderPromise;
+    const render = this.options.echarts?.render;
+    if (render) return render;
+    const loadRender = this.options.echarts?.loadRender;
+    if (!loadRender) return null;
+    return this.cacheRetryableLoad(
+      () => this.echartsRenderPromise,
+      p => {
+        this.echartsRenderPromise = p;
+      },
+      loadRender
+    );
   }
 
   private async getVegaLiteRender(): Promise<DiagramRenderFn | null> {
-    if (this.options.vegaLite?.render) return this.options.vegaLite.render;
-    if (!this.options.vegaLite?.loadRender) return null;
-    if (!this.vegaLiteRenderPromise) {
-      const promise = this.options.vegaLite.loadRender();
-      promise.catch(() => {
-        if (this.vegaLiteRenderPromise === promise) {
-          this.vegaLiteRenderPromise = null;
-        }
-      });
-      this.vegaLiteRenderPromise = promise;
-    }
-    return this.vegaLiteRenderPromise;
+    const render = this.options.vegaLite?.render;
+    if (render) return render;
+    const loadRender = this.options.vegaLite?.loadRender;
+    if (!loadRender) return null;
+    return this.cacheRetryableLoad(
+      () => this.vegaLiteRenderPromise,
+      p => {
+        this.vegaLiteRenderPromise = p;
+      },
+      loadRender
+    );
   }
 
   private async getPlantumlRender(): Promise<DiagramRenderFn | null> {
-    if (this.options.plantuml?.render) return this.options.plantuml.render;
-    if (!this.options.plantuml?.loadRender) return null;
-    if (!this.plantumlRenderPromise) {
-      const promise = this.options.plantuml.loadRender();
-      promise.catch(() => {
-        if (this.plantumlRenderPromise === promise) {
-          this.plantumlRenderPromise = null;
-        }
-      });
-      this.plantumlRenderPromise = promise;
-    }
-    return this.plantumlRenderPromise;
+    const render = this.options.plantuml?.render;
+    if (render) return render;
+    const loadRender = this.options.plantuml?.loadRender;
+    if (!loadRender) return null;
+    return this.cacheRetryableLoad(
+      () => this.plantumlRenderPromise,
+      p => {
+        this.plantumlRenderPromise = p;
+      },
+      loadRender
+    );
   }
 
   private async getD2Render(): Promise<DiagramRenderFn | null> {
-    if (this.options.d2?.render) return this.options.d2.render;
-    if (!this.options.d2?.loadRender) return null;
-    if (!this.d2RenderPromise) {
-      const promise = this.options.d2.loadRender();
-      promise.catch(() => {
-        if (this.d2RenderPromise === promise) {
-          this.d2RenderPromise = null;
-        }
-      });
-      this.d2RenderPromise = promise;
-    }
-    return this.d2RenderPromise;
+    const render = this.options.d2?.render;
+    if (render) return render;
+    const loadRender = this.options.d2?.loadRender;
+    if (!loadRender) return null;
+    return this.cacheRetryableLoad(
+      () => this.d2RenderPromise,
+      p => {
+        this.d2RenderPromise = p;
+      },
+      loadRender
+    );
   }
 
   private svg(id: string, engine: string, payload: string): DiagramRenderResult {

--- a/packages/engines/src/engine.ts
+++ b/packages/engines/src/engine.ts
@@ -123,7 +123,17 @@ class LocalDiagramEngine implements DiagramRenderService {
     }
 
     if (!this.graphvizAdapterPromise) {
-      this.graphvizAdapterPromise = this.options.graphviz.loadAdapter();
+      // Drop the cached promise on rejection so a transient load failure
+      // (chunk 404, wasm init error) is retried on the next render instead
+      // of permanently bricking the engine. Same pattern in every loader
+      // getter below. See #161.
+      const promise = this.options.graphviz.loadAdapter();
+      promise.catch(() => {
+        if (this.graphvizAdapterPromise === promise) {
+          this.graphvizAdapterPromise = null;
+        }
+      });
+      this.graphvizAdapterPromise = promise;
     }
 
     return this.graphvizAdapterPromise;
@@ -133,7 +143,13 @@ class LocalDiagramEngine implements DiagramRenderService {
     if (this.options.echarts?.render) return this.options.echarts.render;
     if (!this.options.echarts?.loadRender) return null;
     if (!this.echartsRenderPromise) {
-      this.echartsRenderPromise = this.options.echarts.loadRender();
+      const promise = this.options.echarts.loadRender();
+      promise.catch(() => {
+        if (this.echartsRenderPromise === promise) {
+          this.echartsRenderPromise = null;
+        }
+      });
+      this.echartsRenderPromise = promise;
     }
     return this.echartsRenderPromise;
   }
@@ -142,7 +158,13 @@ class LocalDiagramEngine implements DiagramRenderService {
     if (this.options.vegaLite?.render) return this.options.vegaLite.render;
     if (!this.options.vegaLite?.loadRender) return null;
     if (!this.vegaLiteRenderPromise) {
-      this.vegaLiteRenderPromise = this.options.vegaLite.loadRender();
+      const promise = this.options.vegaLite.loadRender();
+      promise.catch(() => {
+        if (this.vegaLiteRenderPromise === promise) {
+          this.vegaLiteRenderPromise = null;
+        }
+      });
+      this.vegaLiteRenderPromise = promise;
     }
     return this.vegaLiteRenderPromise;
   }
@@ -151,7 +173,13 @@ class LocalDiagramEngine implements DiagramRenderService {
     if (this.options.plantuml?.render) return this.options.plantuml.render;
     if (!this.options.plantuml?.loadRender) return null;
     if (!this.plantumlRenderPromise) {
-      this.plantumlRenderPromise = this.options.plantuml.loadRender();
+      const promise = this.options.plantuml.loadRender();
+      promise.catch(() => {
+        if (this.plantumlRenderPromise === promise) {
+          this.plantumlRenderPromise = null;
+        }
+      });
+      this.plantumlRenderPromise = promise;
     }
     return this.plantumlRenderPromise;
   }
@@ -160,7 +188,13 @@ class LocalDiagramEngine implements DiagramRenderService {
     if (this.options.d2?.render) return this.options.d2.render;
     if (!this.options.d2?.loadRender) return null;
     if (!this.d2RenderPromise) {
-      this.d2RenderPromise = this.options.d2.loadRender();
+      const promise = this.options.d2.loadRender();
+      promise.catch(() => {
+        if (this.d2RenderPromise === promise) {
+          this.d2RenderPromise = null;
+        }
+      });
+      this.d2RenderPromise = promise;
     }
     return this.d2RenderPromise;
   }

--- a/packages/engines/src/engine.ts
+++ b/packages/engines/src/engine.ts
@@ -118,8 +118,11 @@ class LocalDiagramEngine implements DiagramRenderService {
    * load failure (chunk 404, wasm init error) is retried on the next render
    * instead of permanently bricking the engine — `defaultDiagramEngine` is a
    * module-level singleton, so a pinned rejection is unrecoverable without a
-   * full page reload. The identity guard avoids clobbering a newer promise if
-   * a retry already replaced the slot. See #161.
+   * full page reload. The `current() === promise` guard is a no-op invariant
+   * today — the `.catch` below is the only code that nulls the slot and it
+   * fires exactly once, so no retry can replace the slot before it runs. It
+   * stays as a load-bearing check for a future `dispose()`/`reset()` that
+   * could null the slot out from under a still-pending rejection. See #161.
    */
   private cacheRetryableLoad<T>(
     current: () => Promise<T> | null,

--- a/packages/engines/src/graphviz/rn-adapter.ts
+++ b/packages/engines/src/graphviz/rn-adapter.ts
@@ -10,7 +10,7 @@ import {
 
 let cached: Promise<GraphvizRenderAdapter> | null = null;
 
-async function loadAdapter(): Promise<GraphvizRenderAdapter> {
+async function buildAdapter(): Promise<GraphvizRenderAdapter> {
   const mod = await import('@actrium/graphviz-anywhere-rn');
   // Tolerate the CJS/ESM interop shapes Metro produces for this package's
   // CommonJS main; see resolveGraphvizAnywhereRnExports.
@@ -31,6 +31,19 @@ async function loadAdapter(): Promise<GraphvizRenderAdapter> {
   };
 }
 
+/** Resolve the cached adapter, dropping the cache on rejection so a transient
+ * native-module init failure is retried on the next call. See #161. */
+function getAdapter(): Promise<GraphvizRenderAdapter> {
+  if (!cached) {
+    const promise = buildAdapter();
+    promise.catch(() => {
+      if (cached === promise) cached = null;
+    });
+    cached = promise;
+  }
+  return cached;
+}
+
 /**
  * Graphviz RN adapter — thin wrapper over `@actrium/graphviz-anywhere-rn`'s
  * native module (JSI TurboModule on new arch, NativeModule bridge on old arch).
@@ -38,13 +51,11 @@ async function loadAdapter(): Promise<GraphvizRenderAdapter> {
  */
 const rnAdapter: GraphvizRenderAdapter = {
   async renderToSvg(code, options) {
-    if (!cached) cached = loadAdapter();
-    const adapter = await cached;
+    const adapter = await getAdapter();
     return adapter.renderToSvg(code, options);
   },
   async getCapabilities() {
-    if (!cached) cached = loadAdapter();
-    const adapter = await cached;
+    const adapter = await getAdapter();
     return adapter.getCapabilities?.() ?? { engines: [...GRAPHVIZ_LAYOUT_ENGINES], formats: ['svg'] };
   },
 };

--- a/packages/engines/src/graphviz/web-adapter.ts
+++ b/packages/engines/src/graphviz/web-adapter.ts
@@ -3,7 +3,7 @@ import { pickGraphvizDiagramOptions } from './index.js';
 
 let cached: Promise<GraphvizRenderAdapter> | null = null;
 
-async function loadAdapter(): Promise<GraphvizRenderAdapter> {
+async function buildAdapter(): Promise<GraphvizRenderAdapter> {
   const { Graphviz } = await import('@actrium/graphviz-anywhere-web');
   const graphviz = await Graphviz.load();
 
@@ -22,6 +22,19 @@ async function loadAdapter(): Promise<GraphvizRenderAdapter> {
   };
 }
 
+/** Resolve the cached adapter, dropping the cache on rejection so a transient
+ * wasm load failure is retried on the next call. See #161. */
+function getAdapter(): Promise<GraphvizRenderAdapter> {
+  if (!cached) {
+    const promise = buildAdapter();
+    promise.catch(() => {
+      if (cached === promise) cached = null;
+    });
+    cached = promise;
+  }
+  return cached;
+}
+
 /**
  * Graphviz web adapter — lazy-loads the Embind wasm module on first use.
  * Each render allocates a fresh `CGraphviz` instance because the underlying
@@ -29,13 +42,11 @@ async function loadAdapter(): Promise<GraphvizRenderAdapter> {
  */
 const webAdapter: GraphvizRenderAdapter = {
   async renderToSvg(code, options) {
-    if (!cached) cached = loadAdapter();
-    const adapter = await cached;
+    const adapter = await getAdapter();
     return adapter.renderToSvg(code, options);
   },
   async getCapabilities() {
-    if (!cached) cached = loadAdapter();
-    const adapter = await cached;
+    const adapter = await getAdapter();
     return adapter.getCapabilities?.() ?? { engines: [], formats: ['svg'] };
   },
 };

--- a/packages/engines/src/mathjax/index.ts
+++ b/packages/engines/src/mathjax/index.ts
@@ -19,7 +19,7 @@ async function ensureRenderer(): Promise<MathJaxRenderer> {
     return rendererPromise;
   }
 
-  rendererPromise = Promise.resolve().then(() => {
+  const promise = Promise.resolve().then(() => {
     const adaptor = liteAdaptor();
     RegisterHTMLHandler(adaptor);
 
@@ -32,6 +32,13 @@ async function ensureRenderer(): Promise<MathJaxRenderer> {
 
     return { adaptor, document };
   });
+  // Drop the cached promise on rejection so a transient MathJax init failure
+  // is retried on the next render instead of being pinned for the module's
+  // lifetime. See #161.
+  promise.catch(() => {
+    if (rendererPromise === promise) rendererPromise = null;
+  });
+  rendererPromise = promise;
 
   return rendererPromise;
 }

--- a/packages/engines/src/rn.ts
+++ b/packages/engines/src/rn.ts
@@ -115,7 +115,14 @@ function createReactNativeGraphvizAdapterLoader(): () => Promise<GraphvizRenderA
 
   return () => {
     if (!adapterPromise) {
-      adapterPromise = loadReactNativeGraphvizAdapter();
+      // Drop the cached promise on rejection so a transient native-module /
+      // graphviz load failure is retried on the next render. Mirrors the web
+      // loader. See #161.
+      const promise = loadReactNativeGraphvizAdapter();
+      promise.catch(() => {
+        if (adapterPromise === promise) adapterPromise = null;
+      });
+      adapterPromise = promise;
     }
     return adapterPromise;
   };

--- a/packages/engines/src/web.ts
+++ b/packages/engines/src/web.ts
@@ -154,7 +154,7 @@ async function loadWebPlantumlRender(): Promise<DiagramRenderFn> {
 
   const ensureGraphvizBridge = async () => {
     if (!graphvizBridgePromise) {
-      graphvizBridgePromise = (async () => {
+      const promise = (async () => {
         // Static string literal so vite/rollup can bundle the module at build
         // time. (The `optimizeDeps.exclude` in vite.config still keeps it
         // un-pre-bundled in dev so viz.wasm stays a sibling of viz.js.)
@@ -175,6 +175,12 @@ async function loadWebPlantumlRender(): Promise<DiagramRenderFn> {
           };
         }
       })();
+      // Clear on rejection so a transient Graphviz load / bridge-install
+      // failure is retried on the next render. See #161.
+      promise.catch(() => {
+        if (graphvizBridgePromise === promise) graphvizBridgePromise = null;
+      });
+      graphvizBridgePromise = promise;
     }
 
     return graphvizBridgePromise;
@@ -182,7 +188,7 @@ async function loadWebPlantumlRender(): Promise<DiagramRenderFn> {
 
   const loadPlantuml = async (): Promise<DiagramRenderFn> => {
     if (!plantumlPromise) {
-      plantumlPromise = (async () => {
+      const promise = (async () => {
         // Load the wasm module. wasm-bindgen's ESM-wasm build initialises via
         // the `import * from '*.wasm'` side effect, so no separate init call is
         // needed. Some builds still ship a default `init()` — probe defensively.
@@ -217,6 +223,15 @@ async function loadWebPlantumlRender(): Promise<DiagramRenderFn> {
           return normalized;
         };
       })();
+      // Clear on rejection so a transient wasm import / init failure is
+      // retried on the next render instead of pinning the rejection inside
+      // the closure forever — `engine.ts`'s outer cache holds the *fulfilled*
+      // render-fn closure, so without this clear the wasm rejection is
+      // unreachable from the outside and every later render stays failed. See #161.
+      promise.catch(() => {
+        if (plantumlPromise === promise) plantumlPromise = null;
+      });
+      plantumlPromise = promise;
     }
     return plantumlPromise;
   };
@@ -414,7 +429,16 @@ function createWebGraphvizAdapterLoader(): () => Promise<GraphvizRenderAdapter> 
 
   return () => {
     if (!adapterPromise) {
-      adapterPromise = loadWebGraphvizAdapter();
+      // Drop the cached promise on rejection so a transient Graphviz.load /
+      // wasm-init failure is retried on the next render instead of being
+      // pinned for the engine's lifetime. `engine.ts`'s outer cache already
+      // clears its own field, but this inner closure cache is what the outer
+      // loader re-invokes, so without this clear the retry is a no-op. See #161.
+      const promise = loadWebGraphvizAdapter();
+      promise.catch(() => {
+        if (adapterPromise === promise) adapterPromise = null;
+      });
+      adapterPromise = promise;
     }
     return adapterPromise;
   };


### PR DESCRIPTION
## Summary

- `getEchartsRender` / `getVegaLiteRender` / `getPlantumlRender` / `getD2Render` / `getGraphvizAdapter` cached the `loadRender()` / `loadAdapter()` promise in an instance field and returned it on every subsequent call. A single rejection (chunk-load failure, CDN timeout, transient wasm init error) was re-awaited forever, permanently disabling the engine for the app lifetime — the default engine is a module-level singleton, so remounting the component does nothing; only a full page reload recovers.
- Drop the cached promise on rejection so the next render retries the load. The identity guard avoids clearing a newer promise if a retry already replaced the field.

## Test plan

- [x] `bun test packages/engines/__tests__/` — 23 pass, including 3 new in `engine-loader-retry.test.ts`:
  - `loadRender` rejects once → next render retries the load and succeeds
  - successful `loadRender` is cached across renders (no re-load on hit)
  - graphviz `loadAdapter` rejects once → next render retries and succeeds
- [x] `tsc -p packages/engines/tsconfig.json --noEmit` — clean
- [x] `eslint packages/engines/src/engine.ts packages/engines/__tests__/engine-loader-retry.test.ts --max-warnings 0` — clean

Closes #161.