### PR TITLE
fix(conformance): close remaining harness blind spots

### DIFF
--- a/.github/workflows/markdown-conformance.yml
+++ b/.github/workflows/markdown-conformance.yml
@@ -132,6 +132,10 @@ jobs:
         working-directory: tests/markdown-conformance
         run: pnpm install --frozen-lockfile
 
+      - name: Run conformance harness unit tests
+        working-directory: tests/markdown-conformance
+        run: pnpm test:unit
+
       - name: Install Playwright Chromium
         if: env.RUN_VISUAL == 'true'
         working-directory: tests/markdown-conformance
@@ -139,6 +143,11 @@ jobs:
 
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@1.97.0
+
+      - name: Cache Cargo build
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: markdown-conformance
 
       - name: Import locked data sources
         run: node tests/markdown-conformance/scripts/import.mjs "$SOURCE_NAME"
@@ -246,7 +255,7 @@ jobs:
             gh issue list \
               --repo "$GH_REPO" \
               --state open \
-              --limit 100 \
+              --limit 1000 \
               --json number,title,body \
               | jq -r \
                   --arg title "$issue_title" \

--- a/.prettierignore
+++ b/.prettierignore
@@ -4,6 +4,7 @@ dist
 build
 .next
 .expo
+tests/cases/_fixtures
 
 # Vendored native primitives
 packages/renderers/rn-selection/native/selectable-rich-text

--- a/tests/markdown-conformance/README.md
+++ b/tests/markdown-conformance/README.md
@@ -31,7 +31,7 @@ tests/cases/_fixtures/commonmark/
 
 Run from the repository root:
 
-```powershell
+```console
 node tests/markdown-conformance/scripts/import.mjs commonmark
 node tests/markdown-conformance/scripts/validate.mjs commonmark
 ```
@@ -50,7 +50,7 @@ tests/cases/_fixtures/cmark-gfm/
   NOTICE.md
 ```
 
-```powershell
+```console
 node tests/markdown-conformance/scripts/import.mjs cmark-gfm
 node tests/markdown-conformance/scripts/validate.mjs cmark-gfm
 ```
@@ -59,7 +59,7 @@ node tests/markdown-conformance/scripts/validate.mjs cmark-gfm
 
 The micromark adapter discovers core Markdown-to-HTML assertions from `test/io/**/*.js` at the pinned commit. It excludes aggregation-only modules, stream tests, and constant-table tests. In an isolated capture environment it preserves Markdown input, expected HTML, upstream options, test names, and source line numbers, producing 1,151 normalized cases. Newly matching files require no changes to the import entry point or explicit path list.
 
-```powershell
+```console
 node tests/markdown-conformance/scripts/import.mjs micromark
 node tests/markdown-conformance/scripts/validate.mjs micromark
 ```
@@ -70,14 +70,14 @@ To add another source, provide a source configuration and adapter. The generic e
 
 Install the isolated dependencies and Chromium:
 
-```powershell
+```console
 pnpm --dir tests/markdown-conformance install --frozen-lockfile
 node tests/markdown-conformance/node_modules/playwright/cli.js install chromium
 ```
 
 Build the parser, then run semantic or visual comparison:
 
-```powershell
+```console
 cargo build -p supramark-markdown --bin supramark-markdown
 node tests/markdown-conformance/scripts/run.mjs <source-name>
 node tests/markdown-conformance/scripts/run-visual.mjs <source-name>
@@ -85,7 +85,7 @@ node tests/markdown-conformance/scripts/run-visual.mjs <source-name>
 
 The directly supported source names are `commonmark`, `cmark-gfm`, and `micromark`. For example:
 
-```powershell
+```console
 node tests/markdown-conformance/scripts/run.mjs micromark
 node tests/markdown-conformance/scripts/run-visual.mjs micromark
 ```
@@ -145,7 +145,7 @@ The default `github.token` can create issues when the target repository is the r
 
 Approved baselines are stored per source at `tests/markdown-conformance/baselines/<source-name>.json`. Reports use them to distinguish new, resolved, and persistent failures. A baseline can only be updated after a complete run of every case for that source, with visual testing enabled and zero semantic or visual execution errors:
 
-```powershell
+```console
 node tests/markdown-conformance/scripts/update-baseline.mjs <source-name>
 ```
 

--- a/tests/markdown-conformance/README.zh.md
+++ b/tests/markdown-conformance/README.zh.md
@@ -33,7 +33,7 @@ tests/cases/_fixtures/commonmark/
 
 从仓库根目录执行：
 
-```powershell
+```console
 node tests/markdown-conformance/scripts/import.mjs commonmark
 node tests/markdown-conformance/scripts/validate.mjs commonmark
 ```
@@ -55,7 +55,7 @@ tests/cases/_fixtures/cmark-gfm/
   NOTICE.md
 ```
 
-```powershell
+```console
 node tests/markdown-conformance/scripts/import.mjs cmark-gfm
 node tests/markdown-conformance/scripts/validate.mjs cmark-gfm
 ```
@@ -66,7 +66,7 @@ micromark 适配器从固定 commit 的 `test/io/**/*.js` 自动发现核心 Mar
 仅聚合模块、流测试和常量表测试，在隔离捕获环境中保留 Markdown、期望 HTML、上游选项、
 测试名称及源码行号，共生成 1151 条统一用例。新增匹配文件无需修改导入入口或逐项配置路径。
 
-```powershell
+```console
 node tests/markdown-conformance/scripts/import.mjs micromark
 node tests/markdown-conformance/scripts/validate.mjs micromark
 ```
@@ -78,14 +78,14 @@ node tests/markdown-conformance/scripts/validate.mjs micromark
 
 安装隔离依赖和 Chromium：
 
-```powershell
+```console
 pnpm --dir tests/markdown-conformance install --frozen-lockfile
 node tests/markdown-conformance/node_modules/playwright/cli.js install chromium
 ```
 
 构建 Parser 后执行快速语义对照：
 
-```powershell
+```console
 cargo build -p supramark-markdown --bin supramark-markdown
 node tests/markdown-conformance/scripts/run.mjs <source-name>
 node tests/markdown-conformance/scripts/run-visual.mjs <source-name>
@@ -93,7 +93,7 @@ node tests/markdown-conformance/scripts/run-visual.mjs <source-name>
 
 当前可直接运行 `commonmark`、`cmark-gfm` 和 `micromark`。例如：
 
-```powershell
+```console
 node tests/markdown-conformance/scripts/run.mjs micromark
 node tests/markdown-conformance/scripts/run-visual.mjs micromark
 ```
@@ -158,7 +158,7 @@ Pull Request 始终不会自动创建 Issue，即使 `COMMONMARK_AUTO_ISSUE=true
 
 批准基线按数据源位于 `tests/markdown-conformance/baselines/<source-name>.json`，用于在 Issue 中区分新增失败、已恢复和持续失败。只有完整运行该数据源的全部用例、视觉测试已执行且语义与视觉执行错误均为 0 时，才允许更新：
 
-```powershell
+```console
 node tests/markdown-conformance/scripts/update-baseline.mjs <source-name>
 ```
 

--- a/tests/markdown-conformance/config/sources/README.md
+++ b/tests/markdown-conformance/config/sources/README.md
@@ -36,7 +36,7 @@ can reuse `importers/spec-examples.mjs`; Markdown/HTML file pairs can reuse
 
 From the repository root:
 
-```powershell
+```console
 node tests/markdown-conformance/scripts/import.mjs <source-name>
 node tests/markdown-conformance/scripts/validate.mjs <source-name>
 ```

--- a/tests/markdown-conformance/lib/reports/issue-report.mjs
+++ b/tests/markdown-conformance/lib/reports/issue-report.mjs
@@ -45,6 +45,8 @@ export function renderConformanceIssue({
     semanticFailures,
     visualFailures
   );
+  const representativeId =
+    representatives[0]?.id ?? semanticFailures[0]?.id ?? visualFailures[0]?.id ?? sourceName;
   const lines = [
     metadata.marker,
     `# CommonMark ${comparisonScope} conformance test failures`,
@@ -105,8 +107,20 @@ export function renderConformanceIssue({
     '',
     '### Reproducing a single case (does not overwrite the full report)',
     '',
+    '**Bash (Linux/macOS):**',
+    '',
     fencedCode([
-      `$env:CASE_IDS = "${representatives[0]?.id ?? semanticFailures[0]?.id ?? visualFailures[0]?.id ?? sourceName}"`,
+      `export CASE_IDS="${representativeId}"`,
+      'export FAIL_ON_FAILURES="0"',
+      'export ARTIFACT_DIR="tests/markdown-conformance/artifacts/manual/$CASE_IDS"',
+      runCommand,
+      'unset CASE_IDS FAIL_ON_FAILURES ARTIFACT_DIR',
+    ].join('\n'), 'bash'),
+    '',
+    '**PowerShell (Windows):**',
+    '',
+    fencedCode([
+      `$env:CASE_IDS = "${representativeId}"`,
       '$env:FAIL_ON_FAILURES = "0"',
       '$env:ARTIFACT_DIR = "tests/markdown-conformance/artifacts/manual/$env:CASE_IDS"',
       runCommand,

--- a/tests/markdown-conformance/lib/reports/issue-report.test.mjs
+++ b/tests/markdown-conformance/lib/reports/issue-report.test.mjs
@@ -1,0 +1,34 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { renderConformanceIssue } from './issue-report.mjs';
+
+test('single-case reproduction includes Bash and PowerShell commands', () => {
+  const body = renderConformanceIssue({
+    summary: {
+      source: 'commonmark',
+      sourceDisplayName: 'CommonMark',
+      total: 1,
+      passed: 0,
+      notPassed: 1,
+      overallNotPassedCases: 1,
+      sourceCommit: 'test-source-commit',
+      comparisonTarget: 'ast-projection',
+      generatedAt: '2026-08-10T00:00:00Z',
+      runtime: {},
+      baseline: null,
+      failureGroups: [],
+      visual: { enabled: false, passed: 0, total: 0, notPassed: 0 },
+    },
+    semanticFailures: [{ id: 'commonmark-test-case' }],
+    visualFailures: [],
+    caseById: new Map(),
+    astById: new Map(),
+    actualHtmlById: new Map(),
+    sourceVersion: '0.31.2',
+  });
+
+  assert.match(body, /\*\*Bash \(Linux\/macOS\):\*\*/);
+  assert.match(body, /export CASE_IDS="commonmark-test-case"/);
+  assert.match(body, /\*\*PowerShell \(Windows\):\*\*/);
+  assert.match(body, /\$env:CASE_IDS = "commonmark-test-case"/);
+});

--- a/tests/markdown-conformance/lib/semantic/html-semantics.mjs
+++ b/tests/markdown-conformance/lib/semantic/html-semantics.mjs
@@ -160,7 +160,7 @@ function canonicalNode(node, parentTag) {
 
 function normalizeText(value, parentTag) {
   const normalized = value.replace(/\r\n?/g, '\n');
-  if (parentTag === 'pre' || parentTag === 'code' && value.includes('\n')) return normalized;
+  if (parentTag === 'pre' || parentTag === 'code') return normalized;
   if (BLOCK_CONTAINERS.has(parentTag) && /^\s+$/.test(normalized)) return '';
   return normalized.replace(/[\t\n\f\r ]+/g, ' ');
 }

--- a/tests/markdown-conformance/lib/semantic/html-semantics.test.mjs
+++ b/tests/markdown-conformance/lib/semantic/html-semantics.test.mjs
@@ -1,0 +1,23 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { htmlToSemanticTree } from './html-semantics.mjs';
+
+test('preserves whitespace runs inside inline code', () => {
+  assert.deepEqual(htmlToSemanticTree('<code>a  b\tc</code>'), [
+    {
+      type: 'element',
+      tag: 'code',
+      children: [{ type: 'text', value: 'a  b\tc' }],
+    },
+  ]);
+});
+
+test('still collapses whitespace runs in ordinary inline text', () => {
+  assert.deepEqual(htmlToSemanticTree('<span>a  b\tc</span>'), [
+    {
+      type: 'element',
+      tag: 'span',
+      children: [{ type: 'text', value: 'a b c' }],
+    },
+  ]);
+});

--- a/tests/markdown-conformance/package.json
+++ b/tests/markdown-conformance/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "type": "module",
   "scripts": {
+    "test:unit": "node --test lib/semantic/html-semantics.test.mjs lib/reports/issue-report.test.mjs",
     "import:commonmark": "node scripts/import.mjs commonmark",
     "import:cmark-gfm": "node scripts/import.mjs cmark-gfm",
     "import:micromark": "node scripts/import.mjs micromark",

--- a/tests/official-diagram-visual/scripts/tools/official-diagram-visual-workflow.mjs
+++ b/tests/official-diagram-visual/scripts/tools/official-diagram-visual-workflow.mjs
@@ -1080,27 +1080,17 @@ function visualBandWithEscalation({ pixelBand, perceptual, severeSizeMismatch })
   return pixelBand;
 }
 
-function hasSevereSizePerceptualMismatch({ sizeDelta, perceptual, pixelBand }) {
+function hasSevereSizePerceptualMismatch({ sizeDelta, perceptual }) {
   const contentAreaDelta = Math.abs(sizeDelta?.content?.area ?? 0);
   const originalAreaDelta = Math.abs(sizeDelta?.original?.area ?? 0);
   const severeAreaDelta = Math.max(contentAreaDelta, originalAreaDelta) >= severeSizeDeltaThreshold;
-  const scaleOnlySizeDelta = pixelBand === 'pass' && hasScaleOnlySizeDelta(sizeDelta);
-  return severeAreaDelta && !scaleOnlySizeDelta && (perceptual?.distanceRatio ?? 0) > perceptualSimilarThreshold;
-}
-
-function hasScaleOnlySizeDelta(sizeDelta) {
-  const content = sizeDelta?.content;
-  if (!content) return false;
-  const widthDelta = content.width ?? 0;
-  const heightDelta = content.height ?? 0;
-  const sameDirection = Math.sign(widthDelta) === Math.sign(heightDelta);
-  return sameDirection && Math.abs(widthDelta - heightDelta) <= 0.08;
+  return severeAreaDelta && (perceptual?.distanceRatio ?? 0) > perceptualSimilarThreshold;
 }
 
 function runSelfTests() {
   const tests = [
     {
-      name: 'keeps scale-only size collapse as pass when visual diff passes',
+      name: 'downgrades severe scale-only size collapse with otherwise passing pixels to review',
       actual: visualBandWithEscalation({
         pixelBand: 'pass',
         perceptual: { distanceRatio: 0.16113 },
@@ -1113,7 +1103,7 @@ function runSelfTests() {
           pixelBand: 'pass',
         }),
       }),
-      expected: 'pass',
+      expected: 'review',
     },
     {
       name: 'downgrades severe non-proportional size collapse with otherwise passing pixels to review',
@@ -1130,6 +1120,22 @@ function runSelfTests() {
         }),
       }),
       expected: 'review',
+    },
+    {
+      name: 'keeps moderate scale-only size changes as pass when visual diff passes',
+      actual: visualBandWithEscalation({
+        pixelBand: 'pass',
+        perceptual: { distanceRatio: 0.20 },
+        severeSizeMismatch: hasSevereSizePerceptualMismatch({
+          sizeDelta: {
+            original: { width: -0.20, height: -0.20, area: -0.36 },
+            content: { width: -0.20, height: -0.20, area: -0.36 },
+          },
+          perceptual: { distanceRatio: 0.20 },
+          pixelBand: 'pass',
+        }),
+      }),
+      expected: 'pass',
     },
     {
       name: 'keeps ordinary size differences as pass when visual diff passes',


### PR DESCRIPTION
## Summary

The main regression gate, pull-request trigger, loud baseline mismatch, default-parser profile, and stale fix-report cleanup from #106 are already on `main`. This follow-up closes the remaining concrete blind spots:

- preserve all whitespace inside inline `<code>`, with a regression test that ordinary inline text still collapses whitespace
- classify severe proportional size collapse as review instead of pass, while keeping moderate scale-only changes as pass
- exclude locked generated fixtures from Prettier
- run harness unit tests in the conformance workflow and cache Cargo builds
- search up to 1,000 open issues during automatic deduplication
- generate both Bash and PowerShell single-case reproduction commands, and label platform-neutral README snippets as console commands

Closes #106

## Verification

- `pnpm test:unit` in `tests/markdown-conformance` — 3 pass, 0 fail
- `OFFICIAL_DIAGRAM_VISUAL_SELF_TEST=1 node tests/official-diagram-visual/scripts/tools/official-diagram-visual-workflow.mjs` — 12 checks pass
- rebuilt `supramark-markdown` and ran all 652 CommonMark semantic cases; the semantic-only run completed with the known 16 AST-target differences and loudly reported the expected baseline-target mismatch
- `bunx prettier --file-info tests/cases/_fixtures/commonmark/cases.json` — `ignored: true`
- JavaScript syntax checks — pass
- `bun run lint` — pass
- `bun run lint:types` — 0 findings
- `RUSTFLAGS="-C debuginfo=0" bun run quality` — pass
- `git diff --check` — pass

The explicit Rust flag only neutralizes this developer machines global `-fuse-ld=mold` setting; #186 carries the repository-level fix.