### PR TITLE
fix(rn-selection): enforce viewport gesture boundaries

### DIFF
--- a/packages/renderers/rn-selection/src/__tests__/coordinator/SelectionRoot.test.tsx
+++ b/packages/renderers/rn-selection/src/__tests__/coordinator/SelectionRoot.test.tsx
@@ -863,6 +863,93 @@ describe('SelectionRoot responder negotiation', () => {
     expect(activity).toEqual([true, false]);
   });
 
+  test('a handle that starts outside a viewport cannot select into it', () => {
+    const scopedUnits: SelectionUnit[] = [
+      {
+        kind: 'text',
+        unitId: 'outside#0',
+        nodeId: 'outside',
+        text: 'outer',
+        node: NODE,
+      },
+      {
+        kind: 'text',
+        unitId: 'inside#0',
+        nodeId: 'inside',
+        text: 'inner',
+        node: NODE,
+      },
+    ];
+    let store: SelectionStore | null = null;
+
+    const RegisterBlocks: React.FC = () => {
+      const ctx = useSelectionContext();
+      useEffect(() => {
+        store = ctx.store;
+        const disposeOutside = ctx.registerBlock({
+          nodeId: 'outside',
+          unitIds: ['outside#0'],
+          kind: 'text',
+          rect: { x: 10, y: 10, w: 60, h: 20 },
+        });
+        const disposeInside = ctx.registerBlock({
+          nodeId: 'inside',
+          unitIds: ['inside#0'],
+          kind: 'text',
+          rect: { x: 10, y: 100, w: 60, h: 20 },
+          viewportId: 'list',
+        });
+        return () => {
+          disposeOutside();
+          disposeInside();
+        };
+      }, [ctx]);
+      return null;
+    };
+
+    act(() => {
+      renderer = create(
+        <SelectionRoot units={scopedUnits} overlay={false} toolbar={false}>
+          <RegisterBlocks />
+        </SelectionRoot>
+      );
+    });
+    if (store === null) throw new Error('test did not capture the selection store');
+    act(() => {
+      store.beginAt({ nodeId: 'outside', unitId: 'outside#0', offset: 0 });
+      store.extendTo({ nodeId: 'outside', unitId: 'outside#0', offset: 5 });
+      store.commit();
+    });
+
+    const knobs = renderer.root
+      .findAllByType('View' as unknown as React.ElementType)
+      .filter(node => {
+        const style = node.props.style as {
+          backgroundColor?: string;
+          width?: number;
+          top?: number;
+        };
+        return style?.backgroundColor === '#3399ff' && style.width === 12;
+      })
+      .sort(
+        (a, b) =>
+          ((a.props.style as { top: number }).top ?? 0) -
+          ((b.props.style as { top: number }).top ?? 0)
+      );
+    const endKnob = knobs[1];
+    if (endKnob === undefined) throw new Error('test did not find the end handle');
+
+    act(() => {
+      endKnob.props.onResponderGrant(eventAt(70, 36));
+      endKnob.props.onResponderMove(eventAt(50, 110), { dx: -20, dy: 74 });
+    });
+
+    expect(store.getSnapshot().range).toEqual({
+      anchor: { nodeId: 'outside', unitId: 'outside#0', offset: 0 },
+      focus: { nodeId: 'outside', unitId: 'outside#0', offset: 5 },
+    });
+  });
+
   test('a selection viewport locks only the enclosing scroller during its own touch', async () => {
     const activity: boolean[] = [];
 
@@ -905,6 +992,46 @@ describe('SelectionRoot responder negotiation', () => {
     act(() => {
       scrollView.props.onMomentumScrollBegin(eventAt(20, 120));
       scrollView.props.onMomentumScrollEnd(eventAt(20, 120));
+    });
+    expect(activity).toEqual([true, false]);
+  });
+
+  test('momentum releases a swallowed viewport touch before the fling continues', () => {
+    const activity: boolean[] = [];
+
+    act(() => {
+      renderer = create(
+        <SelectionRoot
+          units={UNITS}
+          overlay={false}
+          handles={false}
+          toolbar={false}
+          onGestureActiveChange={active => activity.push(active)}
+        >
+          <SelectionViewport style={{ height: 80 }}>
+            {React.createElement('ScrollView')}
+          </SelectionViewport>
+        </SelectionRoot>
+      );
+    });
+
+    const viewport = renderer.root
+      .findAllByType('View' as unknown as React.ElementType)
+      .find(node => typeof node.props.onTouchStart === 'function');
+    const scrollView = renderer.root.findByType('ScrollView' as unknown as React.ElementType);
+    if (viewport === undefined) throw new Error('test did not find the selection viewport');
+
+    act(() => {
+      viewport.props.onTouchStart(eventAt(20, 120));
+      scrollView.props.onScrollBeginDrag(eventAt(20, 120));
+      // Android sometimes omits the bubbling touch end/cancel. End-drag alone
+      // cannot release while that stale touch flag remains set.
+      scrollView.props.onScrollEndDrag(eventAt(20, 120));
+    });
+    expect(activity).toEqual([true]);
+
+    act(() => {
+      scrollView.props.onMomentumScrollBegin(eventAt(20, 120));
     });
     expect(activity).toEqual([true, false]);
   });

--- a/packages/renderers/rn-selection/src/__tests__/coordinator/hitTest.test.ts
+++ b/packages/renderers/rn-selection/src/__tests__/coordinator/hitTest.test.ts
@@ -11,6 +11,7 @@ import {
   pointInRect,
   resolvePointToSelection,
   resolvePointToSelectionInViewport,
+  resolvePointToSelectionOutsideViewports,
   verticalGap,
 } from '../../coordinator/hitTest';
 
@@ -141,6 +142,18 @@ describe('resolvePointToSelection', () => {
     expect(resolvePointToSelectionInViewport(scoped, { x: 50, y: 500 }, index, 'list')).toEqual({
       nodeId: 'C',
       unitId: 'C#0',
+      offset: 5,
+    });
+  });
+
+  test('a drag from root content cannot enter a nested viewport', () => {
+    const scoped = blocks();
+    scoped[1].viewportId = 'list';
+    scoped[1].clipRect = rectB;
+
+    expect(resolvePointToSelectionOutsideViewports(scoped, { x: 90, y: 40 }, index)).toEqual({
+      nodeId: 'A',
+      unitId: 'A#0',
       offset: 5,
     });
   });

--- a/packages/renderers/rn-selection/src/coordinator/SelectionRoot.tsx
+++ b/packages/renderers/rn-selection/src/coordinator/SelectionRoot.tsx
@@ -26,6 +26,7 @@ import {
   containingBlock,
   resolvePointToSelection,
   resolvePointToSelectionInViewport,
+  resolvePointToSelectionOutsideViewports,
   type Point,
 } from './hitTest';
 import { computeSelectionRects, type OverlayRect } from './overlay';
@@ -170,7 +171,12 @@ export const SelectionRoot: React.FC<SelectionRootProps> = ({
   const gestureActiveRef = useRef(false);
   const viewportInteractionsRef = useRef(new Set<string>());
   const hostScrollLockedRef = useRef(false);
-  const gestureViewportIdRef = useRef<string | undefined>(undefined);
+  // `undefined` means that no block owned the gesture start, `null` is the
+  // explicit scope for root content outside nested viewports, and a string is
+  // one particular nested viewport. Keeping `null` distinct prevents an
+  // outside handle from crossing into a FlatList (the reverse of the already
+  // constrained inside-to-outside direction).
+  const gestureViewportIdRef = useRef<string | null | undefined>(undefined);
 
   const publishHostScrollLock = useCallback(() => {
     const locked = gestureActiveRef.current || viewportInteractionsRef.current.size > 0;
@@ -287,8 +293,11 @@ export const SelectionRoot: React.FC<SelectionRootProps> = ({
     (point: Point) => {
       const blocks = registry.getBlocks();
       const viewportId = gestureViewportIdRef.current;
-      return viewportId === undefined
-        ? resolvePointToSelection(blocks, point, registry.index)
+      if (viewportId === undefined) {
+        return resolvePointToSelection(blocks, point, registry.index);
+      }
+      return viewportId === null
+        ? resolvePointToSelectionOutsideViewports(blocks, point, registry.index)
         : resolvePointToSelectionInViewport(blocks, point, registry.index, viewportId);
     },
     [registry]
@@ -315,7 +324,7 @@ export const SelectionRoot: React.FC<SelectionRootProps> = ({
         moving.unitId === undefined
           ? registry.getBlock(moving.nodeId)
           : registry.getBlockForUnit(moving.unitId);
-      gestureViewportIdRef.current = block?.viewportId;
+      gestureViewportIdRef.current = block === undefined ? undefined : (block.viewportId ?? null);
     },
     [registry, store]
   );
@@ -404,7 +413,8 @@ export const SelectionRoot: React.FC<SelectionRootProps> = ({
       const point = toRootSpace(e);
       const edge = handleAt(point);
       if (edge === null) {
-        gestureViewportIdRef.current = containingBlock(registry.getBlocks(), point)?.viewportId;
+        const block = containingBlock(registry.getBlocks(), point);
+        gestureViewportIdRef.current = block === null ? undefined : (block.viewportId ?? null);
       } else {
         scopeGestureToHandle(edge);
       }

--- a/packages/renderers/rn-selection/src/coordinator/SelectionViewport.tsx
+++ b/packages/renderers/rn-selection/src/coordinator/SelectionViewport.tsx
@@ -151,9 +151,18 @@ export const SelectionViewport: React.FC<SelectionViewportProps> = ({ children, 
   const childOnMomentumScrollBegin = children.props.onMomentumScrollBegin;
   const onMomentumScrollBegin = useCallback(
     (event: NativeSyntheticEvent<NativeScrollEvent>) => {
+      // Momentum starts only after the finger has left the native scroller.
+      // Android can swallow the matching JS touch-end/cancel, leaving
+      // `touchingRef` stale and the enclosing host interaction locked for the
+      // whole fling. Treat this native lifecycle event as the authoritative
+      // release signal.
+      touchingRef.current = false;
+      draggingRef.current = false;
+      clearReleaseTimer();
+      releaseIfIdle();
       childOnMomentumScrollBegin?.(event);
     },
-    [childOnMomentumScrollBegin]
+    [childOnMomentumScrollBegin, clearReleaseTimer, releaseIfIdle]
   );
 
   const childOnMomentumScrollEnd = children.props.onMomentumScrollEnd;

--- a/packages/renderers/rn-selection/src/coordinator/hitTest.ts
+++ b/packages/renderers/rn-selection/src/coordinator/hitTest.ts
@@ -213,3 +213,23 @@ export function resolvePointToSelectionInViewport(
         };
   return resolvePointToSelection(scoped, point, index);
 }
+
+/**
+ * Resolve a drag that started outside every nested selection viewport.
+ *
+ * `undefined` is a real ownership scope here, not "all blocks": without this
+ * filter a handle on ordinary root content can cross into a FlatList, even
+ * though the inverse direction is constrained by
+ * `resolvePointToSelectionInViewport`.
+ */
+export function resolvePointToSelectionOutsideViewports(
+  blocks: readonly RegisteredBlock[],
+  p: Point,
+  index: SelectionUnitIndex
+): SelectionPoint | null {
+  return resolvePointToSelection(
+    blocks.filter(block => block.viewportId === undefined),
+    p,
+    index
+  );
+}


### PR DESCRIPTION
## Summary

- treat root content outside nested selection viewports as an explicit gesture ownership scope
- prevent outside-in handle drags from selecting FlatList content, matching the existing inside-out clamp
- release stale viewport touch ownership when native momentum begins so UI outside the FlatList remains interactive during a fling
- add pure hit-test and component-level responder regressions for both directions

Closes #182
Closes #183

## Verification

- `bun test packages/renderers/rn-selection/src/__tests__` — 291 pass, 0 fail, 711 expectations
- `bun run build` in `packages/renderers/rn-selection` — pass
- `bun run lint` — pass (ESLint, 21 feature packages, CJK)
- `bun run lint:types` — 0 findings
- `bun run quality` — pass
- Prettier and `git diff --check` — pass

The repository root test command also ran this package successfully (291/291). Its aggregate process later failed while core and RN concurrently rebuilt the same markdown WASM and inherited the developer machine's native `-fuse-ld=mold` flag into `rust-lld`; that repository-level command/environment issue is unrelated to these TypeScript-only changes and is being handled separately in #186.