### PR TITLE
fix(mermaid): replace unsafe YAML parser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,12 +74,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "anyhow"
-version = "1.0.102"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
-
-[[package]]
 name = "ar_archive_writer"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -796,16 +790,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
-name = "libyml"
-version = "0.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3302702afa434ffa30847a83305f0a69d6abd74293b6554c18ec85c7ef30c980"
-dependencies = [
- "anyhow",
- "version_check",
-]
-
-[[package]]
 name = "linked-hash-map"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -871,7 +855,7 @@ dependencies = [
  "rquickjs 0.10.0",
  "serde",
  "serde_json",
- "serde_yml",
+ "serde_norway",
  "supramark-diagram-core",
  "supramark-font-metrics",
  "thiserror 1.0.69",
@@ -1368,18 +1352,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_yml"
-version = "0.0.12"
+name = "serde_norway"
+version = "0.9.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59e2dd588bf1597a252c3b920e0143eb99b0f76e4e082f4c92ce34fbc9e71ddd"
+checksum = "e408f29489b5fd500fab51ff1484fc859bb655f32c671f307dcd733b72e8168c"
 dependencies = [
  "indexmap",
  "itoa",
- "libyml",
- "memchr",
  "ryu",
  "serde",
- "version_check",
+ "unsafe-libyaml-norway",
 ]
 
 [[package]]
@@ -1751,6 +1733,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "unsafe-libyaml-norway"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39abd59bf32521c7f2301b52d05a6a2c975b6003521cbd0c6dc1582f0a22104"
 
 [[package]]
 name = "untrusted"

--- a/crates/mermaid-little/Cargo.toml
+++ b/crates/mermaid-little/Cargo.toml
@@ -127,9 +127,10 @@ serde_json = "1"
 # `%%{init: {...}}%%` bodies are JSON-ish: unquoted keys, single quotes,
 # trailing commas. JSON5 matches that tolerance.
 json5 = "0.4"
-# YAML frontmatter parser (JSON-schema flavoured, which is what
-# upstream `js-yaml` requests via `{ schema: JSON_SCHEMA }`).
-serde_yml = "0.0.12"
+# Maintained YAML frontmatter parser backed by unsafe-libyaml-norway.
+# Its scalar typing matches the JSON schema that upstream `js-yaml`
+# requests via `{ schema: JSON_SCHEMA }` for the values used here.
+serde_norway = "0.9.42"
 regex = "1"
 # Hierarchical directed graph layout. Pinned to a kookyleo fork until
 # dagre-rs has a published release that exposes intersectPolygon /

--- a/crates/mermaid-little/src/config/frontmatter.rs
+++ b/crates/mermaid-little/src/config/frontmatter.rs
@@ -3,9 +3,9 @@
 //! Port of upstream `diagram-api/frontmatter.ts` (60 LoC). Mermaid
 //! uses `js-yaml` with the **JSON schema**, not the full YAML 1.2
 //! schema — that limits the surface to scalars / sequences / mappings
-//! with JSON-style typing. `serde_yml` happens to be loose enough by
-//! default that parsing via `serde_json::Value` gives us the same shape
-//! mermaid ends up with after `yaml.load(..., { schema: JSON_SCHEMA })`.
+//! with JSON-style typing. `serde_norway` gives us the same scalar shape
+//! Mermaid gets from `yaml.load(..., { schema: JSON_SCHEMA })` for the
+//! values this module surfaces.
 //!
 //! Only three keys are surfaced structurally: `title`, `displayMode`,
 //! `config`. Everything else the parser would accept is dropped —
@@ -69,7 +69,7 @@ pub fn parse_frontmatter(source: &str) -> (Option<Frontmatter>, &str) {
     // Parse the YAML body. On parse failure we still strip the block
     // (upstream would throw, but we're trying to be more tolerant) and
     // return an empty Frontmatter.
-    let fm = match serde_yml::from_str::<serde_yml::Value>(body) {
+    let fm = match serde_norway::from_str::<serde_norway::Value>(body) {
         Ok(v) => lift_metadata(&v),
         Err(_) => Frontmatter::default(),
     };
@@ -80,19 +80,19 @@ pub fn parse_frontmatter(source: &str) -> (Option<Frontmatter>, &str) {
 /// Upstream only surfaces `title`, `displayMode` and `config`. Anything
 /// else from the YAML body is intentionally dropped so that a rogue
 /// frontmatter can't inject arbitrary config values.
-fn lift_metadata(value: &serde_yml::Value) -> Frontmatter {
-    let serde_yml::Value::Mapping(map) = value else {
+fn lift_metadata(value: &serde_norway::Value) -> Frontmatter {
+    let serde_norway::Value::Mapping(map) = value else {
         return Frontmatter::default();
     };
     let mut out = Frontmatter::default();
 
-    if let Some(title) = map.get(serde_yml::Value::String("title".into())) {
+    if let Some(title) = map.get(serde_norway::Value::String("title".into())) {
         out.title = yaml_to_string(title);
     }
-    if let Some(dm) = map.get(serde_yml::Value::String("displayMode".into())) {
+    if let Some(dm) = map.get(serde_norway::Value::String("displayMode".into())) {
         out.display_mode = yaml_to_string(dm);
     }
-    if let Some(cfg) = map.get(serde_yml::Value::String("config".into())) {
+    if let Some(cfg) = map.get(serde_norway::Value::String("config".into())) {
         // Re-encode as JSON and let serde_json parse a `Config`. This
         // path tolerates both JSON-schema YAML (which is all upstream
         // supports) and the JSON the JS side would have produced —
@@ -106,11 +106,11 @@ fn lift_metadata(value: &serde_yml::Value) -> Frontmatter {
     out
 }
 
-fn yaml_to_string(v: &serde_yml::Value) -> Option<String> {
+fn yaml_to_string(v: &serde_norway::Value) -> Option<String> {
     match v {
-        serde_yml::Value::String(s) => Some(s.clone()),
-        serde_yml::Value::Number(n) => Some(n.to_string()),
-        serde_yml::Value::Bool(b) => Some(b.to_string()),
+        serde_norway::Value::String(s) => Some(s.clone()),
+        serde_norway::Value::Number(n) => Some(n.to_string()),
+        serde_norway::Value::Bool(b) => Some(b.to_string()),
         _ => None,
     }
 }
@@ -159,7 +159,7 @@ mod tests {
 
     #[test]
     fn tolerates_malformed_yaml_by_dropping_metadata() {
-        // `:` with no space and a stray tab — serde_yml rejects it.
+        // `:` with no space and a stray tab — serde_norway rejects it.
         // Upstream JS throws, we keep going with empty metadata.
         let src = "---\n\t: broken\n---\ngraph TD\n";
         let (fm, rest) = parse_frontmatter(src);
@@ -175,5 +175,26 @@ mod tests {
         let (fm, rest) = parse_frontmatter(src);
         assert!(fm.is_none());
         assert_eq!(rest, src);
+    }
+
+    #[test]
+    fn preserves_json_schema_scalar_typing() {
+        let cases = [
+            ("yes", Some("yes")),
+            ("no", Some("no")),
+            ("on", Some("on")),
+            ("off", Some("off")),
+            ("1.10", Some("1.1")),
+            ("12:34:56", Some("12:34:56")),
+            ("true", Some("true")),
+            ("null", None),
+        ];
+
+        for (scalar, expected) in cases {
+            let src = format!("---\ntitle: {scalar}\n---\nflowchart TD\nA-->B\n");
+            let (fm, rest) = parse_frontmatter(&src);
+            assert_eq!(fm.and_then(|value| value.title).as_deref(), expected);
+            assert_eq!(rest, "flowchart TD\nA-->B\n");
+        }
     }
 }

--- a/crates/mermaid-little/src/parser/packet.rs
+++ b/crates/mermaid-little/src/parser/packet.rs
@@ -163,20 +163,22 @@ fn strip_frontmatter(source: &str) -> (Option<String>, Option<PacketConfig>, Str
         .map(|s| after_open[s..].to_owned())
         .unwrap_or_default();
 
-    // Parse the body. We rely on serde_yml to handle nesting / quotes
+    // Parse the body. We rely on serde_norway to handle nesting / quotes
     // / booleans / bare strings. Match the same tolerant-on-failure
     // stance as the shared frontmatter parser.
     let mut title: Option<String> = None;
     let mut packet_config: Option<PacketConfig> = None;
 
-    if let Ok(serde_yml::Value::Mapping(map)) = serde_yml::from_str::<serde_yml::Value>(body) {
-        if let Some(t) = map.get(serde_yml::Value::String("title".into())) {
+    if let Ok(serde_norway::Value::Mapping(map)) =
+        serde_norway::from_str::<serde_norway::Value>(body)
+    {
+        if let Some(t) = map.get(serde_norway::Value::String("title".into())) {
             title = yaml_to_string(t);
         }
-        if let Some(serde_yml::Value::Mapping(cfg_map)) =
-            map.get(serde_yml::Value::String("config".into()))
+        if let Some(serde_norway::Value::Mapping(cfg_map)) =
+            map.get(serde_norway::Value::String("config".into()))
         {
-            if let Some(pkt) = cfg_map.get(serde_yml::Value::String("packet".into())) {
+            if let Some(pkt) = cfg_map.get(serde_norway::Value::String("packet".into())) {
                 packet_config = Some(extract_packet_config(pkt));
             }
         }
@@ -185,21 +187,21 @@ fn strip_frontmatter(source: &str) -> (Option<String>, Option<PacketConfig>, Str
     (title, packet_config, rest)
 }
 
-fn yaml_to_string(v: &serde_yml::Value) -> Option<String> {
+fn yaml_to_string(v: &serde_norway::Value) -> Option<String> {
     match v {
-        serde_yml::Value::String(s) => Some(s.clone()),
-        serde_yml::Value::Number(n) => Some(n.to_string()),
-        serde_yml::Value::Bool(b) => Some(b.to_string()),
+        serde_norway::Value::String(s) => Some(s.clone()),
+        serde_norway::Value::Number(n) => Some(n.to_string()),
+        serde_norway::Value::Bool(b) => Some(b.to_string()),
         _ => None,
     }
 }
 
-fn extract_packet_config(v: &serde_yml::Value) -> PacketConfig {
+fn extract_packet_config(v: &serde_norway::Value) -> PacketConfig {
     let mut cfg = PacketConfig::default();
-    let serde_yml::Value::Mapping(map) = v else {
+    let serde_norway::Value::Mapping(map) = v else {
         return cfg;
     };
-    let get = |key: &str| map.get(serde_yml::Value::String(key.into()));
+    let get = |key: &str| map.get(serde_norway::Value::String(key.into()));
 
     if let Some(n) = get("rowHeight").and_then(yaml_to_f64) {
         cfg.row_height = n;
@@ -222,25 +224,25 @@ fn extract_packet_config(v: &serde_yml::Value) -> PacketConfig {
     cfg
 }
 
-fn yaml_to_f64(v: &serde_yml::Value) -> Option<f64> {
+fn yaml_to_f64(v: &serde_norway::Value) -> Option<f64> {
     match v {
-        serde_yml::Value::Number(n) => n.as_f64(),
-        serde_yml::Value::String(s) => s.parse().ok(),
+        serde_norway::Value::Number(n) => n.as_f64(),
+        serde_norway::Value::String(s) => s.parse().ok(),
         _ => None,
     }
 }
 
-fn yaml_to_u32(v: &serde_yml::Value) -> Option<u32> {
+fn yaml_to_u32(v: &serde_norway::Value) -> Option<u32> {
     match v {
-        serde_yml::Value::Number(n) => n.as_u64().and_then(|x| u32::try_from(x).ok()),
-        serde_yml::Value::String(s) => s.parse().ok(),
+        serde_norway::Value::Number(n) => n.as_u64().and_then(|x| u32::try_from(x).ok()),
+        serde_norway::Value::String(s) => s.parse().ok(),
         _ => None,
     }
 }
 
-fn yaml_to_bool(v: &serde_yml::Value) -> Option<bool> {
+fn yaml_to_bool(v: &serde_norway::Value) -> Option<bool> {
     match v {
-        serde_yml::Value::Bool(b) => Some(*b),
+        serde_norway::Value::Bool(b) => Some(*b),
         _ => None,
     }
 }

--- a/crates/mermaid-little/src/parser/sankey.rs
+++ b/crates/mermaid-little/src/parser/sankey.rs
@@ -177,7 +177,7 @@ fn find_frontmatter_end(body: &str) -> Option<(&str, &str)> {
 
 /// Walk the YAML body line-by-line looking for `config:` → `sankey:`
 /// and pull out the handful of keys we care about. We deliberately
-/// avoid `serde_yml` here to sidestep the dependency on the Wave-0
+/// avoid reparsing YAML here to sidestep the Wave-0
 /// frontmatter module — it already consumed the top-level `title` and
 /// `config` but produced only a generic `Config` value.
 fn apply_sankey_config(body: &str, cfg: &mut SankeyConfig) {

--- a/crates/mermaid-little/src/parser/xychart.rs
+++ b/crates/mermaid-little/src/parser/xychart.rs
@@ -203,7 +203,7 @@ fn strip_colon_keyword<'a>(line: &'a str, keyword: &str) -> Option<&'a str> {
 
 // ── Frontmatter ──────────────────────────────────────────────────────
 
-fn strip_frontmatter(src: &str) -> (Option<String>, Option<serde_yml::Value>, String) {
+fn strip_frontmatter(src: &str) -> (Option<String>, Option<serde_norway::Value>, String) {
     if !src.starts_with("---") {
         return (None, None, src.to_string());
     }
@@ -231,10 +231,10 @@ fn strip_frontmatter(src: &str) -> (Option<String>, Option<serde_yml::Value>, St
         .map(|s| after_open[s..].to_string())
         .unwrap_or_default();
 
-    let parsed: Option<serde_yml::Value> = serde_yml::from_str(body).ok();
+    let parsed: Option<serde_norway::Value> = serde_norway::from_str(body).ok();
     let mut title: Option<String> = None;
-    if let Some(serde_yml::Value::Mapping(m)) = parsed.as_ref() {
-        if let Some(t) = m.get(serde_yml::Value::String("title".into())) {
+    if let Some(serde_norway::Value::Mapping(m)) = parsed.as_ref() {
+        if let Some(t) = m.get(serde_norway::Value::String("title".into())) {
             title = yaml_to_string(t);
         }
     }
@@ -243,7 +243,7 @@ fn strip_frontmatter(src: &str) -> (Option<String>, Option<serde_yml::Value>, St
 
 // ── %%{init:…}%% directive ───────────────────────────────────────────
 
-fn extract_init_directives(src: &str) -> (Vec<serde_yml::Value>, String) {
+fn extract_init_directives(src: &str) -> (Vec<serde_norway::Value>, String) {
     let mut values = Vec::new();
     let mut out = String::with_capacity(src.len());
     let bytes = src.as_bytes();
@@ -274,15 +274,15 @@ fn extract_init_directives(src: &str) -> (Vec<serde_yml::Value>, String) {
             }
             if let Some(end_pos) = end {
                 let directive_body = &src[i + 3..end_pos - 3]; // between `%%{` and `}%%`
-                                                               // Try parsing as JSON5-ish via serde_yml (which handles
+                                                               // Try parsing as JSON5-ish via serde_norway (which handles
                                                                // the `{"xyChart":{...}}` shape upstream uses). Prefix
                                                                // with `{` since directive body starts with e.g.
                                                                // `init: {...}` or `init:{...}`.
                 let wrapped = format!("{{{directive_body}}}");
-                if let Ok(serde_yml::Value::Mapping(m)) =
-                    serde_yml::from_str::<serde_yml::Value>(&wrapped)
+                if let Ok(serde_norway::Value::Mapping(m)) =
+                    serde_norway::from_str::<serde_norway::Value>(&wrapped)
                 {
-                    if let Some(init) = m.get(serde_yml::Value::String("init".into())) {
+                    if let Some(init) = m.get(serde_norway::Value::String("init".into())) {
                         values.push(init.clone());
                     }
                 }
@@ -305,18 +305,18 @@ fn extract_init_directives(src: &str) -> (Vec<serde_yml::Value>, String) {
 // ── Config/theme merge from YAML ────────────────────────────────────
 
 fn apply_top_level(
-    v: &serde_yml::Value,
+    v: &serde_norway::Value,
     cfg: &mut XychartConfig,
     theme: &mut XychartThemeOverride,
     theme_name: &mut Option<String>,
 ) {
-    let serde_yml::Value::Mapping(m) = v else {
+    let serde_norway::Value::Mapping(m) = v else {
         return;
     };
-    let get = |key: &str| m.get(serde_yml::Value::String(key.into()));
-    if let Some(serde_yml::Value::Mapping(inner)) = get("config") {
+    let get = |key: &str| m.get(serde_norway::Value::String(key.into()));
+    if let Some(serde_norway::Value::Mapping(inner)) = get("config") {
         apply_top_level(
-            &serde_yml::Value::Mapping(inner.clone()),
+            &serde_norway::Value::Mapping(inner.clone()),
             cfg,
             theme,
             theme_name,
@@ -333,11 +333,11 @@ fn apply_top_level(
     }
 }
 
-fn apply_xychart_config(v: &serde_yml::Value, cfg: &mut XychartConfig) {
-    let serde_yml::Value::Mapping(m) = v else {
+fn apply_xychart_config(v: &serde_norway::Value, cfg: &mut XychartConfig) {
+    let serde_norway::Value::Mapping(m) = v else {
         return;
     };
-    let get = |key: &str| m.get(serde_yml::Value::String(key.into()));
+    let get = |key: &str| m.get(serde_norway::Value::String(key.into()));
     if let Some(x) = get("width").and_then(yaml_to_f64) {
         cfg.width = x;
     }
@@ -377,11 +377,11 @@ fn apply_xychart_config(v: &serde_yml::Value, cfg: &mut XychartConfig) {
     }
 }
 
-fn apply_axis_config(v: &serde_yml::Value, ac: &mut XyAxisConfig) {
-    let serde_yml::Value::Mapping(m) = v else {
+fn apply_axis_config(v: &serde_norway::Value, ac: &mut XyAxisConfig) {
+    let serde_norway::Value::Mapping(m) = v else {
         return;
     };
-    let get = |key: &str| m.get(serde_yml::Value::String(key.into()));
+    let get = |key: &str| m.get(serde_norway::Value::String(key.into()));
     if let Some(x) = get("showLabel").and_then(yaml_to_bool) {
         ac.show_label = x;
     }
@@ -417,21 +417,21 @@ fn apply_axis_config(v: &serde_yml::Value, ac: &mut XyAxisConfig) {
     }
 }
 
-fn apply_theme_variables(v: &serde_yml::Value, theme: &mut XychartThemeOverride) {
-    let serde_yml::Value::Mapping(m) = v else {
+fn apply_theme_variables(v: &serde_norway::Value, theme: &mut XychartThemeOverride) {
+    let serde_norway::Value::Mapping(m) = v else {
         return;
     };
-    if let Some(xy) = m.get(serde_yml::Value::String("xyChart".into())) {
+    if let Some(xy) = m.get(serde_norway::Value::String("xyChart".into())) {
         apply_xychart_theme(xy, theme);
     }
 }
 
-fn apply_xychart_theme(v: &serde_yml::Value, theme: &mut XychartThemeOverride) {
-    let serde_yml::Value::Mapping(m) = v else {
+fn apply_xychart_theme(v: &serde_norway::Value, theme: &mut XychartThemeOverride) {
+    let serde_norway::Value::Mapping(m) = v else {
         return;
     };
     let get_str = |key: &str| {
-        m.get(serde_yml::Value::String(key.into()))
+        m.get(serde_norway::Value::String(key.into()))
             .and_then(yaml_to_string)
     };
     if let Some(s) = get_str("backgroundColor") {
@@ -472,27 +472,27 @@ fn apply_xychart_theme(v: &serde_yml::Value, theme: &mut XychartThemeOverride) {
     }
 }
 
-fn yaml_to_string(v: &serde_yml::Value) -> Option<String> {
+fn yaml_to_string(v: &serde_norway::Value) -> Option<String> {
     match v {
-        serde_yml::Value::String(s) => Some(s.clone()),
-        serde_yml::Value::Number(n) => Some(n.to_string()),
-        serde_yml::Value::Bool(b) => Some(b.to_string()),
+        serde_norway::Value::String(s) => Some(s.clone()),
+        serde_norway::Value::Number(n) => Some(n.to_string()),
+        serde_norway::Value::Bool(b) => Some(b.to_string()),
         _ => None,
     }
 }
 
-fn yaml_to_f64(v: &serde_yml::Value) -> Option<f64> {
+fn yaml_to_f64(v: &serde_norway::Value) -> Option<f64> {
     match v {
-        serde_yml::Value::Number(n) => n.as_f64(),
-        serde_yml::Value::String(s) => s.parse().ok(),
+        serde_norway::Value::Number(n) => n.as_f64(),
+        serde_norway::Value::String(s) => s.parse().ok(),
         _ => None,
     }
 }
 
-fn yaml_to_bool(v: &serde_yml::Value) -> Option<bool> {
+fn yaml_to_bool(v: &serde_norway::Value) -> Option<bool> {
     match v {
-        serde_yml::Value::Bool(b) => Some(*b),
-        serde_yml::Value::String(s) => {
+        serde_norway::Value::Bool(b) => Some(*b),
+        serde_norway::Value::String(s) => {
             let s = s.trim().to_ascii_lowercase();
             if s == "true" {
                 Some(true)
@@ -908,5 +908,13 @@ xychart
 "#;
         let d = parse(src).unwrap();
         assert_eq!(d.config.width, 1000.0);
+    }
+
+    #[test]
+    fn parses_json5_style_init_directive() {
+        let src = "%%{init: {xyChart: {width: 1000, chartOrientation: 'horizontal',},}}%%\nxychart\n  bar [1,2,3]\n";
+        let d = parse(src).unwrap();
+        assert_eq!(d.config.width, 1000.0);
+        assert_eq!(d.config.chart_orientation, ChartOrientation::Horizontal);
     }
 }

--- a/deny.toml
+++ b/deny.toml
@@ -92,14 +92,6 @@ allow-git = []
 version = 2
 yanked = "warn"
 ignore = [
-    # serde_yml v0.0.12 is unsound + unmaintained (segfault risk in
-    # Serializer.emitter; archived upstream). Pulled by mermaid-little
-    # for Mermaid frontmatter `--- yaml ---` blocks. Recommended
-    # alternatives: serde_norway / serde_yaml_ng.
-    # Tracking: open issue at kookyleo/mermaid-little to migrate.
-    # Remove this entry after mermaid-little drops the dep.
-    "RUSTSEC-2025-0068",
-
     # bincode is unmaintained (RUSTSEC-2025-0141); pulled in
     # transitively. No maintained drop-in replacement yet; revisit
     # when the upstream consumer migrates off bincode.


### PR DESCRIPTION
## Summary

- replace archived `serde_yml`/`libyml` with maintained `serde_norway`/`unsafe-libyaml-norway`
- migrate Mermaid frontmatter, packet, and xychart YAML parsing call sites
- remove the obsolete RustSec advisory exception
- lock JSON-schema scalar typing and JSON5-style init directive behavior with regression tests

## Root cause

`mermaid-little` parsed user-controlled Mermaid frontmatter and init directives through `serde_yml`, whose archived `libyml` dependency has an unsound scanner path. The scanner is reachable during deserialization, so avoiding serialization does not avoid the advisory.

## Impact

The vulnerable dependency chain is removed without changing Mermaid output. The full visual sweep remains exactly at its pre-change baseline of 704/1323.

## Validation

- `cargo test -p mermaid-little` (705 unit tests plus all byte-exact integration suites)
- pre/post `sweep_all` comparison: 704/1323 on both versions
- `cargo deny check`
- `cargo fmt -p mermaid-little --check`
- `cargo clippy -p mermaid-little --all-targets -- -D warnings`
- `cargo check -p mermaid-little-web --target wasm32-unknown-unknown`
- `cargo check -p supramark-mermaid-native`
- `bun run build:wasm mermaid`
- `bun run lint`
- `bun run lint:types`
- `bun run quality`

Fixes #190
