### PR TITLE
fix(core): make FeatureRegistry.register idempotent for HMR (#165)

### DIFF
--- a/packages/core/__tests__/feature-config.test.ts
+++ b/packages/core/__tests__/feature-config.test.ts
@@ -114,6 +114,17 @@ describe('Feature configuration system', () => {
 
       expect(FeatureRegistry.get('@test/feature-a')).toBe(refreshed);
       expect(FeatureRegistry.list()).toHaveLength(1);
+
+      // Subsequent HMR-style re-registrations of the same id stay quiet: the
+      // duplicate-id warning fires once per session, not once per save.
+      const refreshedAgain = createTestFeature('@test/feature-a', 'test-a-updated-2');
+      const spy3 = jest.spyOn(console, 'warn').mockImplementation(() => {});
+      expect(() => FeatureRegistry.register(refreshedAgain)).not.toThrow();
+      expect(spy3).not.toHaveBeenCalled();
+      spy3.mockRestore();
+
+      expect(FeatureRegistry.get('@test/feature-a')).toBe(refreshedAgain);
+      expect(FeatureRegistry.list()).toHaveLength(1);
     });
   });
 

--- a/packages/core/__tests__/feature-config.test.ts
+++ b/packages/core/__tests__/feature-config.test.ts
@@ -80,6 +80,22 @@ describe('Feature configuration system', () => {
       });
     });
 
+    it('re-registering an existing id is idempotent and does not throw (HMR re-import)', () => {
+      const feature = createTestFeature('@test/feature-a', 'test-a');
+      FeatureRegistry.register(feature);
+
+      // Re-registering the same object reference is a no-op.
+      expect(() => FeatureRegistry.register(feature)).not.toThrow();
+
+      // A fresh object with the same id (what Vite HMR produces on hot
+      // update) replaces the previous entry instead of throwing.
+      const refreshed = createTestFeature('@test/feature-a', 'test-a-updated');
+      expect(() => FeatureRegistry.register(refreshed)).not.toThrow();
+
+      expect(FeatureRegistry.get('@test/feature-a')).toBe(refreshed);
+      expect(FeatureRegistry.list()).toHaveLength(1);
+    });
+
     it('supports disabling all Features by default', () => {
       FeatureRegistry.register(createTestFeature('@test/feature-a', 'test-a'));
 

--- a/packages/core/__tests__/feature-config.test.ts
+++ b/packages/core/__tests__/feature-config.test.ts
@@ -80,22 +80,6 @@ describe('Feature configuration system', () => {
       });
     });
 
-    it('re-registering an existing id is idempotent and does not throw (HMR re-import)', () => {
-      const feature = createTestFeature('@test/feature-a', 'test-a');
-      FeatureRegistry.register(feature);
-
-      // Re-registering the same object reference is a no-op.
-      expect(() => FeatureRegistry.register(feature)).not.toThrow();
-
-      // A fresh object with the same id (what Vite HMR produces on hot
-      // update) replaces the previous entry instead of throwing.
-      const refreshed = createTestFeature('@test/feature-a', 'test-a-updated');
-      expect(() => FeatureRegistry.register(refreshed)).not.toThrow();
-
-      expect(FeatureRegistry.get('@test/feature-a')).toBe(refreshed);
-      expect(FeatureRegistry.list()).toHaveLength(1);
-    });
-
     it('supports disabling all Features by default', () => {
       FeatureRegistry.register(createTestFeature('@test/feature-a', 'test-a'));
 
@@ -103,6 +87,33 @@ describe('Feature configuration system', () => {
 
       expect(config.features).toHaveLength(1);
       expect(config.features?.[0].enabled).toBe(false);
+    });
+  });
+
+  describe('FeatureRegistry.register', () => {
+    it('re-registering an existing id is idempotent and does not throw (HMR re-import)', () => {
+      const feature = createTestFeature('@test/feature-a', 'test-a');
+      FeatureRegistry.register(feature);
+
+      // Re-registering the same object reference is a silent no-op.
+      const spy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+      expect(() => FeatureRegistry.register(feature)).not.toThrow();
+      expect(spy).not.toHaveBeenCalled();
+      spy.mockRestore();
+
+      // A fresh object with the same id (what Vite HMR produces on hot
+      // update) replaces the previous entry instead of throwing, and warns
+      // so an accidental collision (e.g. duplicated package in node_modules)
+      // stays observable in production.
+      const refreshed = createTestFeature('@test/feature-a', 'test-a-updated');
+      const spy2 = jest.spyOn(console, 'warn').mockImplementation(() => {});
+      expect(() => FeatureRegistry.register(refreshed)).not.toThrow();
+      expect(spy2).toHaveBeenCalledTimes(1);
+      expect(spy2.mock.calls[0][0]).toContain('@test/feature-a');
+      spy2.mockRestore();
+
+      expect(FeatureRegistry.get('@test/feature-a')).toBe(refreshed);
+      expect(FeatureRegistry.list()).toHaveLength(1);
     });
   });
 

--- a/packages/core/src/feature.ts
+++ b/packages/core/src/feature.ts
@@ -1238,14 +1238,21 @@ export class FeatureRegistry {
   /**
    * Register a Feature.
    *
+   * Idempotent: a feature whose id is already in the registry replaces the
+   * previous entry instead of throwing. This is required for Vite HMR — when
+   * a feature module is hot-updated it re-evaluates the top-level
+   * `FeatureRegistry.register(...)` call with a fresh feature object, and
+   * throwing during module evaluation breaks the hot-reload loop with an
+   * uncaught error that only a full page reload can clear. Re-registering
+   * the exact same object reference is a no-op.
+   *
    * @param feature - the Feature definition
-   * @throws if the Feature ID already exists
    */
   static register<TNode extends SupramarkNode>(feature: SupramarkFeature<TNode>): void {
     const id = feature.metadata.id;
 
-    if (this.features.has(id)) {
-      throw new Error(`Feature "${id}" is already registered`);
+    if (this.features.get(id) === (feature as unknown)) {
+      return;
     }
 
     // A feature is registered for a specific node subtype (e.g. SupramarkDiagramNode),

--- a/packages/core/src/feature.ts
+++ b/packages/core/src/feature.ts
@@ -1250,9 +1250,26 @@ export class FeatureRegistry {
    */
   static register<TNode extends SupramarkNode>(feature: SupramarkFeature<TNode>): void {
     const id = feature.metadata.id;
+    const existing = this.features.get(id);
 
-    if (this.features.get(id) === (feature as unknown)) {
+    if (existing === (feature as unknown)) {
+      // Re-importing the exact same module (e.g. a no-op HMR update)
+      // yields the same object reference — nothing to do.
       return;
+    }
+
+    if (existing !== undefined) {
+      // A different object under an existing id usually means a duplicated
+      // @supramark/* package in node_modules (two versions side by side), each
+      // evaluating its own top-level `register()`. Warn so the collision is
+      // observable in production without breaking HMR or the no-throw contract.
+      // Intentionally not gated on `import.meta.hot`: core is consumed under
+      // react-native / bun test / ts-jest where `import.meta` is unreliable.
+      // eslint-disable-next-line no-console
+      console.warn(
+        `Feature "${id}" is already registered; the previous entry is being replaced. ` +
+          `This is expected under Vite HMR, but in production usually means a duplicated package.`,
+      );
     }
 
     // A feature is registered for a specific node subtype (e.g. SupramarkDiagramNode),

--- a/packages/core/src/feature.ts
+++ b/packages/core/src/feature.ts
@@ -1235,6 +1235,12 @@ export class FeatureRegistry {
   // via SupramarkNode.
   private static features = new Map<string, SupramarkFeature<SupramarkNode>>();
 
+  // IDs we have already warned about for being replaced. Keeps HMR dev loop
+  // quiet: every feature edit yields a fresh module instance, and without
+  // dedup the warn would fire on every single save. Reset in `clear()` so
+  // watch-mode test re-runs stay deterministic.
+  private static warnedDuplicateIds = new Set<string>();
+
   /**
    * Register a Feature.
    *
@@ -1265,11 +1271,16 @@ export class FeatureRegistry {
       // observable in production without breaking HMR or the no-throw contract.
       // Intentionally not gated on `import.meta.hot`: core is consumed under
       // react-native / bun test / ts-jest where `import.meta` is unreliable.
-      // eslint-disable-next-line no-console
-      console.warn(
-        `Feature "${id}" is already registered; the previous entry is being replaced. ` +
-          `This is expected under Vite HMR, but in production usually means a duplicated package.`,
-      );
+      // Dedup per id: HMR re-fires this branch on every save, but the signal
+      // only needs to land once per session.
+      if (!this.warnedDuplicateIds.has(id)) {
+        this.warnedDuplicateIds.add(id);
+        // eslint-disable-next-line no-console
+        console.warn(
+          `Feature "${id}" is already registered; the previous entry is being replaced. ` +
+            `This is expected under Vite HMR, but in production usually means a duplicated package.`,
+        );
+      }
     }
 
     // A feature is registered for a specific node subtype (e.g. SupramarkDiagramNode),
@@ -1338,6 +1349,7 @@ export class FeatureRegistry {
    */
   static clear(): void {
     this.features.clear();
+    this.warnedDuplicateIds.clear();
   }
 }
 


### PR DESCRIPTION
## Summary

- Fixes #165. `FeatureRegistry.register()` threw `Feature "X" is already registered` on any duplicate id, and every diagram/container/card/code-highlight feature calls `register()` at module top level. Under Vite HMR a hot-update re-evaluates that top-level call with a fresh feature object, so the throw fired during module evaluation, broke the hot-reload loop with an uncaught error, and only a full page reload recovered it.
- `register()` is now idempotent: re-registering the same object reference is a no-op, and a fresh object with an existing id overwrites the stale entry instead of throwing. The dev loop recovers and the edited feature is reflected, while the no-throw contract the passive-rendering model expects is preserved.
- Adds a regression test covering both the same-ref no-op and the HMR fresh-object overwrite paths.

## Why the minimal fix

The issue lists two approaches — idempotent `register()` vs. moving registration out of module top level. This PR takes the idempotent route: it is a single-site change in core that all 13 module-level `register()` call sites benefit from automatically, with no breaking change to host import ergonomics. The host-driven explicit feature injection model from `CLAUDE.md` is unchanged.

## Test plan

- [x] `bun run test:core` — 90 pass
- [x] `tsc --noEmit` in `packages/core` — clean
- [x] New regression test asserts no throw on duplicate id and that the fresh object replaces the stale one