### PR TITLE
fix(rn): preserve list markers on task items

### DIFF
--- a/packages/renderers/rn/__tests__/list.test.tsx
+++ b/packages/renderers/rn/__tests__/list.test.tsx
@@ -96,8 +96,24 @@ describe('list rendering', () => {
       listAst({ ordered: false, items: [{ checked: false, text: 'a' }, { checked: true, text: 'b' }] }),
     );
     const texts = textContents(r.root);
-    expect(texts).toContain('☐ a');
-    expect(texts).toContain('☑ b');
+    expect(texts).toContain('• ☐ a');
+    expect(texts).toContain('• ☑ b');
+  });
+
+  it('ordered task list preserves numeric markers before checkboxes', async () => {
+    const r = await renderAst(
+      listAst({
+        ordered: true,
+        start: 3,
+        items: [
+          { checked: false, text: 'a' },
+          { checked: true, text: 'b' },
+        ],
+      }),
+    );
+    const texts = textContents(r.root);
+    expect(texts).toContain('3. ☐ a');
+    expect(texts).toContain('4. ☑ b');
   });
 });
 

--- a/packages/renderers/rn/src/Supramark.tsx
+++ b/packages/renderers/rn/src/Supramark.tsx
@@ -588,7 +588,7 @@ function renderNode(
       const item = node;
       const isTaskList = item.checked !== undefined;
       const checkSymbol = item.checked === true ? '☑' : '☐';
-      const marker = isTaskList ? `${checkSymbol} ` : `${listMarker ?? '•'} `;
+      const marker = `${listMarker ?? '•'} ${isTaskList ? `${checkSymbol} ` : ''}`;
 
       // Tight list (inline-only children): plain <Text>, width-safe (see #101).
       if (item.children.every(isInlineNode)) {


### PR DESCRIPTION
## Summary

- keep each list marker when rendering GFM task items in React Native
- render ordered task items as `3. ☐ item` / `4. ☑ item` instead of dropping their numbers
- keep the unordered bullet before its checkbox and add regression coverage for both forms

Closes #95

## Verification

- `bun test packages/renderers/rn/__tests__/list.test.tsx` — 9 pass, 0 fail, 17 expectations
- `RUSTFLAGS="-C debuginfo=0" bun --filter @supramark/rn test` — 116 pass, 0 fail, 226 expectations; browser/node WASM and TypeScript builds pass
- `bun run lint` — pass
- `bun run lint:types` — 0 findings
- `RUSTFLAGS="-C debuginfo=0" bun run quality` — pass
- focused ESLint and `git diff --check` — pass

The explicit Rust flag only neutralizes this developer machines global `-fuse-ld=mold` setting for WASM. The repository-level fix is tracked separately in #186.