### PR TITLE
fix(web): honor engineConfig.cache via a real diagram cache (#163)

### DIFF
--- a/packages/renderers/web/__tests__/SupramarkCache.test.tsx
+++ b/packages/renderers/web/__tests__/SupramarkCache.test.tsx
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, setSystemTime, test } from 'bun:test';
 import React from 'react';
 import { Window } from 'happy-dom';
 import { createRoot, type Root } from 'react-dom/client';
@@ -40,6 +40,8 @@ afterEach(async () => {
     root = null;
   }
   browser.document.body.replaceChildren();
+  // Reset any mocked system time so it can't leak into the next test.
+  setSystemTime();
 });
 
 function createContainer(): TestContainer {
@@ -103,17 +105,35 @@ async function renderDocument(config: unknown): Promise<void> {
         })
       )
     );
-    // Let the async effect (expandOpaqueContainers + preRenderAll) settle.
-    await Promise.resolve();
-    await Promise.resolve();
-    await Promise.resolve();
   });
+  // Let the async effect (expandOpaqueContainers + preRenderAll) settle.
+  await settle();
 }
 
 async function unmount(): Promise<void> {
   if (root) {
     await act(async () => root?.unmount());
     root = null;
+  }
+}
+
+// Flush microtasks until engineState.renderCalls has been stable for a few
+// consecutive ticks. Covers both the cache-miss path (count increments once
+// then settles) and the cache-hit path (count never moves) without depending
+// on a fixed number of awaits — robust to the effect gaining an extra async
+// tick. Uses a tick counter rather than Date.now() so mocked time can't hang
+// the loop.
+async function settle(stableTicks = 3, maxTicks = 1000): Promise<void> {
+  let last = engineState.renderCalls;
+  let stable = 0;
+  for (let i = 0; i < maxTicks; i++) {
+    await Promise.resolve();
+    if (engineState.renderCalls === last) {
+      if (++stable >= stableTicks) return;
+    } else {
+      last = engineState.renderCalls;
+      stable = 0;
+    }
   }
 }
 
@@ -203,10 +223,8 @@ describe('Supramark web diagram cache', () => {
           })
         )
       );
-      await Promise.resolve();
-      await Promise.resolve();
-      await Promise.resolve();
     });
+    await settle();
     expect(engineState.renderCalls).toBe(1);
     await unmount();
 
@@ -224,11 +242,34 @@ describe('Supramark web diagram cache', () => {
           })
         )
       );
-      await Promise.resolve();
-      await Promise.resolve();
-      await Promise.resolve();
     });
+    await settle();
     expect(engineState.renderCalls).toBe(2);
     await unmount();
+  });
+
+  test('re-renders after the cache entry ttl expires', async () => {
+    // LRUCache expires entries by Date.now() - timestamp > ttl, so advancing
+    // the mocked clock past the ttl window must invalidate the prior render
+    // and force a fresh engine.render call on the next mount.
+    const config = {
+      diagram: { defaultCache: { enabled: true, maxSize: 10, ttl: 1000 } },
+    };
+
+    setSystemTime(new Date('2026-01-01T00:00:00Z'));
+    await renderDocument(config);
+    expect(engineState.renderCalls).toBe(1);
+
+    await unmount();
+    // Advance 2s — past the 1s ttl — then remount: the cached entry is stale.
+    setSystemTime(new Date('2026-01-01T00:00:02Z'));
+    await renderDocument(config);
+    expect(engineState.renderCalls).toBe(2);
+
+    await unmount();
+    // Without further time advancing, the freshly cached entry is still live
+    // and a third mount is a cache hit again.
+    await renderDocument(config);
+    expect(engineState.renderCalls).toBe(2);
   });
 });

--- a/packages/renderers/web/__tests__/SupramarkCache.test.tsx
+++ b/packages/renderers/web/__tests__/SupramarkCache.test.tsx
@@ -1,0 +1,234 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import React from 'react';
+import { Window } from 'happy-dom';
+import { createRoot, type Root } from 'react-dom/client';
+import type { DiagramRenderResult, DiagramRenderService } from '@supramark/engines';
+import type { SupramarkRootNode } from '@supramark/core';
+
+import { Supramark } from '../src/Supramark';
+import { DiagramEngineContext } from '../src/DiagramEngineProvider';
+import { clearWebRendererCaches } from '../src/renderCache';
+
+/**
+ * Integration tests for the web renderer's diagram cache (issue #163).
+ *
+ * Before this cache existed, `engineConfig.cache` was a silent no-op on web:
+ * `buildDiagramRenderOptions` forwarded the field into render `options`, but
+ * no web engine read it, so every remount re-ran the full wasm render. These
+ * tests pin the contract that a host's cache policy is now honored.
+ */
+
+type TestAct = (callback: () => void | Promise<void>) => Promise<void>;
+const act = (React as typeof React & { act: TestAct }).act;
+const browser = new Window();
+Object.assign(globalThis, {
+  window: browser,
+  document: browser.document,
+  navigator: browser.navigator,
+  HTMLElement: browser.HTMLElement,
+  Node: browser.Node,
+});
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT =
+  true;
+
+let root: Root | null = null;
+type TestContainer = ReturnType<typeof browser.document.createElement>;
+
+afterEach(async () => {
+  if (root) {
+    await act(async () => root?.unmount());
+    root = null;
+  }
+  browser.document.body.replaceChildren();
+});
+
+function createContainer(): TestContainer {
+  const container = browser.document.createElement('div');
+  browser.document.body.appendChild(container);
+  root = createRoot(container as unknown as HTMLDivElement);
+  return container;
+}
+
+// Controlled engine: counts render calls so a cache miss/hit is observable.
+// Returning a resolved promise mirrors the real async render boundary.
+const engineState = {
+  renderCalls: 0,
+};
+
+const controlledDiagramEngine: DiagramRenderService = {
+  render: () => {
+    engineState.renderCalls += 1;
+    return Promise.resolve(successResult());
+  },
+};
+
+function successResult(): DiagramRenderResult {
+  return {
+    id: 'test',
+    engine: 'mermaid',
+    success: true,
+    format: 'svg',
+    payload: '<svg data-test="mermaid"></svg>',
+  };
+}
+
+function diagramAst(): SupramarkRootNode {
+  return {
+    type: 'root',
+    ast_version: 2,
+    diagnostics: [],
+    children: [
+      {
+        type: 'diagram',
+        engine: 'mermaid',
+        code: 'graph TD; A-->B;',
+        fence_closed: true,
+      } as never,
+    ],
+  } as SupramarkRootNode;
+}
+
+async function renderDocument(config: unknown): Promise<void> {
+  createContainer();
+  await act(async () => {
+    root?.render(
+      React.createElement(
+        DiagramEngineContext.Provider,
+        { value: controlledDiagramEngine },
+        React.createElement(Supramark, {
+          markdown: '',
+          ast: diagramAst(),
+          sourceState: 'complete',
+          config: config as never,
+        })
+      )
+    );
+    // Let the async effect (expandOpaqueContainers + preRenderAll) settle.
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+async function unmount(): Promise<void> {
+  if (root) {
+    await act(async () => root?.unmount());
+    root = null;
+  }
+}
+
+describe('Supramark web diagram cache', () => {
+  beforeEach(() => {
+    clearWebRendererCaches();
+    engineState.renderCalls = 0;
+  });
+
+  test('reuses an engine render across remounts when cache is enabled', async () => {
+    const config = {
+      diagram: { defaultCache: { enabled: true, maxSize: 10, ttl: 60_000 } },
+    };
+    await renderDocument(config);
+    expect(engineState.renderCalls).toBe(1);
+
+    await unmount();
+    await renderDocument(config);
+    // Second mount hits the cache: no additional engine.render call.
+    expect(engineState.renderCalls).toBe(1);
+  });
+
+  test('shares cache entries across equivalent inline config objects', async () => {
+    await renderDocument({ diagram: { defaultCache: { enabled: true, maxSize: 10 } } });
+    expect(engineState.renderCalls).toBe(1);
+
+    await unmount();
+    // A fresh inline config object with the same resolved policy must hit the
+    // same cache bucket (policy key is namespace+maxSize+ttl, not identity).
+    await renderDocument({ diagram: { defaultCache: { enabled: true, maxSize: 10 } } });
+    expect(engineState.renderCalls).toBe(1);
+  });
+
+  test('re-renders on every mount when caching is disabled', async () => {
+    const config = {
+      diagram: { defaultCache: { enabled: false } },
+    };
+    await renderDocument(config);
+    expect(engineState.renderCalls).toBe(1);
+
+    await unmount();
+    await renderDocument(config);
+    expect(engineState.renderCalls).toBe(2);
+  });
+
+  test('honors an enabled per-engine cache without global cache', async () => {
+    const config = () => ({
+      options: { cache: false },
+      diagram: {
+        engines: {
+          mermaid: { cache: { enabled: true, maxSize: 10, ttl: 60_000 } },
+        },
+      },
+    });
+    await renderDocument(config());
+    expect(engineState.renderCalls).toBe(1);
+
+    await unmount();
+    await renderDocument(config());
+    expect(engineState.renderCalls).toBe(1);
+  });
+
+  test('a changed engine instance bypasses the prior cache', async () => {
+    // A different engine identity gets a different cache key prefix, so a host
+    // swapping engine instances never serves another engine's cached SVG.
+    const otherEngine: DiagramRenderService = {
+      render: () => {
+        engineState.renderCalls += 1;
+        return Promise.resolve(successResult());
+      },
+    };
+    const config = {
+      diagram: { defaultCache: { enabled: true, maxSize: 10, ttl: 60_000 } },
+    };
+
+    createContainer();
+    await act(async () => {
+      root?.render(
+        React.createElement(
+          DiagramEngineContext.Provider,
+          { value: controlledDiagramEngine },
+          React.createElement(Supramark, {
+            markdown: '',
+            ast: diagramAst(),
+            sourceState: 'complete',
+            config,
+          })
+        )
+      );
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(engineState.renderCalls).toBe(1);
+    await unmount();
+
+    createContainer();
+    await act(async () => {
+      root?.render(
+        React.createElement(
+          DiagramEngineContext.Provider,
+          { value: otherEngine },
+          React.createElement(Supramark, {
+            markdown: '',
+            ast: diagramAst(),
+            sourceState: 'complete',
+            config,
+          })
+        )
+      );
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(engineState.renderCalls).toBe(2);
+    await unmount();
+  });
+});

--- a/packages/renderers/web/__tests__/renderCache.test.ts
+++ b/packages/renderers/web/__tests__/renderCache.test.ts
@@ -65,6 +65,13 @@ describe('stableSerialize', () => {
     expect(stableSerialize([1, [2, 3]])).toBe(stableSerialize([1, [2, 3]]));
     expect(stableSerialize([1, [2, 3]])).not.toBe(stableSerialize([1, [2, 4]]));
   });
+
+  it('a function value uses identity, not source text', () => {
+    const f1 = () => 1;
+    const f2 = () => 1;
+    expect(stableSerialize({ fn: f1 })).not.toBe(stableSerialize({ fn: f2 }));
+    expect(stableSerialize({ fn: f1 })).toBe(stableSerialize({ fn: f1 }));
+  });
 });
 
 describe('resolveRendererCachePolicy', () => {

--- a/packages/renderers/web/__tests__/renderCache.test.ts
+++ b/packages/renderers/web/__tests__/renderCache.test.ts
@@ -1,0 +1,225 @@
+import { beforeEach, describe, expect, it } from 'bun:test';
+
+import type { DiagramRenderResult } from '@supramark/engines';
+import {
+  clearWebRendererCaches,
+  getRendererCache,
+  resolveDiagramCachePolicy,
+  resolveRendererCachePolicy,
+  stableSerialize,
+} from '../src/renderCache';
+import type { AsyncRendererCache } from '../src/renderCache';
+
+/**
+ * Tests for the web renderer cache. The AsyncRendererCache / policy resolvers
+ * are a direct port of the RN renderer's cache (issue #163), so these tests
+ * mirror packages/renderers/rn/__tests__/renderCache.test.ts.
+ */
+
+describe('stableSerialize', () => {
+  it('distinguishes options containing different Date values (no longer collide on the same key)', () => {
+    const a = { since: new Date('2026-01-01'), label: 'x' };
+    const b = { since: new Date('2020-06-15'), label: 'x' };
+    expect(stableSerialize(a)).not.toBe(stableSerialize(b));
+  });
+
+  it('distinguishes options containing different Map values', () => {
+    const a = { tags: new Map([['k', 'v1']]) };
+    const b = { tags: new Map([['k', 'v2']]) };
+    expect(stableSerialize(a)).not.toBe(stableSerialize(b));
+  });
+
+  it('distinguishes options containing different Set values', () => {
+    const a = { set: new Set([1, 2, 3]) };
+    const b = { set: new Set([4, 5, 6]) };
+    expect(stableSerialize(a)).not.toBe(stableSerialize(b));
+  });
+
+  it('serializing the same non-plain instance multiple times yields the same key (identity-stable)', () => {
+    const date = new Date('2026-01-01');
+    expect(stableSerialize({ d: date })).toBe(stableSerialize({ d: date }));
+  });
+
+  it('a circular reference does not throw a RangeError', () => {
+    const cyclic: Record<string, unknown> = { a: 1 };
+    cyclic.self = cyclic;
+    expect(() => stableSerialize(cyclic)).not.toThrow();
+  });
+
+  it('a plain object is still serialized by structure + sorted keys', () => {
+    expect(stableSerialize({ b: 2, a: 1 })).toBe(stableSerialize({ a: 1, b: 2 }));
+    expect(stableSerialize({ a: 1 })).not.toBe(stableSerialize({ a: 2 }));
+  });
+
+  it('number and string do not collide on the same key', () => {
+    expect(stableSerialize(1)).not.toBe(stableSerialize('1'));
+  });
+
+  it('null and undefined are each independent', () => {
+    expect(stableSerialize(null)).toBe('null');
+    expect(stableSerialize(undefined)).toBe('undefined');
+    expect(stableSerialize(null)).not.toBe(stableSerialize(undefined));
+  });
+
+  it('nested arrays are serialized by structure', () => {
+    expect(stableSerialize([1, [2, 3]])).toBe(stableSerialize([1, [2, 3]]));
+    expect(stableSerialize([1, [2, 3]])).not.toBe(stableSerialize([1, [2, 4]]));
+  });
+});
+
+describe('resolveRendererCachePolicy', () => {
+  it('defaults to disabled when neither override nor fallback enable it', () => {
+    expect(resolveRendererCachePolicy(undefined, undefined).enabled).toBe(false);
+  });
+
+  it('falls back to global cache when no engine policy is set', () => {
+    expect(resolveRendererCachePolicy(undefined, { enabled: true }).enabled).toBe(true);
+  });
+
+  it('engine override wins over fallback', () => {
+    const policy = resolveRendererCachePolicy({ enabled: false, maxSize: 5 }, { enabled: true });
+    expect(policy.enabled).toBe(false);
+    expect(policy.maxSize).toBe(5);
+  });
+
+  it('clamps a non-finite maxSize to the default', () => {
+    const policy = resolveRendererCachePolicy(
+      { enabled: true, maxSize: Number.POSITIVE_INFINITY },
+      undefined
+    );
+    expect(policy.maxSize).toBe(100);
+  });
+
+  it('drops a non-positive ttl', () => {
+    expect(resolveRendererCachePolicy({ enabled: true, ttl: 0 }).ttl).toBeUndefined();
+    expect(resolveRendererCachePolicy({ enabled: true, ttl: -5 }).ttl).toBeUndefined();
+  });
+});
+
+describe('resolveDiagramCachePolicy', () => {
+  it('resolves engine > diagram default > global precedence', () => {
+    const policy = resolveDiagramCachePolicy(
+      { enabled: true, maxSize: 7 },
+      { enabled: true, maxSize: 50 },
+      false
+    );
+    expect(policy.enabled).toBe(true);
+    expect(policy.maxSize).toBe(7);
+  });
+
+  it('global cache enables when no explicit policy is set', () => {
+    const policy = resolveDiagramCachePolicy(undefined, undefined, true);
+    expect(policy.enabled).toBe(true);
+  });
+
+  it('explicitly disabled engine cache wins even when global is true', () => {
+    const policy = resolveDiagramCachePolicy({ enabled: false }, undefined, true);
+    expect(policy.enabled).toBe(false);
+  });
+});
+
+describe('getRendererCache', () => {
+  beforeEach(() => {
+    clearWebRendererCaches();
+  });
+
+  it('returns undefined when caching is disabled', () => {
+    expect(getRendererCache<DiagramRenderResult>('diagram', resolveRendererCachePolicy(undefined, undefined))).toBeUndefined();
+  });
+
+  it('returns a shared cache for an equivalent policy key', () => {
+    const policy = resolveRendererCachePolicy({ enabled: true, maxSize: 10 }, undefined);
+    const a = getRendererCache<DiagramRenderResult>('diagram', policy);
+    const b = getRendererCache<DiagramRenderResult>('diagram', policy);
+    expect(a).toBe(b);
+  });
+
+  it('returns a distinct cache when maxSize differs', () => {
+    const p1 = getRendererCache<DiagramRenderResult>('diagram', resolveRendererCachePolicy({ enabled: true, maxSize: 10 }, undefined));
+    const p2 = getRendererCache<DiagramRenderResult>('diagram', resolveRendererCachePolicy({ enabled: true, maxSize: 20 }, undefined));
+    expect(p1).not.toBe(p2);
+  });
+});
+
+describe('AsyncRendererCache', () => {
+  beforeEach(() => {
+    clearWebRendererCaches();
+  });
+
+  function makeCache(): AsyncRendererCache<DiagramRenderResult> {
+    const policy = resolveRendererCachePolicy({ enabled: true, maxSize: 10 }, undefined);
+    return getRendererCache<DiagramRenderResult>('diagram', policy)!;
+  }
+
+  it('shares in-flight work for the same key', async () => {
+    const cache = makeCache();
+    let calls = 0;
+    const factory = () => {
+      calls += 1;
+      return new Promise<DiagramRenderResult>(resolve => {
+        setTimeout(() => {
+          calls += 0;
+          resolve(successResult());
+        }, 0);
+      });
+    };
+    const [a, b] = await Promise.all([
+      cache.getOrCreate('k', factory, r => r.success),
+      cache.getOrCreate('k', factory, r => r.success),
+    ]);
+    expect(calls).toBe(1);
+    expect(a).toBe(b);
+  });
+
+  it('serves a completed value on a later getOrCreate', async () => {
+    const cache = makeCache();
+    let calls = 0;
+    const factory = () => {
+      calls += 1;
+      return Promise.resolve(successResult());
+    };
+    await cache.getOrCreate('k', factory, r => r.success);
+    const second = await cache.getOrCreate('k', factory, r => r.success);
+    expect(calls).toBe(1);
+    expect(second.success).toBe(true);
+  });
+
+  it('does not retain an unsuccessful result so the next call retries', async () => {
+    const cache = makeCache();
+    let calls = 0;
+    const factory = () => {
+      calls += 1;
+      return Promise.resolve(errorResult());
+    };
+    await cache.getOrCreate('k', factory, r => r.success);
+    await cache.getOrCreate('k', factory, r => r.success);
+    expect(calls).toBe(2);
+  });
+
+  it('returns the cached value synchronously from get', async () => {
+    const cache = makeCache();
+    await cache.getOrCreate('k', () => Promise.resolve(successResult()), r => r.success);
+    expect(cache.get('k')?.success).toBe(true);
+  });
+});
+
+function successResult(): DiagramRenderResult {
+  return {
+    id: 'test',
+    engine: 'mermaid',
+    success: true,
+    format: 'svg',
+    payload: '<svg></svg>',
+  };
+}
+
+function errorResult(): DiagramRenderResult {
+  return {
+    id: 'test',
+    engine: 'mermaid',
+    success: false,
+    format: 'error',
+    payload: 'boom',
+    error: { code: 'render_error', message: 'boom' },
+  };
+}

--- a/packages/renderers/web/src/Supramark.tsx
+++ b/packages/renderers/web/src/Supramark.tsx
@@ -37,6 +37,11 @@ import { DiagramEngineContext } from './DiagramEngineProvider.js';
 import { ErrorBoundary, type ErrorInfo, ErrorDisplay } from './ErrorBoundary.js';
 import { MathBlockWeb, MathInlineWeb } from './MathBlockWeb.js';
 import { SourceStateContext } from './SourceStateContext.js';
+import {
+  getRendererCache,
+  resolveDiagramCachePolicy,
+  stableSerialize,
+} from './renderCache.js';
 
 export interface ContainerRendererWeb {
   (args: {
@@ -76,6 +81,7 @@ export interface SupramarkRenderState {
 type RenderTask = {
   key: string;
   engine: string;
+  rawEngine: string;
   code: string;
   options?: Record<string, unknown>;
 };
@@ -110,6 +116,21 @@ function getDefinitionDescriptions(
 }
 
 const defaultDiagramEngine = createWebDiagramEngine();
+
+// Engine identities prevent an injected renderer from reading another engine's
+// cached result, and isolate cache entries when a host swaps engine instances.
+const diagramEngineIds = new WeakMap<DiagramRenderService, number>();
+let nextDiagramEngineId = 1;
+
+function getDiagramEngineId(engine: DiagramRenderService): number {
+  const existing = diagramEngineIds.get(engine);
+  if (existing !== undefined) {
+    return existing;
+  }
+  const next = nextDiagramEngineId++;
+  diagramEngineIds.set(engine, next);
+  return next;
+}
 
 interface WebDiagramNodeProps {
   node: SupramarkDiagramNode;
@@ -246,7 +267,12 @@ export const Supramark: React.FC<SupramarkWebProps> = ({
           });
         }
 
-        const renderedMap = await preRenderAll(renderTasks, diagramEngine);
+        const renderedMap = await preRenderAll(
+          renderTasks,
+          diagramEngine,
+          config?.diagram,
+          config?.options?.cache
+        );
         const highlightedMap = await preHighlightAll(highlightTasks, codeHighlighter);
 
         if (!cancelled) {
@@ -1645,6 +1671,7 @@ function collectRenderTasks(
           tasks.push({
             key: buildRenderKey(diagram.engine, diagram.code, diagram.meta),
             engine: normalizeRenderEngine(diagram.engine),
+            rawEngine: diagram.engine,
             code: diagram.code,
             options: buildDiagramRenderOptions(diagram.engine, diagram.meta, config?.diagram),
           });
@@ -1655,6 +1682,7 @@ function collectRenderTasks(
           tasks.push({
             key: buildRenderKey('math', mathBlock.value, { displayMode: true }),
             engine: 'math',
+            rawEngine: 'math',
             code: mathBlock.value,
             options: { displayMode: true },
           });
@@ -1665,6 +1693,7 @@ function collectRenderTasks(
           tasks.push({
             key: buildRenderKey('math', mathInline.value, { displayMode: false }),
             engine: 'math',
+            rawEngine: 'math',
             code: mathInline.value,
             options: { displayMode: false },
           });
@@ -1717,7 +1746,9 @@ function collectCodeHighlightTasks(
 
 async function preRenderAll(
   tasks: RenderTask[],
-  engine: DiagramRenderService
+  engine: DiagramRenderService,
+  diagramConfig?: SupramarkDiagramConfig,
+  globalCache?: boolean
 ): Promise<Map<string, DiagramRenderResult>> {
   if (tasks.length === 0) {
     return new Map();
@@ -1731,14 +1762,33 @@ async function preRenderAll(
   }
 
   const taskList = [...unique.values()];
+  const engineId = getDiagramEngineId(engine);
   const results = await Promise.all(
-    taskList.map(task =>
-      engine.render({
-        engine: task.engine,
-        code: task.code,
-        options: task.options,
-      })
-    )
+    taskList.map(task => {
+      // Resolve the cache policy the same way the RN renderer does: engine
+      // override > diagram.defaultCache > global options.cache. Without this,
+      // engineConfig.cache is a silent no-op on web (issue #163).
+      const cachePolicy = resolveDiagramCachePolicy(
+        diagramConfig?.engines?.[task.rawEngine]?.cache,
+        diagramConfig?.defaultCache,
+        globalCache
+      );
+      const diagramCache = getRendererCache<DiagramRenderResult>('diagram', cachePolicy);
+      // Include the engine identity and the full resolved options so a cached
+      // result cannot cross engine instances or option variants (e.g. a
+      // different PlantUML server URL).
+      const cacheKey = `${engineId} ${task.engine} ${task.code} ${stableSerialize(task.options)}`;
+
+      const render = () =>
+        engine.render({ engine: task.engine, code: task.code, options: task.options });
+
+      if (!diagramCache) {
+        return render();
+      }
+      // Retain only successful results so a transient engine error can be retried
+      // on the next mount instead of being served from cache.
+      return diagramCache.getOrCreate(cacheKey, render, result => result.success);
+    })
   );
 
   return new Map(taskList.map((task, index) => [task.key, results[index]]));
@@ -1850,22 +1900,6 @@ function buildDiagramRenderOptions(
   }
 
   return { ...base, ...meta };
-}
-
-function stableSerialize(value: unknown): string {
-  if (value === null || value === undefined) {
-    return '';
-  }
-  if (Array.isArray(value)) {
-    return `[${value.map(stableSerialize).join(',')}]`;
-  }
-  if (typeof value === 'object') {
-    return `{${Object.entries(value as Record<string, unknown>)
-      .sort(([left], [right]) => left.localeCompare(right))
-      .map(([key, entryValue]) => `${key}:${stableSerialize(entryValue)}`)
-      .join(',')}}`;
-  }
-  return String(value);
 }
 
 function renderDisabledDiagram(

--- a/packages/renderers/web/src/Supramark.tsx
+++ b/packages/renderers/web/src/Supramark.tsx
@@ -1776,8 +1776,10 @@ async function preRenderAll(
       const diagramCache = getRendererCache<DiagramRenderResult>('diagram', cachePolicy);
       // Include the engine identity and the full resolved options so a cached
       // result cannot cross engine instances or option variants (e.g. a
-      // different PlantUML server URL).
-      const cacheKey = `${engineId} ${task.engine} ${task.code} ${stableSerialize(task.options)}`;
+      // different PlantUML server URL). Serialize the tuple as an array so
+      // task.code — arbitrary diagram text that may contain spaces or braces —
+      // can't collide with another (code, options) pair on the delimiter.
+      const cacheKey = stableSerialize([engineId, task.engine, task.code, task.options]);
 
       const render = () =>
         engine.render({ engine: task.engine, code: task.code, options: task.options });

--- a/packages/renderers/web/src/renderCache.ts
+++ b/packages/renderers/web/src/renderCache.ts
@@ -1,0 +1,222 @@
+import { LRUCache } from '@supramark/core';
+
+/** Runtime cache policy resolved from the host's Supramark configuration. */
+export interface RendererCachePolicy {
+  enabled: boolean;
+  maxSize: number;
+  ttl?: number;
+}
+
+/** Cache policy input accepted by existing Supramark diagram configuration. */
+export interface RendererCachePolicyInput {
+  enabled?: boolean;
+  maxSize?: number;
+  ttl?: number;
+}
+
+// Default bounds apply only when a host explicitly enables caching without limits.
+const DEFAULT_CACHE_MAX_SIZE = 100;
+
+/**
+ * Keeps resolved values in the core LRU cache and shares equivalent in-flight work.
+ * Rejected work is never retained, so a later mount can retry normally.
+ */
+export class AsyncRendererCache<T> {
+  private readonly values: LRUCache<T>;
+  private readonly pending = new Map<string, Promise<T>>();
+
+  constructor(policy: RendererCachePolicy) {
+    this.values = new LRUCache<T>({
+      maxSize: policy.maxSize,
+      ttl: policy.ttl,
+      // Eviction is entry-count based (LRUCache compares cache.size to maxSize),
+      // so each entry contributes a fixed unit. Override the default
+      // sizeCalculator — which JSON.stringifies the whole value on every set()
+      // (entire AST / SVG string) to feed a totalSize stat that never affects
+      // eviction — to avoid that O(payload) work in the render path.
+      sizeCalculator: () => 1,
+    });
+  }
+
+  /** Returns a resolved cache value synchronously for first-render restoration. */
+  get(key: string): T | undefined {
+    return this.values.get(key);
+  }
+
+  /** Returns cached work or starts one shared asynchronous computation. */
+  getOrCreate(
+    key: string,
+    factory: () => Promise<T>,
+    shouldRetain: (value: T) => boolean = () => true
+  ): Promise<T> {
+    const cached = this.values.get(key);
+    if (cached !== undefined) {
+      return Promise.resolve(cached);
+    }
+
+    const existing = this.pending.get(key);
+    if (existing) {
+      return existing;
+    }
+
+    const promise = factory()
+      .then(value => {
+        if (shouldRetain(value)) {
+          this.values.set(key, value);
+        }
+        return value;
+      })
+      .finally(() => {
+        if (this.pending.get(key) === promise) {
+          this.pending.delete(key);
+        }
+      });
+
+    this.pending.set(key, promise);
+    return promise;
+  }
+}
+
+// Renderer-level caches are keyed by namespace and policy rather than config identity.
+// This lets equivalent inline config objects share completed and in-flight work while
+// each AsyncRendererCache remains bounded by its resolved LRU policy.
+//
+// Lifecycle note: the key encodes `namespace:maxSize:ttl`, so if a host changes cache
+// policy at runtime (e.g. maxSize 10 -> 20) a NEW AsyncRendererCache is created under
+// the new key and the old one stays in this Map. This is intentional: we cannot safely
+// tell whether the old cache is still referenced by an in-flight render. The leak is
+// bounded — each stranded cache holds at most `maxSize` entries plus a transient
+// `pending` map — and changing policy at runtime is rare (policy usually comes from a
+// static host config for the whole app lifetime), so no proactive sweep is wired.
+const rendererCaches = new Map<string, AsyncRendererCache<unknown>>();
+
+/** Resolves an engine override on top of the diagram-wide cache policy. */
+export function resolveRendererCachePolicy(
+  override: RendererCachePolicyInput | undefined,
+  fallback: RendererCachePolicyInput | undefined
+): RendererCachePolicy {
+  const enabled = override?.enabled ?? fallback?.enabled ?? false;
+  const configuredMaxSize = override?.maxSize ?? fallback?.maxSize ?? DEFAULT_CACHE_MAX_SIZE;
+  const configuredTtl = override?.ttl ?? fallback?.ttl;
+
+  return {
+    enabled,
+    maxSize: Number.isFinite(configuredMaxSize)
+      ? Math.max(0, Math.floor(configuredMaxSize))
+      : DEFAULT_CACHE_MAX_SIZE,
+    ttl:
+      configuredTtl !== undefined && Number.isFinite(configuredTtl) && configuredTtl > 0
+        ? configuredTtl
+        : undefined,
+  };
+}
+
+/** Resolves engine > diagram default > global cache precedence. */
+export function resolveDiagramCachePolicy(
+  enginePolicy: RendererCachePolicyInput | undefined,
+  diagramPolicy: RendererCachePolicyInput | undefined,
+  globalCache: boolean | undefined
+): RendererCachePolicy {
+  const diagramFallback = resolveRendererCachePolicy(
+    diagramPolicy,
+    globalCache === undefined ? undefined : { enabled: globalCache }
+  );
+  return resolveRendererCachePolicy(enginePolicy, diagramFallback);
+}
+
+/** Returns the renderer-level cache for one namespace and resolved policy. */
+export function getRendererCache<T>(
+  namespace: string,
+  policy: RendererCachePolicy
+): AsyncRendererCache<T> | undefined {
+  // maxSize:0 means "zero capacity", i.e. nothing can be retained, so caching is
+  // disabled even when policy.enabled is true. Note this can surprise a host that
+  // sets options.cache:true together with diagram.defaultCache.maxSize:0: the
+  // explicit zero capacity wins and documents are not cached. The combination is
+  // self-consistent (0 capacity stores nothing) but uncommon — if both signals
+  // appear, raise the maxSize rather than relying on the global toggle here.
+  if (!policy.enabled || policy.maxSize === 0) {
+    return undefined;
+  }
+
+  const policyKey = `${namespace}:${policy.maxSize}:${policy.ttl ?? 'none'}`;
+  let cache = rendererCaches.get(policyKey);
+  if (!cache) {
+    cache = new AsyncRendererCache<unknown>(policy);
+    rendererCaches.set(policyKey, cache);
+  }
+
+  return cache as AsyncRendererCache<T>;
+}
+
+/**
+ * Deterministically serializes JSON-like render options for cache keys.
+ *
+ * Plain objects/arrays are serialized structurally; non-plain values
+ * (Date / Map / Set / RegExp / class instances / functions) cannot be compared
+ * by content cheaply or safely, so each distinct instance gets a stable
+ * process-local identity id via a WeakMap. This keeps two options objects that
+ * differ only by Date/Map/Set value from colliding on the same cache key (which
+ * would serve a wrong cached SVG), and a cyclic config object from overflowing
+ * the stack (the seen-set short-circuits re-entrant cycles to the identity id).
+ */
+const nonPlainIdentities = new WeakMap<object, number>();
+let nextNonPlainId = 1;
+
+function isPlainObject(value: object): boolean {
+  // Object.getPrototypeOf is typed `any` in the ES5 lib, so assert the return
+  // to keep the type-aware lint (no-unsafe-assignment) happy.
+  const proto = Object.getPrototypeOf(value) as object | null;
+  return proto === null || proto === Object.prototype;
+}
+
+function nonPlainIdentity(value: object): string {
+  const existing = nonPlainIdentities.get(value);
+  if (existing !== undefined) {
+    return `obj:${existing}`;
+  }
+  const next = nextNonPlainId++;
+  nonPlainIdentities.set(value, next);
+  return `obj:${next}`;
+}
+
+export function stableSerialize(value: unknown, seen = new Set<object>()): string {
+  if (value === null) {
+    return 'null';
+  }
+  if (value === undefined) {
+    return 'undefined';
+  }
+  if (Array.isArray(value)) {
+    if (seen.has(value)) {
+      return nonPlainIdentity(value);
+    }
+    const nextSeen = new Set(seen);
+    nextSeen.add(value);
+    return `[${value.map(item => stableSerialize(item, nextSeen)).join(',')}]`;
+  }
+  if (typeof value === 'object') {
+    if (seen.has(value)) {
+      return nonPlainIdentity(value);
+    }
+    if (!isPlainObject(value)) {
+      // Date / Map / Set / RegExp / class instances: identity, not content.
+      return nonPlainIdentity(value);
+    }
+    const nextSeen = new Set(seen);
+    nextSeen.add(value);
+    return `{${Object.entries(value as Record<string, unknown>)
+      .sort(([left], [right]) => (left < right ? -1 : left > right ? 1 : 0))
+      .map(([key, entryValue]) => `${JSON.stringify(key)}:${stableSerialize(entryValue, nextSeen)}`)
+      .join(',')}}`;
+  }
+  if (typeof value === 'string') {
+    return `string:${JSON.stringify(value)}`;
+  }
+  return `${typeof value}:${String(value)}`;
+}
+
+/** @internal Resets renderer caches for deterministic tests. */
+export function clearWebRendererCaches(): void {
+  rendererCaches.clear();
+}

--- a/packages/renderers/web/src/renderCache.ts
+++ b/packages/renderers/web/src/renderCache.ts
@@ -210,6 +210,11 @@ export function stableSerialize(value: unknown, seen = new Set<object>()): strin
       .map(([key, entryValue]) => `${JSON.stringify(key)}:${stableSerialize(entryValue, nextSeen)}`)
       .join(',')}}`;
   }
+  if (typeof value === 'function') {
+    // Source text isn't a stable key (engines may reorder params, truncate
+    // bodies); treat functions like non-plain objects — identity-stable.
+    return nonPlainIdentity(value);
+  }
   if (typeof value === 'string') {
     return `string:${JSON.stringify(value)}`;
   }


### PR DESCRIPTION
## Summary

The web renderer had no module-level runtime cache — `AsyncRendererCache | getRendererCache | renderCache | LRUCache` returned zero hits across `packages/renderers/web/src/`. `buildDiagramRenderOptions` forwarded `engineConfig.cache` into render `options`, but no web engine read `options.cache` either, so a host setting `diagram.engines.mermaid.cache = { enabled: true, maxSize: 50 }` on web got nothing — the option was silently dropped (#163). On remount-heavy hosts (virtual-list recycling, tab switches, React strict-mode remounts) every diagram re-ran the full wasm render from scratch — a doc with 20 mermaid blocks re-ran all wasm work on every scroll-back.

### Fix

Port the RN renderer's `AsyncRendererCache` to web ([packages/renderers/web/src/renderCache.ts](packages/renderers/web/src/renderCache.ts)) and consume the resolved cache policy inside `preRenderAll`, mirroring `DiagramNode.tsx` on RN:

- `resolveDiagramCachePolicy(engine > diagram.defaultCache > global options.cache)`
- `getRendererCache('diagram', policy)` — shared, policy-keyed LRU
- `getOrCreate` keyed by engine identity + engine + code + resolved options, so a cached result cannot cross engine instances or option variants (e.g. a different PlantUML server URL)
- retain only successful results (`result.success`) so a transient engine error is retried on the next mount instead of being served from cache

`buildRenderKey` now uses the shared `stableSerialize`, which also handles cycles and non-plain option values (Date / Map / Set) that previously collided on the same key.

### Scope note

The document-level (parsed-document) cache is intentionally **not** ported. Web's `ParsedDocument` bundles the `rendered` map, so caching it safely would require fingerprinting the whole diagram config in the cache key; the diagram cache alone resolves both the silent no-op (the headline bug) and the remount perf cliff (the headline symptom). Parse cost on remount is negligible relative to wasm rendering.

## Test plan

- [x] `bun --filter @supramark/web build` (tsc --emitDeclarationOnly) passes
- [x] `bun run build` (repo-wide) passes
- [x] eslint clean on changed files
- [x] `bun test` in `packages/renderers/web` — 54 pass (added 24 + 5 cache tests, no regressions)

New tests (`packages/renderers/web/__tests__/`):
- `renderCache.test.ts` — `stableSerialize` collision/cycle coverage, policy resolution precedence, `getRendererCache` sharing, `AsyncRendererCache` in-flight dedup + error-retry contract
- `SupramarkCache.test.tsx` — remount reuses the engine render when cache is enabled; re-renders when disabled; per-engine cache honored without global cache; swapping the engine instance bypasses the prior cache

Closes #163.