### PR TITLE
fix(rn): render-cache review follow-ups (maxBytes:0, freeze timing)

### DIFF
--- a/packages/renderers/rn/__tests__/renderCache.test.ts
+++ b/packages/renderers/rn/__tests__/renderCache.test.ts
@@ -256,3 +256,29 @@ describe('getRendererCache policy reconfiguration (#124 #3)', () => {
     expect(after).not.toBe(before); // new instance after clear
   });
 });
+
+describe('resolveRendererCachePolicy maxBytes resolution (#124 follow-up)', () => {
+  // Pre-fix, an explicit maxBytes: 0 fell through to the 8 MB default
+  // (indistinguishable from "unset"), so a host could not opt out of the byte
+  // cap. Now 0 (or any non-positive / non-finite value) means "no byte bound",
+  // matching ttl and LRUCache.reconfigure.
+  it('treats an explicit maxBytes: 0 as "no byte cap"', () => {
+    expect(resolveRendererCachePolicy({ enabled: true, maxBytes: 0 }).maxBytes).toBeUndefined();
+  });
+
+  it('treats a negative / non-finite maxBytes as "no byte cap"', () => {
+    expect(resolveRendererCachePolicy({ enabled: true, maxBytes: -1 }).maxBytes).toBeUndefined();
+    expect(resolveRendererCachePolicy({ enabled: true, maxBytes: Infinity }).maxBytes).toBeUndefined();
+    expect(resolveRendererCachePolicy({ enabled: true, maxBytes: Number.NaN }).maxBytes).toBeUndefined();
+  });
+
+  it('keeps an explicit positive maxBytes and applies the default when it is unset', () => {
+    expect(resolveRendererCachePolicy({ enabled: true, maxBytes: 1024 }).maxBytes).toBe(1024);
+    // override wins over a fallback that does set it
+    expect(
+      resolveRendererCachePolicy({ enabled: true, maxBytes: 0 }, { maxBytes: 2048 }).maxBytes
+    ).toBeUndefined();
+    // unset → default
+    expect(resolveRendererCachePolicy({ enabled: true }).maxBytes).toBe(8_000_000);
+  });
+});

--- a/packages/renderers/rn/src/Supramark.tsx
+++ b/packages/renderers/rn/src/Supramark.tsx
@@ -378,6 +378,15 @@ export const Supramark: React.FC<SupramarkProps> = ({
             collectCodeHighlightTasks(parsed.children, config, codeHighlightTheme),
             codeHighlighter
           );
+          // Dev-only deep freeze BEFORE the snapshot can be shared. The factory
+          // result is stored into the document cache by getOrCreate, so freezing
+          // here (rather than after the await) closes the microtask window in
+          // which a concurrent cache hit could observe an unfrozen shared AST
+          // and let a containerRenderer mutate it in place. Production skips it;
+          // the read-only contract still holds by convention. See deepFreezeAst.
+          if (isDevMode) {
+            deepFreezeAst(parsed);
+          }
           return {
             root: parsed,
             highlighted: highlightedMap,
@@ -402,12 +411,9 @@ export const Supramark: React.FC<SupramarkProps> = ({
               )
             : await buildParsedDocument();
         if (!cancelled) {
-          // Dev-only deep freeze enforces the read-only AST contract on the
-          // shared cached snapshot; see deepFreezeAst. containerRenderers that
-          // annotate in place would otherwise cross-contaminate sibling rows.
-          if (isDevMode) {
-            deepFreezeAst(nextDocument.root);
-          }
+          // The shared snapshot was frozen inside buildParsedDocument (dev) so
+          // every consumer — first mount, virtual-list remount, or a concurrent
+          // cache hit — sees the same read-only AST from the start.
           setParsedDocument(nextDocument);
           setParseError(null);
         }

--- a/packages/renderers/rn/src/renderCache.ts
+++ b/packages/renderers/rn/src/renderCache.ts
@@ -8,7 +8,8 @@ export interface RendererCachePolicy {
   /**
    * Optional total-byte cap. When set, the cache evicts oldest entries until
    * the summed `sizeCalculator` output fits, in addition to the entry-count
-   * `maxSize` bound. `undefined` disables the byte bound.
+   * `maxSize` bound. `undefined` or `0` disables the byte bound (an explicit
+   * `0` is the documented opt-out; leaving it unset applies the 8 MB default).
    */
   maxBytes?: number;
 }
@@ -156,7 +157,12 @@ export function resolveRendererCachePolicy(
   const enabled = override?.enabled ?? fallback?.enabled ?? false;
   const configuredMaxSize = override?.maxSize ?? fallback?.maxSize ?? DEFAULT_CACHE_MAX_SIZE;
   const configuredTtl = override?.ttl ?? fallback?.ttl;
-  const configuredMaxBytes = override?.maxBytes ?? fallback?.maxBytes ?? DEFAULT_CACHE_MAX_BYTES;
+  // Distinguish "not configured" (→ default 8 MB cap) from an explicit zero or
+  // invalid value (→ undefined, no byte cap). This mirrors ttl resolution and
+  // LRUCache.reconfigure, so a host can disable the byte bound with maxBytes: 0
+  // instead of being silently bumped back to the default. Without this, the 0
+  // case was indistinguishable from "unset", which both fell through to 8 MB.
+  const rawMaxBytes = override?.maxBytes ?? fallback?.maxBytes;
 
   return {
     enabled,
@@ -168,11 +174,11 @@ export function resolveRendererCachePolicy(
         ? configuredTtl
         : undefined,
     maxBytes:
-      configuredMaxBytes !== undefined &&
-      Number.isFinite(configuredMaxBytes) &&
-      configuredMaxBytes > 0
-        ? configuredMaxBytes
-        : DEFAULT_CACHE_MAX_BYTES,
+      rawMaxBytes === undefined
+        ? DEFAULT_CACHE_MAX_BYTES
+        : Number.isFinite(rawMaxBytes) && rawMaxBytes > 0
+          ? rawMaxBytes
+          : undefined,
   };
 }
 


### PR DESCRIPTION
## Summary
Follow-up to #160 (render-cache follow-ups, merged). Two small review-driven fixes:

- **`maxBytes: 0` symmetry.** `resolveRendererCachePolicy` now distinguishes "not configured" (→ 8 MB default) from an explicit `0` / non-positive / non-finite value (→ `undefined`, no byte cap). Pre-fix, an explicit `0` was indistinguishable from "unset" and silently fell through to the 8 MB default, so a host could not opt out of the byte bound. Mirrors how `ttl` and `LRUCache.reconfigure` already resolve.
- **Freeze timing.** Moved the dev-only `deepFreezeAst` into the `buildParsedDocument` factory so the parsed snapshot is frozen *before* it is handed to anything that might retain it, instead of at the `setParsedDocument` call site.

## Test plan
- [x] New `resolveRendererCachePolicy maxBytes resolution` describe block (3 cases): `maxBytes:0` → `undefined`; negative / `Infinity` / `NaN` → `undefined`; positive retained + override-wins + unset → default.
- [x] Existing `renderCache` suite green (28/28).
- [x] `tsc --noEmit` clean on `@supramark/rn`.