### PR TITLE
feat(rn,web): add copy button to fenced code blocks

### DIFF
--- a/docs/guide/getting-started.zh.md
+++ b/docs/guide/getting-started.zh.md
@@ -58,6 +58,39 @@ function App() {
 }
 ```
 
+## 代码块复制
+
+Web 渲染器默认对带语言信息字符串的代码块显示复制按钮，并使用
+`navigator.clipboard.writeText`。宿主也可以通过 `onCopyCode` 接管复制行为：
+
+```tsx
+<Supramark
+  markdown={markdown}
+  onCopyCode={async code => {
+    await copyWithHostApi(code);
+  }}
+/>
+```
+
+React Native 渲染器不依赖任何剪贴板库，只有提供 `onCopyCode` 时才显示按钮。
+两端都可以通过 `copyButton={false}` 关闭复制 UI；Web 此时恢复独立的
+`<pre><code>` 结构。
+
+当前 AST 不区分无语言的 fenced code block 与 indented code block，因此只有
+`node.lang` 非空时才显示复制按钮。无语言代码块仍使用相同的代码卡片样式，但不显示
+header 和按钮；如需让它们也可复制，需要先在 parser AST 中增加 fenced 标记。
+
+Web 默认样式的颜色可以由宿主 CSS 覆盖，适合暗色容器：
+
+```css
+.dark-markdown {
+  --sm-code-bg: #2d2d2d;
+  --sm-code-lang-color: rgba(255, 255, 255, 0.6);
+  --sm-code-btn-bg: rgba(255, 255, 255, 0.25);
+  --sm-code-btn-color: #fff;
+}
+```
+
 ## 启用 Features
 
 ```typescript

--- a/examples/react-web-csr/src/App.css
+++ b/examples/react-web-csr/src/App.css
@@ -197,6 +197,59 @@
   overflow-x: auto;
 }
 
+/* Code-block card with header (language label + copy button): the container
+   owns the chrome so the header and body read as one continuous block. */
+.sm-code-block-container {
+  background-color: #f6f8fa;
+  border: 1px solid #e1e4e8;
+  border-radius: 6px;
+  margin-bottom: 1rem;
+  overflow: hidden;
+}
+
+.sm-code-block-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.25rem 0.5rem;
+  user-select: none;
+}
+
+.sm-code-block-lang {
+  font-size: 0.75rem;
+  color: #6a737d;
+  font-family: 'Consolas', 'Monaco', 'Courier New', monospace;
+  user-select: none;
+}
+
+.sm-code-block-container > .sm-code-block-body {
+  background: transparent;
+  border: 0;
+  border-radius: 0;
+  margin: 0;
+  padding: 1rem;
+  overflow-x: auto;
+}
+
+.sm-code-btn {
+  background-color: #586069;
+  color: #ffffff;
+  border: none;
+  border-radius: 4px;
+  padding: 0.25rem 0.5rem;
+  font-size: 0.75rem;
+  cursor: pointer;
+  user-select: none;
+}
+
+.sm-code-btn:hover {
+  background-color: #444d56;
+}
+
+.sm-code-btn-text {
+  user-select: none;
+}
+
 .sm-code {
   font-family: 'Consolas', 'Monaco', 'Courier New', monospace;
   font-size: 0.9em;

--- a/packages/renderers/rn/__tests__/code-block-copy.test.tsx
+++ b/packages/renderers/rn/__tests__/code-block-copy.test.tsx
@@ -89,4 +89,13 @@ describe('code block copy button (RN)', () => {
     const labelAfter = renderer.root.findByType('TouchableOpacity').children[0];
     expect(labelAfter.props.children).toBe('Copied');
   });
+
+  it('omits the button when the code block has no language even if onCopyCode is provided', async () => {
+    const onCopyCode = mock(() => undefined);
+    const renderer = await renderAst(codeAst('foo\n'), { onCopyCode });
+    expect(renderer.root.findAllByType('TouchableOpacity')).toHaveLength(0);
+    // code content still renders
+    const text = renderer.root.findByType('Text');
+    expect(text.props.children).toBe('foo\n');
+  });
 });

--- a/packages/renderers/rn/__tests__/code-block-copy.test.tsx
+++ b/packages/renderers/rn/__tests__/code-block-copy.test.tsx
@@ -66,6 +66,14 @@ describe('code block copy button (RN)', () => {
     expect(onCopyCode.mock.calls[0][1]).toMatchObject({ type: 'code' });
   });
 
+  it('shows the language label in a header row beside the button', async () => {
+    const onCopyCode = mock(() => undefined);
+    const renderer = await renderAst(codeAst('const x = 1\n', 'ts'), { onCopyCode });
+    // The header carries the language Text and the button as siblings.
+    const texts = renderer.root.findAllByType('Text');
+    expect(texts.some(t => t.props.children === 'ts')).toBe(true);
+  });
+
   it('omits the button when copyButton is false even if onCopyCode is provided', async () => {
     const onCopyCode = mock(() => undefined);
     const renderer = await renderAst(codeAst('const x = 1\n', 'ts'), {

--- a/packages/renderers/rn/__tests__/code-block-copy.test.tsx
+++ b/packages/renderers/rn/__tests__/code-block-copy.test.tsx
@@ -1,0 +1,92 @@
+import { describe, expect, it, mock } from 'bun:test';
+import React from 'react';
+import { act, create, type ReactTestRenderer } from 'react-test-renderer';
+import type { SupramarkRootNode } from '@supramark/core';
+
+import './support/mock-react-native';
+import './support/mock-renderer';
+
+// react-test-renderer needs the act environment to flush effects synchronously.
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT =
+  true;
+
+const { Supramark } = await import('../src/Supramark');
+
+function codeAst(value: string, lang?: string): SupramarkRootNode {
+  return {
+    type: 'root',
+    ast_version: 2,
+    diagnostics: [],
+    children: [{ type: 'code', value, ...(lang ? { lang } : {}) }] as SupramarkRootNode['children'],
+  } as SupramarkRootNode;
+}
+
+interface RenderOptions {
+  onCopyCode?: (code: string, node: SupramarkCodeNodeLike) => void;
+  copyButton?: boolean;
+}
+
+type SupramarkCodeNodeLike = { type: 'code'; value: string; lang?: string };
+
+async function renderAst(
+  ast: SupramarkRootNode,
+  options?: RenderOptions
+): Promise<ReactTestRenderer> {
+  let renderer: ReactTestRenderer | null = null;
+  await act(async () => {
+    renderer = create(React.createElement(Supramark, { ast, markdown: '', ...options }));
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+  return renderer as unknown as ReactTestRenderer;
+}
+
+describe('code block copy button (RN)', () => {
+  it('omits the copy button when no onCopyCode is provided (RN stays clipboard-free)', async () => {
+    const renderer = await renderAst(codeAst('const x = 1\n', 'ts'));
+    expect(renderer.root.findAllByType('TouchableOpacity')).toHaveLength(0);
+    // code content still renders
+    const text = renderer.root.findByType('Text');
+    expect(text.props.children).toBe('const x = 1\n');
+  });
+
+  it('renders the copy button when onCopyCode is provided and invokes it on press', async () => {
+    const onCopyCode = mock(() => undefined);
+    const renderer = await renderAst(codeAst('const x = 1\n', 'ts'), { onCopyCode });
+    const btn = renderer.root.findByType('TouchableOpacity');
+    expect(typeof btn.props.onPress).toBe('function');
+
+    await act(async () => {
+      btn.props.onPress();
+    });
+
+    expect(onCopyCode).toHaveBeenCalledTimes(1);
+    expect(onCopyCode.mock.calls[0][0]).toBe('const x = 1\n');
+    expect(onCopyCode.mock.calls[0][1]).toMatchObject({ type: 'code' });
+  });
+
+  it('omits the button when copyButton is false even if onCopyCode is provided', async () => {
+    const onCopyCode = mock(() => undefined);
+    const renderer = await renderAst(codeAst('const x = 1\n', 'ts'), {
+      onCopyCode,
+      copyButton: false,
+    });
+    expect(renderer.root.findAllByType('TouchableOpacity')).toHaveLength(0);
+  });
+
+  it('shows the Copy label initially and switches to Copied after pressing', async () => {
+    const onCopyCode = mock(() => undefined);
+    const renderer = await renderAst(codeAst('const x = 1\n', 'ts'), { onCopyCode });
+    const btn = renderer.root.findByType('TouchableOpacity');
+    const labelBefore = btn.children[0];
+    expect(labelBefore.props.children).toBe('Copy');
+
+    await act(async () => {
+      btn.props.onPress();
+    });
+
+    const labelAfter = renderer.root.findByType('TouchableOpacity').children[0];
+    expect(labelAfter.props.children).toBe('Copied');
+  });
+});

--- a/packages/renderers/rn/__tests__/code-block-copy.test.tsx
+++ b/packages/renderers/rn/__tests__/code-block-copy.test.tsx
@@ -22,7 +22,7 @@ function codeAst(value: string, lang?: string): SupramarkRootNode {
 }
 
 interface RenderOptions {
-  onCopyCode?: (code: string, node: SupramarkCodeNodeLike) => void;
+  onCopyCode?: (code: string, node: SupramarkCodeNodeLike) => void | Promise<void>;
   copyButton?: boolean;
 }
 
@@ -96,6 +96,53 @@ describe('code block copy button (RN)', () => {
 
     const labelAfter = renderer.root.findByType('TouchableOpacity').children[0];
     expect(labelAfter.props.children).toBe('Copied');
+    expect(renderer.root.findByType('TouchableOpacity').props.accessibilityLabel).toBe(
+      'Copied code'
+    );
+  });
+
+  it('waits for the host callback before reporting success', async () => {
+    let resolveCopy: (() => void) | undefined;
+    const onCopyCode = () =>
+      new Promise<void>(resolve => {
+        resolveCopy = resolve;
+      });
+    const renderer = await renderAst(codeAst('const x = 1\n', 'ts'), { onCopyCode });
+    const btn = renderer.root.findByType('TouchableOpacity');
+
+    await act(async () => btn.props.onPress());
+    expect(renderer.root.findByType('TouchableOpacity').children[0].props.children).toBe('Copy');
+    expect(renderer.root.findByType('TouchableOpacity').props.accessibilityLabel).toBe('Copy code');
+
+    await act(async () => resolveCopy?.());
+    expect(renderer.root.findByType('TouchableOpacity').children[0].props.children).toBe('Copied');
+    expect(renderer.root.findByType('TouchableOpacity').props.accessibilityLabel).toBe(
+      'Copied code'
+    );
+  });
+
+  it('does not schedule feedback after an in-flight copy unmounts', async () => {
+    let resolveCopy: (() => void) | undefined;
+    const onCopyCode = () =>
+      new Promise<void>(resolve => {
+        resolveCopy = resolve;
+      });
+    const renderer = await renderAst(codeAst('const x = 1\n', 'ts'), { onCopyCode });
+    await act(async () => renderer.root.findByType('TouchableOpacity').props.onPress());
+    await act(async () => renderer.unmount());
+
+    // Resolving after cleanup must not create the 1.5-second label timer.
+    const originalSetTimeout = globalThis.setTimeout;
+    const feedbackTimer = mock(() => 0 as unknown as ReturnType<typeof setTimeout>);
+    globalThis.setTimeout = feedbackTimer as unknown as typeof setTimeout;
+    try {
+      resolveCopy?.();
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(feedbackTimer).not.toHaveBeenCalled();
+    } finally {
+      globalThis.setTimeout = originalSetTimeout;
+    }
   });
 
   it('omits the button when the code block has no language even if onCopyCode is provided', async () => {
@@ -105,5 +152,67 @@ describe('code block copy button (RN)', () => {
     // code content still renders
     const text = renderer.root.findByType('Text');
     expect(text.props.children).toBe('foo\n');
+  });
+
+  it('a rejected onCopyCode leaves the label as Copy and raises no unhandledRejection', async () => {
+    const rejections: unknown[] = [];
+    const onUnhandled = (reason: unknown): void => {
+      rejections.push(reason);
+    };
+    process.on('unhandledRejection', onUnhandled);
+    try {
+      const onCopyCode = () => Promise.reject(new Error('host denied'));
+      const renderer = await renderAst(codeAst('const x = 1\n', 'ts'), { onCopyCode });
+      const btn = renderer.root.findByType('TouchableOpacity');
+
+      await act(async () => {
+        btn.props.onPress();
+      });
+      // Flush the rejected promise so the internal catch path settles.
+      await act(async () => {});
+
+      const label = renderer.root.findByType('TouchableOpacity').children[0];
+      expect(label.props.children).toBe('Copy');
+      expect(renderer.root.findByType('TouchableOpacity').props.accessibilityLabel).toBe(
+        'Copy code'
+      );
+      await new Promise(resolve => setTimeout(resolve, 10));
+      expect(rejections).toHaveLength(0);
+    } finally {
+      process.removeListener('unhandledRejection', onUnhandled);
+    }
+  });
+
+  it('exposes accessibilityRole="button" so screen readers announce the control', async () => {
+    const onCopyCode = mock(() => undefined);
+    const renderer = await renderAst(codeAst('const x = 1\n', 'ts'), { onCopyCode });
+    const btn = renderer.root.findByType('TouchableOpacity');
+    expect(btn.props.accessibilityRole).toBe('button');
+    expect(btn.props.accessibilityLabel).toBe('Copy code');
+  });
+
+  it('keeps the card chrome on the container and off the body (no seam)', async () => {
+    const onCopyCode = mock(() => undefined);
+    const renderer = await renderAst(codeAst('const x = 1\n', 'ts'), { onCopyCode });
+    const { defaultStyles } = await import('../src/styles');
+    // Container owns background + radius; header and body stay transparent so
+    // no tint seam shows between header and code body.
+    expect(defaultStyles.codeBlockContainer.backgroundColor).toBe('#f5f5f5');
+    expect(defaultStyles.codeBlockHeader).not.toHaveProperty('backgroundColor');
+    expect(defaultStyles.codeBlockBody).not.toHaveProperty('backgroundColor');
+    expect(defaultStyles.codeBlockBody).not.toHaveProperty('borderRadius');
+    expect(defaultStyles.codeBlockContainer).not.toHaveProperty('marginBottom');
+    expect(renderer.root.findByType('TouchableOpacity')).toBeTruthy();
+  });
+
+  it('puts the dark background on the shared container instead of the header', async () => {
+    const { darkThemeStyles } = await import('../src/styles');
+    expect(darkThemeStyles.codeBlockContainer?.backgroundColor).toBe('#2d2d2d');
+    expect(darkThemeStyles.codeBlockHeader).toBeUndefined();
+  });
+
+  it('keeps RN clipboard-free when copyButton is explicitly true without a handler', async () => {
+    const renderer = await renderAst(codeAst('const x = 1\n', 'ts'), { copyButton: true });
+    expect(renderer.root.findAllByType('TouchableOpacity')).toHaveLength(0);
   });
 });

--- a/packages/renderers/rn/src/CodeBlock.tsx
+++ b/packages/renderers/rn/src/CodeBlock.tsx
@@ -59,7 +59,7 @@ export function CodeBlock({ node, styles, children }: CodeBlockProps): React.Rea
     if (!onCopyCode) {
       return;
     }
-    onCopyCode(node.value, node);
+    void onCopyCode(node.value, node);
     setCopied(true);
     if (timerRef.current) {
       clearTimeout(timerRef.current);

--- a/packages/renderers/rn/src/CodeBlock.tsx
+++ b/packages/renderers/rn/src/CodeBlock.tsx
@@ -55,16 +55,26 @@ export function CodeBlock({ node, styles, children }: CodeBlockProps): React.Rea
   const showButton =
     copyButton !== false && typeof onCopyCode === 'function' && Boolean(node.lang);
 
+  // Wait for the host handler to resolve before flipping the label: a
+  // rejected onCopyCode must leave "Copy" in place so the user does not see a
+  // fake success. The handler stays void (not async) to satisfy the onPress
+  // contract; the async IIFE carries its own catch.
   const handlePress = (): void => {
     if (!onCopyCode) {
       return;
     }
-    void onCopyCode(node.value, node);
-    setCopied(true);
-    if (timerRef.current) {
-      clearTimeout(timerRef.current);
-    }
-    timerRef.current = setTimeout(() => setCopied(false), 1500);
+    void (async () => {
+      try {
+        await onCopyCode(node.value, node);
+        setCopied(true);
+        if (timerRef.current) {
+          clearTimeout(timerRef.current);
+        }
+        timerRef.current = setTimeout(() => setCopied(false), 1500);
+      } catch {
+        // Host handler rejected: keep "Copy".
+      }
+    })();
   };
 
   if (!showButton) {
@@ -77,7 +87,7 @@ export function CodeBlock({ node, styles, children }: CodeBlockProps): React.Rea
       <TouchableOpacity
         style={styles.codeButton}
         onPress={handlePress}
-        accessibilityLabel="Copy code"
+        accessibilityLabel={copied ? 'Copied code' : 'Copy code'}
       >
         <Text style={styles.codeButtonText}>{copied ? 'Copied' : 'Copy'}</Text>
       </TouchableOpacity>

--- a/packages/renderers/rn/src/CodeBlock.tsx
+++ b/packages/renderers/rn/src/CodeBlock.tsx
@@ -26,7 +26,9 @@ interface CodeBlockProps {
 }
 
 /**
- * Renders the code-block shell with an optional top-right copy button.
+ * Renders the code-block shell with an optional header row carrying the
+ * language label (left) and a copy button (right), so the button never
+ * overlays a code line.
  *
  * React Native stays clipboard-free: the button is rendered only when the host
  * provides `onCopyCode` (and has not disabled it via `copyButton: false`).
@@ -82,15 +84,18 @@ export function CodeBlock({ node, styles, children }: CodeBlockProps): React.Rea
   }
 
   return (
-    <View style={[styles.codeBlock, { position: 'relative' }]}>
-      {children}
-      <TouchableOpacity
-        style={styles.codeButton}
-        onPress={handlePress}
-        accessibilityLabel={copied ? 'Copied code' : 'Copy code'}
-      >
-        <Text style={styles.codeButtonText}>{copied ? 'Copied' : 'Copy'}</Text>
-      </TouchableOpacity>
+    <View style={styles.codeBlockContainer}>
+      <View style={styles.codeBlockHeader}>
+        <Text style={styles.codeBlockLang}>{node.lang}</Text>
+        <TouchableOpacity
+          style={styles.codeButton}
+          onPress={handlePress}
+          accessibilityLabel={copied ? 'Copied code' : 'Copy code'}
+        >
+          <Text style={styles.codeButtonText}>{copied ? 'Copied' : 'Copy'}</Text>
+        </TouchableOpacity>
+      </View>
+      <View style={styles.codeBlock}>{children}</View>
     </View>
   );
 }

--- a/packages/renderers/rn/src/CodeBlock.tsx
+++ b/packages/renderers/rn/src/CodeBlock.tsx
@@ -47,7 +47,13 @@ export function CodeBlock({ node, styles, children }: CodeBlockProps): React.Rea
     };
   }, []);
 
-  const showButton = copyButton !== false && typeof onCopyCode === 'function';
+  // Only fenced code blocks that declare a language (info string) get the
+  // button. The AST does not distinguish fenced from indented code (both are
+  // `type: 'code'`), so `node.lang` is the signal that the author marked a
+  // real code block; indented pre-formatted text and language-less fences
+  // stay a plain <View> without a "Copy" button.
+  const showButton =
+    copyButton !== false && typeof onCopyCode === 'function' && Boolean(node.lang);
 
   const handlePress = (): void => {
     if (!onCopyCode) {

--- a/packages/renderers/rn/src/CodeBlock.tsx
+++ b/packages/renderers/rn/src/CodeBlock.tsx
@@ -1,0 +1,80 @@
+import React, { createContext, useContext, useEffect, useRef, useState } from 'react';
+import { Text, TouchableOpacity, View } from 'react-native';
+import type { SupramarkCodeNode } from '@supramark/core';
+import type { MergedStyles } from './styles';
+
+/**
+ * Context carrying the host-provided copy handler and the copyButton toggle.
+ *
+ * The Supramark component wraps its rendered tree in this Provider so every
+ * CodeBlock can read the host callback without threading it through the
+ * top-level renderNode / renderRootNodes signatures (which would require
+ * updating every recursive call site).
+ */
+export interface CodeCopyContextValue {
+  onCopyCode?: (code: string, node: SupramarkCodeNode) => void | Promise<void>;
+  copyButton?: boolean;
+}
+
+export const CodeCopyContext = createContext<CodeCopyContextValue>({});
+
+interface CodeBlockProps {
+  node: SupramarkCodeNode;
+  styles: MergedStyles;
+  /** Already-rendered code content (the inner <Text> tree, with or without highlight tokens). */
+  children: React.ComponentProps<typeof Text>['children'];
+}
+
+/**
+ * Renders the code-block shell with an optional top-right copy button.
+ *
+ * React Native stays clipboard-free: the button is rendered only when the host
+ * provides `onCopyCode` (and has not disabled it via `copyButton: false`).
+ * The host owns the clipboard API (expo-clipboard / @react-native-clipboard /
+ * mini-program clipboard) inside that callback.
+ */
+export function CodeBlock({ node, styles, children }: CodeBlockProps): React.ReactElement {
+  const { onCopyCode, copyButton } = useContext(CodeCopyContext);
+  const [copied, setCopied] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Clear the "Copied" reset timer if the block unmounts mid-feedback.
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+      }
+    };
+  }, []);
+
+  const showButton = copyButton !== false && typeof onCopyCode === 'function';
+
+  const handlePress = (): void => {
+    if (!onCopyCode) {
+      return;
+    }
+    onCopyCode(node.value, node);
+    setCopied(true);
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+    }
+    timerRef.current = setTimeout(() => setCopied(false), 1500);
+  };
+
+  if (!showButton) {
+    return <View style={styles.codeBlock}>{children}</View>;
+  }
+
+  return (
+    <View style={[styles.codeBlock, { position: 'relative' }]}>
+      {children}
+      <TouchableOpacity
+        style={styles.codeButton}
+        onPress={handlePress}
+        accessibilityLabel="Copy code"
+      >
+        <Text style={styles.codeButtonText}>{copied ? 'Copied' : 'Copy'}</Text>
+      </TouchableOpacity>
+    </View>
+  );
+}

--- a/packages/renderers/rn/src/CodeBlock.tsx
+++ b/packages/renderers/rn/src/CodeBlock.tsx
@@ -38,11 +38,17 @@ interface CodeBlockProps {
 export function CodeBlock({ node, styles, children }: CodeBlockProps): React.ReactElement {
   const { onCopyCode, copyButton } = useContext(CodeCopyContext);
   const [copied, setCopied] = useState(false);
+  // Prevent a host Promise that settles after unmount from updating state or
+  // creating a feedback timer that no mounted block can consume.
+  const mountedRef = useRef(true);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // Clear the "Copied" reset timer if the block unmounts mid-feedback.
   useEffect(() => {
+    // StrictMode replays effect setup, so mark the live setup as mounted too.
+    mountedRef.current = true;
     return () => {
+      mountedRef.current = false;
       if (timerRef.current) {
         clearTimeout(timerRef.current);
       }
@@ -54,8 +60,7 @@ export function CodeBlock({ node, styles, children }: CodeBlockProps): React.Rea
   // `type: 'code'`), so `node.lang` is the signal that the author marked a
   // real code block; indented pre-formatted text and language-less fences
   // stay a plain <View> without a "Copy" button.
-  const showButton =
-    copyButton !== false && typeof onCopyCode === 'function' && Boolean(node.lang);
+  const showButton = copyButton !== false && typeof onCopyCode === 'function' && Boolean(node.lang);
 
   // Wait for the host handler to resolve before flipping the label: a
   // rejected onCopyCode must leave "Copy" in place so the user does not see a
@@ -68,6 +73,10 @@ export function CodeBlock({ node, styles, children }: CodeBlockProps): React.Rea
     void (async () => {
       try {
         await onCopyCode(node.value, node);
+        // The host callback may resolve after navigation removed this block.
+        if (!mountedRef.current) {
+          return;
+        }
         setCopied(true);
         if (timerRef.current) {
           clearTimeout(timerRef.current);
@@ -90,12 +99,13 @@ export function CodeBlock({ node, styles, children }: CodeBlockProps): React.Rea
         <TouchableOpacity
           style={styles.codeButton}
           onPress={handlePress}
+          accessibilityRole="button"
           accessibilityLabel={copied ? 'Copied code' : 'Copy code'}
         >
           <Text style={styles.codeButtonText}>{copied ? 'Copied' : 'Copy'}</Text>
         </TouchableOpacity>
       </View>
-      <View style={styles.codeBlock}>{children}</View>
+      <View style={styles.codeBlockBody}>{children}</View>
     </View>
   );
 }

--- a/packages/renderers/rn/src/Supramark.tsx
+++ b/packages/renderers/rn/src/Supramark.tsx
@@ -32,6 +32,7 @@ import { MathInline } from './MathInline';
 import { type SupramarkStyles, mergeStyles, darkThemeStyles } from './styles';
 import { ErrorBoundary, type ErrorInfo, ErrorDisplay } from './ErrorBoundary';
 import { SourceStateContext } from './SourceStateContext';
+import { CodeBlock, CodeCopyContext } from './CodeBlock';
 import { resolveDevelopmentMode } from './devMode';
 import {
   getRendererCache,
@@ -314,6 +315,17 @@ export interface SupramarkProps {
   containerRenderers?: Record<string, ContainerRendererRN>;
   codeHighlighter?: SupramarkCodeHighlighter;
   codeHighlightTheme?: string;
+  /**
+   * Copy handler for fenced code blocks. When provided, each code block
+   * renders a top-right copy button that calls this with the raw source.
+   *
+   * RN stays clipboard-free: the host owns the clipboard API
+   * (expo-clipboard / @react-native-clipboard / mini-program clipboard)
+   * inside this callback. Without it, no copy button is shown on RN.
+   */
+  onCopyCode?: (code: string, node: SupramarkCodeNode) => void | Promise<void>;
+  /** Whether to show the code-block copy button (default: shown when onCopyCode is set). */
+  copyButton?: boolean;
 
   /**
    * Callback invoked when the user taps an HTML Page card.
@@ -349,6 +361,8 @@ export const Supramark: React.FC<SupramarkProps> = ({
   containerRenderers,
   codeHighlighter,
   codeHighlightTheme,
+  onCopyCode,
+  copyButton,
 }) => {
   // Global options.cache provides the least-specific cache default.
   const documentCachePolicy = useMemo(() => resolveDocumentCachePolicy(config), [config]);
@@ -537,16 +551,18 @@ export const Supramark: React.FC<SupramarkProps> = ({
     <ErrorBoundary onError={onError} fallback={errorFallback}>
       <SourceStateContext.Provider value={parsedDocument.sourceState}>
         <ImagePressContext.Provider value={onImagePress}>
-          <View style={mergedStyles.root}>
-            {renderRootNodes(
-              parsedDocument.root.children,
-              mergedStyles,
-              parsedDocument.highlighted,
-              config,
-              onOpenHtmlPage,
-              mergedContainerRenderers
-            )}
-          </View>
+          <CodeCopyContext.Provider value={{ onCopyCode, copyButton }}>
+            <View style={mergedStyles.root}>
+              {renderRootNodes(
+                parsedDocument.root.children,
+                mergedStyles,
+                parsedDocument.highlighted,
+                config,
+                onOpenHtmlPage,
+                mergedContainerRenderers
+              )}
+            </View>
+          </CodeCopyContext.Provider>
         </ImagePressContext.Provider>
       </SourceStateContext.Provider>
     </ErrorBoundary>
@@ -901,7 +917,11 @@ function renderNode(
     }
     case 'code': {
       const codeBlock = node;
-      return renderCodeBlock(codeBlock, key, styles, highlighted);
+      return (
+        <CodeBlock key={key} node={codeBlock} styles={styles}>
+          {renderCodeContent(codeBlock, styles, highlighted)}
+        </CodeBlock>
+      );
     }
     case 'math_block': {
       const mathBlock = node;
@@ -1108,9 +1128,7 @@ function renderNode(
 
         return (
           <View key={key} style={admonitionContainerStyle}>
-            {title ? (
-              <Text style={[styles.paragraph, { fontWeight: '600' }]}>{title}</Text>
-            ) : null}
+            {title ? <Text style={[styles.paragraph, { fontWeight: '600' }]}>{title}</Text> : null}
             {renderAdmonitionContent()}
           </View>
         );
@@ -1321,9 +1339,8 @@ function renderNode(
   }
 }
 
-function renderCodeBlock(
+function renderCodeContent(
   codeBlock: SupramarkCodeNode,
-  key: number,
   styles: ReturnType<typeof mergeStyles>,
   highlighted: ReadonlyMap<string, SupramarkCodeHighlightResult>
 ): RenderedNode {
@@ -1332,28 +1349,22 @@ function renderCodeBlock(
   );
 
   if (!highlight) {
-    return (
-      <View key={key} style={styles.codeBlock}>
-        <Text style={styles.code}>{codeBlock.value}</Text>
-      </View>
-    );
+    return <Text style={styles.code}>{codeBlock.value}</Text>;
   }
 
   return (
-    <View key={key} style={styles.codeBlock}>
-      <Text style={styles.code}>
-        {highlight.lines.map((line, lineIndex) => (
-          <Text key={lineIndex}>
-            {line.tokens.map((token, tokenIndex) => (
-              <Text key={tokenIndex} style={codeTokenTextStyle(token)}>
-                {token.text}
-              </Text>
-            ))}
-            {lineIndex < highlight.lines.length - 1 ? '\n' : null}
-          </Text>
-        ))}
-      </Text>
-    </View>
+    <Text style={styles.code}>
+      {highlight.lines.map((line, lineIndex) => (
+        <Text key={lineIndex}>
+          {line.tokens.map((token, tokenIndex) => (
+            <Text key={tokenIndex} style={codeTokenTextStyle(token)}>
+              {token.text}
+            </Text>
+          ))}
+          {lineIndex < highlight.lines.length - 1 ? '\n' : null}
+        </Text>
+      ))}
+    </Text>
   );
 }
 
@@ -1526,13 +1537,7 @@ function renderInlineNode(
       // the same config from yielding structurally different output per
       // platform.
       if (parentType === 'strong' && config?.options?.flattenNestedStrong === true) {
-        return renderInlineNodes(
-          strongNode.children,
-          styles,
-          highlighted,
-          config,
-          'strong'
-        );
+        return renderInlineNodes(strongNode.children, styles, highlighted, config, 'strong');
       }
       return (
         <Text key={key} style={styles.strong}>

--- a/packages/renderers/rn/src/Supramark.tsx
+++ b/packages/renderers/rn/src/Supramark.tsx
@@ -316,15 +316,20 @@ export interface SupramarkProps {
   codeHighlighter?: SupramarkCodeHighlighter;
   codeHighlightTheme?: string;
   /**
-   * Copy handler for fenced code blocks. When provided, each code block
-   * renders a top-right copy button that calls this with the raw source.
+   * Copy handler for code blocks with a language info string. When provided,
+   * the header renders a copy button that calls this with the raw source.
    *
    * RN stays clipboard-free: the host owns the clipboard API
    * (expo-clipboard / @react-native-clipboard / mini-program clipboard)
    * inside this callback. Without it, no copy button is shown on RN.
+   * Language-less fences and indented code have no distinct AST flag and do
+   * not render a copy button.
    */
   onCopyCode?: (code: string, node: SupramarkCodeNode) => void | Promise<void>;
-  /** Whether to show the code-block copy button (default: shown when onCopyCode is set). */
+  /**
+   * Whether to show the code-block copy button (requires onCopyCode;
+   * default: enabled).
+   */
   copyButton?: boolean;
 
   /**
@@ -527,6 +532,12 @@ export const Supramark: React.FC<SupramarkProps> = ({
     return containerRenderers ?? {};
   }, [containerRenderers]);
 
+  // Keep the provider identity stable for memoized code-block consumers.
+  const codeCopyContextValue = useMemo(
+    () => ({ onCopyCode, copyButton }),
+    [onCopyCode, copyButton],
+  );
+
   // Parse-error fallback: show the error info or the raw markdown
   if (parseError) {
     if (errorFallback) {
@@ -551,7 +562,7 @@ export const Supramark: React.FC<SupramarkProps> = ({
     <ErrorBoundary onError={onError} fallback={errorFallback}>
       <SourceStateContext.Provider value={parsedDocument.sourceState}>
         <ImagePressContext.Provider value={onImagePress}>
-          <CodeCopyContext.Provider value={{ onCopyCode, copyButton }}>
+          <CodeCopyContext.Provider value={codeCopyContextValue}>
             <View style={mergedStyles.root}>
               {renderRootNodes(
                 parsedDocument.root.children,
@@ -1128,7 +1139,9 @@ function renderNode(
 
         return (
           <View key={key} style={admonitionContainerStyle}>
-            {title ? <Text style={[styles.paragraph, { fontWeight: '600' }]}>{title}</Text> : null}
+            {title ? (
+              <Text style={[styles.paragraph, { fontWeight: '600' }]}>{title}</Text>
+            ) : null}
             {renderAdmonitionContent()}
           </View>
         );
@@ -1537,7 +1550,13 @@ function renderInlineNode(
       // the same config from yielding structurally different output per
       // platform.
       if (parentType === 'strong' && config?.options?.flattenNestedStrong === true) {
-        return renderInlineNodes(strongNode.children, styles, highlighted, config, 'strong');
+        return renderInlineNodes(
+          strongNode.children,
+          styles,
+          highlighted,
+          config,
+          'strong'
+        );
       }
       return (
         <Text key={key} style={styles.strong}>

--- a/packages/renderers/rn/src/styles.ts
+++ b/packages/renderers/rn/src/styles.ts
@@ -24,7 +24,13 @@ export interface SupramarkStyles {
   // Code blocks
   codeBlock?: ViewStyle;
   code?: TextStyle;
-  /** Copy button overlay on a code block (shown only when onCopyCode is provided). */
+  /** Wrapper around a code block header (lang + button) and the code body. */
+  codeBlockContainer?: ViewStyle;
+  /** Header row: language label on the left, copy button on the right. */
+  codeBlockHeader?: ViewStyle;
+  /** Language label in the header (the fenced info string). */
+  codeBlockLang?: TextStyle;
+  /** Copy button in the header (shown only when onCopyCode is provided). */
   codeButton?: ViewStyle;
   /** Label text inside the copy button. */
   codeButtonText?: TextStyle;
@@ -143,10 +149,25 @@ export const defaultStyles = StyleSheet.create({
     fontFamily: 'Menlo',
     fontSize: 12,
   },
+  codeBlockContainer: {
+    borderRadius: 4,
+    overflow: 'hidden',
+    marginBottom: 4,
+  },
+  codeBlockHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 8,
+    paddingVertical: 4,
+    backgroundColor: 'rgba(0, 0, 0, 0.08)',
+  },
+  codeBlockLang: {
+    fontSize: 12,
+    color: 'rgba(0, 0, 0, 0.55)',
+    fontFamily: 'Menlo',
+  },
   codeButton: {
-    position: 'absolute',
-    top: 8,
-    right: 8,
     backgroundColor: 'rgba(0, 0, 0, 0.5)',
     borderRadius: 4,
     paddingHorizontal: 8,
@@ -465,6 +486,12 @@ export const darkThemeStyles: SupramarkStyles = {
   },
   codeBlock: {
     backgroundColor: '#2d2d2d',
+  },
+  codeBlockHeader: {
+    backgroundColor: 'rgba(255, 255, 255, 0.08)',
+  },
+  codeBlockLang: {
+    color: 'rgba(255, 255, 255, 0.6)',
   },
   codeButton: {
     backgroundColor: 'rgba(255, 255, 255, 0.25)',

--- a/packages/renderers/rn/src/styles.ts
+++ b/packages/renderers/rn/src/styles.ts
@@ -24,6 +24,10 @@ export interface SupramarkStyles {
   // Code blocks
   codeBlock?: ViewStyle;
   code?: TextStyle;
+  /** Copy button overlay on a code block (shown only when onCopyCode is provided). */
+  codeButton?: ViewStyle;
+  /** Label text inside the copy button. */
+  codeButtonText?: TextStyle;
 
   // Lists
   list?: ViewStyle;
@@ -137,6 +141,19 @@ export const defaultStyles = StyleSheet.create({
   },
   code: {
     fontFamily: 'Menlo',
+    fontSize: 12,
+  },
+  codeButton: {
+    position: 'absolute',
+    top: 8,
+    right: 8,
+    backgroundColor: 'rgba(0, 0, 0, 0.5)',
+    borderRadius: 4,
+    paddingHorizontal: 8,
+    paddingVertical: 4,
+  },
+  codeButtonText: {
+    color: '#ffffff',
     fontSize: 12,
   },
   list: {
@@ -415,6 +432,9 @@ export function mergeStyles(customStyles?: SupramarkStyles): typeof defaultStyle
   return merged as typeof defaultStyles;
 }
 
+/** The fully-merged style shape consumed by renderer components. */
+export type MergedStyles = ReturnType<typeof mergeStyles>;
+
 /**
  * Dark theme styles
  */
@@ -445,6 +465,9 @@ export const darkThemeStyles: SupramarkStyles = {
   },
   codeBlock: {
     backgroundColor: '#2d2d2d',
+  },
+  codeButton: {
+    backgroundColor: 'rgba(255, 255, 255, 0.25)',
   },
   inlineCode: {
     backgroundColor: '#2d2d2d',

--- a/packages/renderers/rn/src/styles.ts
+++ b/packages/renderers/rn/src/styles.ts
@@ -24,12 +24,14 @@ export interface SupramarkStyles {
   // Code blocks
   codeBlock?: ViewStyle;
   code?: TextStyle;
-  /** Wrapper around a code block header (lang + button) and the code body. */
+  /** Wrapper around a code block header (lang + button) and the code body. Owns the card chrome (background, radius). */
   codeBlockContainer?: ViewStyle;
   /** Header row: language label on the left, copy button on the right. */
   codeBlockHeader?: ViewStyle;
   /** Language label in the header (the fenced info string). */
   codeBlockLang?: TextStyle;
+  /** Code body inside the headered container (chrome lives on the container). */
+  codeBlockBody?: ViewStyle;
   /** Copy button in the header (shown only when onCopyCode is provided). */
   codeButton?: ViewStyle;
   /** Label text inside the copy button. */
@@ -150,9 +152,9 @@ export const defaultStyles = StyleSheet.create({
     fontSize: 12,
   },
   codeBlockContainer: {
+    backgroundColor: '#f5f5f5',
     borderRadius: 4,
     overflow: 'hidden',
-    marginBottom: 4,
   },
   codeBlockHeader: {
     flexDirection: 'row',
@@ -160,12 +162,14 @@ export const defaultStyles = StyleSheet.create({
     justifyContent: 'space-between',
     paddingHorizontal: 8,
     paddingVertical: 4,
-    backgroundColor: 'rgba(0, 0, 0, 0.08)',
   },
   codeBlockLang: {
     fontSize: 12,
     color: 'rgba(0, 0, 0, 0.55)',
     fontFamily: 'Menlo',
+  },
+  codeBlockBody: {
+    padding: 8,
   },
   codeButton: {
     backgroundColor: 'rgba(0, 0, 0, 0.5)',
@@ -487,8 +491,8 @@ export const darkThemeStyles: SupramarkStyles = {
   codeBlock: {
     backgroundColor: '#2d2d2d',
   },
-  codeBlockHeader: {
-    backgroundColor: 'rgba(255, 255, 255, 0.08)',
+  codeBlockContainer: {
+    backgroundColor: '#2d2d2d',
   },
   codeBlockLang: {
     color: 'rgba(255, 255, 255, 0.6)',

--- a/packages/renderers/web/__tests__/code-block-copy.test.tsx
+++ b/packages/renderers/web/__tests__/code-block-copy.test.tsx
@@ -109,4 +109,10 @@ describe('code block copy button (web)', () => {
     expect(writeText).not.toHaveBeenCalled();
     expect(button.textContent).toContain('Copied');
   });
+
+  test('omits the button when the code block has no language (indented / language-less fence)', async () => {
+    const container = await renderCode('foo\n', undefined);
+    expect(findButton(container)).toBeNull();
+    expect(container.innerHTML).toContain('foo');
+  });
 });

--- a/packages/renderers/web/__tests__/code-block-copy.test.tsx
+++ b/packages/renderers/web/__tests__/code-block-copy.test.tsx
@@ -1,0 +1,112 @@
+import React from 'react';
+import { afterEach, describe, expect, mock, test } from 'bun:test';
+import { Window } from 'happy-dom';
+import { createRoot, type Root } from 'react-dom/client';
+import type { SupramarkRootNode } from '@supramark/core';
+import { Supramark } from '../src/Supramark';
+
+type TestAct = (callback: () => void | Promise<void>) => Promise<void>;
+const act = (React as typeof React & { act: TestAct }).act;
+const browser = new Window();
+const writeText = mock(() => Promise.resolve());
+Object.assign(globalThis, {
+  window: browser,
+  document: browser.document,
+  navigator: { ...browser.navigator, clipboard: { writeText } } as typeof browser.navigator,
+  HTMLElement: browser.HTMLElement,
+  Event: browser.Event,
+  Node: browser.Node,
+});
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT =
+  true;
+
+let root: Root | null = null;
+type TestContainer = ReturnType<typeof browser.document.createElement>;
+
+afterEach(async () => {
+  if (root) {
+    await act(async () => root?.unmount());
+    root = null;
+  }
+  browser.document.body.replaceChildren();
+});
+
+function createContainer(): TestContainer {
+  const container = browser.document.createElement('div');
+  browser.document.body.appendChild(container);
+  root = createRoot(container as unknown as HTMLDivElement);
+  return container;
+}
+
+interface RenderOpts {
+  onCopyCode?: (code: string, node: { type: 'code' }) => void;
+  copyButton?: boolean;
+}
+
+async function renderCode(
+  value: string,
+  lang: string | undefined,
+  opts?: RenderOpts
+): Promise<TestContainer> {
+  const container = createContainer();
+  const children = [{ type: 'code', value, ...(lang ? { lang } : {}) }];
+  const ast = {
+    type: 'root',
+    ast_version: 2,
+    diagnostics: [],
+    children,
+  } as SupramarkRootNode;
+  await act(async () => {
+    root?.render(<Supramark markdown="" ast={ast} {...opts} />);
+  });
+  return container;
+}
+
+function findButton(container: TestContainer): HTMLButtonElement | null {
+  const buttons = container.getElementsByTagName('button');
+  return buttons.length > 0 ? (buttons[0] as unknown as HTMLButtonElement) : null;
+}
+
+async function click(button: HTMLButtonElement): Promise<void> {
+  await act(async () => {
+    button.dispatchEvent(new browser.Event('click', { bubbles: true }));
+  });
+}
+
+describe('code block copy button (web)', () => {
+  test('renders a copy button by default and keeps the language class', async () => {
+    const container = await renderCode('const x = 1\n', 'ts');
+    const button = findButton(container);
+    expect(button).not.toBeNull();
+    expect(button?.textContent).toContain('Copy');
+    expect(container.innerHTML).toContain('language-ts');
+  });
+
+  test('omits the button when copyButton is false', async () => {
+    const container = await renderCode('const x = 1\n', 'ts', { copyButton: false });
+    expect(findButton(container)).toBeNull();
+    expect(container.innerHTML).toContain('const x = 1');
+  });
+
+  test('clicking the button writes the code via navigator.clipboard and shows Copied', async () => {
+    writeText.mockClear();
+    const container = await renderCode('const x = 1\n', 'ts');
+    const button = findButton(container)!;
+    await click(button);
+    expect(writeText).toHaveBeenCalledTimes(1);
+    expect(writeText.mock.calls[0][0]).toBe('const x = 1\n');
+    expect(button.textContent).toContain('Copied');
+  });
+
+  test('onCopyCode overrides the default clipboard call', async () => {
+    writeText.mockClear();
+    const onCopyCode = mock(() => undefined);
+    const container = await renderCode('const x = 1\n', 'ts', { onCopyCode });
+    const button = findButton(container)!;
+    await click(button);
+    expect(onCopyCode).toHaveBeenCalledTimes(1);
+    expect(onCopyCode.mock.calls[0][0]).toBe('const x = 1\n');
+    expect(writeText).not.toHaveBeenCalled();
+    expect(button.textContent).toContain('Copied');
+  });
+});

--- a/packages/renderers/web/__tests__/code-block-copy.test.tsx
+++ b/packages/renderers/web/__tests__/code-block-copy.test.tsx
@@ -93,6 +93,14 @@ describe('code block copy button (web)', () => {
     expect(header?.textContent).toContain('Copy');
   });
 
+  test('marks the header and language label as non-selectable', async () => {
+    const container = await renderCode('const x = 1\n', 'ts');
+    // A select-all on the block must not sweep the language label or button
+    // text into the clipboard. The default (empty classNames) path uses inline
+    // user-select: none on the header, the language label, and the button.
+    expect(container.innerHTML).toMatch(/user-select: none/);
+  });
+
   test('omits the button when copyButton is false', async () => {
     const container = await renderCode('const x = 1\n', 'ts', { copyButton: false });
     expect(findButton(container)).toBeNull();

--- a/packages/renderers/web/__tests__/code-block-copy.test.tsx
+++ b/packages/renderers/web/__tests__/code-block-copy.test.tsx
@@ -82,6 +82,17 @@ describe('code block copy button (web)', () => {
     expect(container.innerHTML).toContain('language-ts');
   });
 
+  test('shows the language label in a header row beside the button', async () => {
+    const container = await renderCode('const x = 1\n', 'ts');
+    // The header carries the language text and the button as siblings, so the
+    // button never overlays a code line.
+    expect(container.innerHTML).toContain('>ts<');
+    const button = findButton(container)!;
+    const header = button.parentElement;
+    expect(header?.textContent).toContain('ts');
+    expect(header?.textContent).toContain('Copy');
+  });
+
   test('omits the button when copyButton is false', async () => {
     const container = await renderCode('const x = 1\n', 'ts', { copyButton: false });
     expect(findButton(container)).toBeNull();

--- a/packages/renderers/web/__tests__/code-block-copy.test.tsx
+++ b/packages/renderers/web/__tests__/code-block-copy.test.tsx
@@ -39,8 +39,9 @@ function createContainer(): TestContainer {
 }
 
 interface RenderOpts {
-  onCopyCode?: (code: string, node: { type: 'code' }) => void;
+  onCopyCode?: (code: string, node: { type: 'code' }) => void | Promise<void>;
   copyButton?: boolean;
+  theme?: 'tailwind' | 'minimal';
 }
 
 async function renderCode(
@@ -133,5 +134,55 @@ describe('code block copy button (web)', () => {
     const container = await renderCode('foo\n', undefined);
     expect(findButton(container)).toBeNull();
     expect(container.innerHTML).toContain('foo');
+  });
+
+  test('a rejected writeText leaves the label as Copy (no fake success)', async () => {
+    writeText.mockImplementationOnce(() => Promise.reject(new Error('denied')));
+    const container = await renderCode('const x = 1\n', 'ts');
+    const button = findButton(container);
+    if (!button) {
+      throw new Error('copy button not rendered');
+    }
+    await click(button);
+    // Flush the rejected promise so the catch path settles before asserting.
+    await act(async () => {});
+    expect(button.textContent).toBe('Copy');
+  });
+
+  test('a rejected onCopyCode leaves the label as Copy', async () => {
+    const onCopyCode = () => Promise.reject(new Error('host denied'));
+    const container = await renderCode('const x = 1\n', 'ts', { onCopyCode });
+    const button = findButton(container);
+    if (!button) {
+      throw new Error('copy button not rendered');
+    }
+    await click(button);
+    await act(async () => {});
+    expect(button.textContent).toBe('Copy');
+  });
+
+  test('copyButton false with a fenced language yields one bare pre without style', async () => {
+    const container = await renderCode('const x = 1\n', 'ts', { copyButton: false });
+    const pres = container.getElementsByTagName('pre');
+    expect(pres.length).toBe(1);
+    expect(pres[0].getAttribute('style')).toBeNull();
+    expect(findButton(container)).toBeNull();
+  });
+
+  test('tailwind theme keeps the standalone chrome on the bare pre (copyButton false)', async () => {
+    const container = await renderCode('const x = 1\n', 'ts', {
+      copyButton: false,
+      theme: 'tailwind',
+    });
+    const pre = container.getElementsByTagName('pre')[0] as unknown as HTMLElement;
+    expect(pre.className).toBe('bg-gray-100 dark:bg-gray-800 rounded-md p-4 mb-4 overflow-x-auto');
+  });
+
+  test('tailwind theme moves the chrome to the container and zeroes the headered body', async () => {
+    const container = await renderCode('const x = 1\n', 'ts', { theme: 'tailwind' });
+    const pre = container.getElementsByTagName('pre')[0] as unknown as HTMLElement;
+    expect(pre.className).toBe('m-0 p-4 overflow-x-auto');
+    const wrapper = pre.parentElement as unknown as HTMLElement | null;
+    expect(wrapper?.className).toBe('bg-gray-100 dark:bg-gray-800 rounded-md mb-4 overflow-hidden');
   });
 });

--- a/packages/renderers/web/__tests__/code-block-copy.test.tsx
+++ b/packages/renderers/web/__tests__/code-block-copy.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { afterEach, describe, expect, mock, test } from 'bun:test';
 import { Window } from 'happy-dom';
 import { createRoot, type Root } from 'react-dom/client';
+import { renderToStaticMarkup } from 'react-dom/server';
 import type { SupramarkRootNode } from '@supramark/core';
 import { Supramark } from '../src/Supramark';
 
@@ -116,6 +117,79 @@ describe('code block copy button (web)', () => {
     expect(writeText).toHaveBeenCalledTimes(1);
     expect(writeText.mock.calls[0][0]).toBe('const x = 1\n');
     expect(button.textContent).toContain('Copied');
+    expect(button.getAttribute('aria-label')).toBe('Copied code');
+  });
+
+  test('waits for the clipboard write before reporting success', async () => {
+    let resolveWrite: (() => void) | undefined;
+    writeText.mockImplementationOnce(
+      () =>
+        new Promise<void>(resolve => {
+          resolveWrite = resolve;
+        })
+    );
+    const container = await renderCode('const x = 1\n', 'ts');
+    const button = findButton(container)!;
+
+    await click(button);
+    expect(button.textContent).toBe('Copy');
+    expect(button.getAttribute('aria-label')).toBe('Copy code');
+
+    await act(async () => resolveWrite?.());
+    expect(button.textContent).toBe('Copied');
+    expect(button.getAttribute('aria-label')).toBe('Copied code');
+  });
+
+  test('does not schedule feedback after an in-flight copy unmounts', async () => {
+    let resolveWrite: (() => void) | undefined;
+    writeText.mockImplementationOnce(
+      () =>
+        new Promise<void>(resolve => {
+          resolveWrite = resolve;
+        })
+    );
+    const container = await renderCode('const x = 1\n', 'ts');
+    await click(findButton(container)!);
+    await act(async () => root?.unmount());
+    root = null;
+
+    // Resolving after cleanup must not create the 1.5-second label timer.
+    const originalSetTimeout = globalThis.setTimeout;
+    const feedbackTimer = mock(() => 0 as unknown as ReturnType<typeof setTimeout>);
+    globalThis.setTimeout = feedbackTimer as unknown as typeof setTimeout;
+    try {
+      resolveWrite?.();
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(feedbackTimer).not.toHaveBeenCalled();
+    } finally {
+      globalThis.setTimeout = originalSetTimeout;
+    }
+  });
+
+  test('still resets Copied after the host replaces onCopyCode', async () => {
+    const firstHandler = mock(() => undefined);
+    const container = await renderCode('const x = 1\n', 'ts', { onCopyCode: firstHandler });
+    const button = findButton(container)!;
+    await click(button);
+    expect(button.textContent).toBe('Copied');
+
+    const ast = {
+      type: 'root',
+      ast_version: 2,
+      diagnostics: [],
+      children: [{ type: 'code', value: 'const x = 1\n', lang: 'ts' }],
+    } as SupramarkRootNode;
+    const replacementHandler = mock(() => undefined);
+    await act(async () => {
+      root?.render(<Supramark markdown="" ast={ast} onCopyCode={replacementHandler} />);
+    });
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 1600));
+    });
+
+    expect(findButton(container)?.textContent).toBe('Copy');
+    expect(findButton(container)?.getAttribute('aria-label')).toBe('Copy code');
   });
 
   test('onCopyCode overrides the default clipboard call', async () => {
@@ -136,36 +210,63 @@ describe('code block copy button (web)', () => {
     expect(container.innerHTML).toContain('foo');
   });
 
-  test('a rejected writeText leaves the label as Copy (no fake success)', async () => {
-    writeText.mockImplementationOnce(() => Promise.reject(new Error('denied')));
-    const container = await renderCode('const x = 1\n', 'ts');
-    const button = findButton(container);
-    if (!button) {
-      throw new Error('copy button not rendered');
+  test('a rejected writeText leaves the label as Copy (no fake success, no unhandledRejection)', async () => {
+    const rejections: unknown[] = [];
+    const onUnhandled = (reason: unknown): void => {
+      rejections.push(reason);
+    };
+    process.on('unhandledRejection', onUnhandled);
+    try {
+      writeText.mockImplementationOnce(() => Promise.reject(new Error('denied')));
+      const container = await renderCode('const x = 1\n', 'ts');
+      const button = findButton(container);
+      if (!button) {
+        throw new Error('copy button not rendered');
+      }
+      await click(button);
+      // Flush the rejected promise so the catch path settles before asserting.
+      await act(async () => {});
+      expect(button.textContent).toBe('Copy');
+      expect(button.getAttribute('aria-label')).toBe('Copy code');
+      await new Promise(resolve => setTimeout(resolve, 10));
+      expect(rejections).toHaveLength(0);
+    } finally {
+      process.removeListener('unhandledRejection', onUnhandled);
     }
-    await click(button);
-    // Flush the rejected promise so the catch path settles before asserting.
-    await act(async () => {});
-    expect(button.textContent).toBe('Copy');
   });
 
-  test('a rejected onCopyCode leaves the label as Copy', async () => {
-    const onCopyCode = () => Promise.reject(new Error('host denied'));
-    const container = await renderCode('const x = 1\n', 'ts', { onCopyCode });
-    const button = findButton(container);
-    if (!button) {
-      throw new Error('copy button not rendered');
+  test('a rejected onCopyCode leaves the label as Copy and raises no unhandledRejection', async () => {
+    const rejections: unknown[] = [];
+    const onUnhandled = (reason: unknown): void => {
+      rejections.push(reason);
+    };
+    process.on('unhandledRejection', onUnhandled);
+    try {
+      const onCopyCode = () => Promise.reject(new Error('host denied'));
+      const container = await renderCode('const x = 1\n', 'ts', { onCopyCode });
+      const button = findButton(container);
+      if (!button) {
+        throw new Error('copy button not rendered');
+      }
+      await click(button);
+      await act(async () => {});
+      expect(button.textContent).toBe('Copy');
+      expect(button.getAttribute('aria-label')).toBe('Copy code');
+      await new Promise(resolve => setTimeout(resolve, 10));
+      expect(rejections).toHaveLength(0);
+    } finally {
+      process.removeListener('unhandledRejection', onUnhandled);
     }
-    await click(button);
-    await act(async () => {});
-    expect(button.textContent).toBe('Copy');
   });
 
   test('copyButton false with a fenced language yields one bare pre without style', async () => {
     const container = await renderCode('const x = 1\n', 'ts', { copyButton: false });
+    const rootElement = container.firstElementChild as unknown as HTMLElement;
     const pres = container.getElementsByTagName('pre');
     expect(pres.length).toBe(1);
     expect(pres[0].getAttribute('style')).toBeNull();
+    expect(pres[0].getAttribute('class')).toBeNull();
+    expect(rootElement.innerHTML).toBe('<pre><code class="language-ts">const x = 1\n</code></pre>');
     expect(findButton(container)).toBeNull();
   });
 
@@ -184,5 +285,111 @@ describe('code block copy button (web)', () => {
     expect(pre.className).toBe('m-0 p-4 overflow-x-auto');
     const wrapper = pre.parentElement as unknown as HTMLElement | null;
     expect(wrapper?.className).toBe('bg-gray-100 dark:bg-gray-800 rounded-md mb-4 overflow-hidden');
+  });
+
+  test('tailwind theme keeps card chrome on a language-less code block', async () => {
+    const container = await renderCode('plain\n', undefined, { theme: 'tailwind' });
+    const pre = container.getElementsByTagName('pre')[0] as unknown as HTMLElement;
+    const wrapper = pre.parentElement as unknown as HTMLElement | null;
+    expect(pre.className).toBe('m-0 p-4 overflow-x-auto');
+    expect(wrapper?.className).toBe('bg-gray-100 dark:bg-gray-800 rounded-md mb-4 overflow-hidden');
+    expect(wrapper?.getElementsByTagName('button')).toHaveLength(0);
+  });
+
+  test('minimal theme wires every code-block hook without inline fallback styles', async () => {
+    const container = await renderCode('const x = 1\n', 'ts', { theme: 'minimal' });
+    const pre = container.getElementsByTagName('pre')[0] as unknown as HTMLElement;
+    const wrapper = pre.parentElement as unknown as HTMLElement;
+    const header = wrapper.firstElementChild as unknown as HTMLElement;
+    const button = findButton(container)!;
+
+    expect(wrapper.className).toBe('sm-code-block-container');
+    expect(header.className).toBe('sm-code-block-header');
+    expect((header.firstElementChild as unknown as HTMLElement).className).toBe(
+      'sm-code-block-lang'
+    );
+    expect(button.className).toBe('sm-code-btn');
+    expect((button.firstElementChild as unknown as HTMLElement).className).toBe('sm-code-btn-text');
+    expect(pre.className).toBe('sm-code-block-body');
+    expect(wrapper.getAttribute('style')).toBeNull();
+    expect(header.getAttribute('style')).toBeNull();
+    expect(button.getAttribute('style')).toBeNull();
+    expect(pre.getAttribute('style')).toBeNull();
+  });
+
+  // Pins the default (copyButton on) DOM shape: the conformance harness runs
+  // with copyButton={false}, so without this test the DOM the library emits by
+  // default would be unmeasured.
+  test('default DOM shape: every code block gets the card; only a language gets the header', async () => {
+    const withLang = await renderCode('const x = 1\n', 'ts');
+    const root = withLang.firstElementChild as unknown as HTMLElement;
+    const card = root.firstElementChild as unknown as HTMLElement;
+    expect(card.tagName).toBe('DIV');
+    // Card chrome is inline. happy-dom strips var() values from its CSSOM, so
+    // the --sm-code-bg background cannot be asserted here; assert the rest of
+    // the inline chrome instead (source: INLINE_CONTAINER_STYLE).
+    const cardStyle = card.getAttribute('style') ?? '';
+    expect(cardStyle).toContain('border-radius: 4px');
+    expect(cardStyle).toContain('overflow: hidden');
+    // Header: language label + exactly one button.
+    const header = card.firstElementChild as unknown as HTMLElement;
+    expect(header.tagName).toBe('DIV');
+    expect(header.textContent).toContain('ts');
+    expect(header.getElementsByTagName('button').length).toBe(1);
+    // Body pre is a direct child of the card.
+    const bodyPre = card.getElementsByTagName('pre')[0] as unknown as HTMLElement;
+    expect(bodyPre.parentElement).toBe(card);
+
+    // Language-less fence: card without header or button, so adjacent blocks
+    // with and without a language no longer look unrelated.
+    const noLang = await renderCode('plain\n', undefined);
+    const noLangRoot = noLang.firstElementChild as unknown as HTMLElement;
+    const noLangCard = noLangRoot.firstElementChild as unknown as HTMLElement;
+    expect(noLangCard.tagName).toBe('DIV');
+    expect(noLangCard.children.length).toBe(1);
+    expect(noLangCard.firstElementChild?.tagName).toBe('PRE');
+    expect(noLangCard.getElementsByTagName('button').length).toBe(0);
+  });
+
+  test('server output exposes overridable color variables and matches initial hydration', () => {
+    const ast = {
+      type: 'root',
+      ast_version: 2,
+      diagnostics: [],
+      children: [{ type: 'code', value: 'const x = 1\n', lang: 'ts' }],
+    } as SupramarkRootNode;
+    const html = renderToStaticMarkup(<Supramark markdown="" ast={ast} />);
+
+    expect(html).toContain('background-color:var(--sm-code-bg, #f5f5f5)');
+    expect(html).toContain('color:var(--sm-code-lang-color, rgba(0, 0, 0, 0.55))');
+    expect(html).toContain('background-color:var(--sm-code-btn-bg, rgba(0, 0, 0, 0.5))');
+    expect(html).toContain('<button type="button"');
+  });
+
+  test('hides the button but keeps the header when no clipboard API and no onCopyCode exist', async () => {
+    const nav = globalThis.navigator as Navigator & { clipboard?: unknown };
+    const originalClipboard = nav.clipboard;
+    nav.clipboard = undefined;
+    try {
+      const container = await renderCode('const x = 1\n', 'ts');
+      // An inert button is worse than none: the effect hides it post-mount.
+      expect(findButton(container)).toBeNull();
+      expect(container.innerHTML).toContain('>ts<');
+    } finally {
+      nav.clipboard = originalClipboard;
+    }
+  });
+
+  test('hides the button when clipboard exists without a writeText function', async () => {
+    const nav = globalThis.navigator as Navigator & { clipboard?: unknown };
+    const originalClipboard = nav.clipboard;
+    nav.clipboard = {};
+    try {
+      const container = await renderCode('const x = 1\n', 'ts');
+      expect(findButton(container)).toBeNull();
+      expect(container.innerHTML).toContain('>ts<');
+    } finally {
+      nav.clipboard = originalClipboard;
+    }
   });
 });

--- a/packages/renderers/web/src/CodeBlock.tsx
+++ b/packages/renderers/web/src/CodeBlock.tsx
@@ -1,0 +1,102 @@
+import React, { createContext, useContext, useEffect, useRef, useState } from 'react';
+import type { SupramarkCodeNode } from '@supramark/core';
+import type { SupramarkClassNames } from './classNames';
+
+/**
+ * Context carrying the host-provided copy handler and the copyButton toggle.
+ *
+ * The Supramark component wraps its rendered tree in this Provider so every
+ * CodeBlock can read the host callback without threading it through the
+ * top-level renderNode signature (which would require updating every
+ * recursive call site).
+ */
+export interface CodeCopyContextValue {
+  onCopyCode?: (code: string, node: SupramarkCodeNode) => void | Promise<void>;
+  copyButton?: boolean;
+}
+
+export const CodeCopyContext = createContext<CodeCopyContextValue>({});
+
+interface CodeBlockProps {
+  node: SupramarkCodeNode;
+  classNames: SupramarkClassNames;
+  /** Already-rendered code content (the inner <code> tree, with or without highlight tokens). */
+  children: React.ReactNode;
+}
+
+// Inline fallback styles so the button works out of the box even when the host
+// uses the empty defaultClassNames. When the host supplies a className for the
+// button or container, the inline style is dropped so the className owns it.
+const INLINE_CONTAINER_STYLE: React.CSSProperties = { position: 'relative' };
+const INLINE_BUTTON_STYLE: React.CSSProperties = {
+  position: 'absolute',
+  top: 8,
+  right: 8,
+  backgroundColor: 'rgba(0, 0, 0, 0.5)',
+  color: '#ffffff',
+  border: 'none',
+  borderRadius: 4,
+  padding: '4px 8px',
+  fontSize: 12,
+  cursor: 'pointer',
+};
+
+/**
+ * Renders the code-block shell with an optional top-right copy button.
+ *
+ * Web defaults to `navigator.clipboard.writeText` (zero dependency); the host
+ * can override the action via `onCopyCode`. Disable the button with
+ * `copyButton: false`.
+ */
+export function CodeBlock({ node, classNames, children }: CodeBlockProps): React.ReactElement {
+  const { onCopyCode, copyButton } = useContext(CodeCopyContext);
+  const [copied, setCopied] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Clear the "Copied" reset timer if the block unmounts mid-feedback.
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+      }
+    };
+  }, []);
+
+  const showButton = copyButton !== false;
+
+  const handleClick = (): void => {
+    if (onCopyCode) {
+      onCopyCode(node.value, node);
+    } else if (typeof navigator !== 'undefined' && navigator.clipboard) {
+      void navigator.clipboard.writeText(node.value);
+    }
+    setCopied(true);
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+    }
+    timerRef.current = setTimeout(() => setCopied(false), 1500);
+  };
+
+  // No button: render the pre as before (no wrapper div).
+  if (!showButton) {
+    return <pre className={classNames.codeBlock}>{children}</pre>;
+  }
+
+  const containerStyle = classNames.codeBlockContainer ? undefined : INLINE_CONTAINER_STYLE;
+  const buttonStyle = classNames.codeButton ? undefined : INLINE_BUTTON_STYLE;
+
+  return (
+    <div className={classNames.codeBlockContainer} style={containerStyle}>
+      <pre className={classNames.codeBlock}>{children}</pre>
+      <button
+        type="button"
+        className={classNames.codeButton}
+        style={buttonStyle}
+        onClick={handleClick}
+        aria-label="Copy code"
+      >
+        <span className={classNames.codeButtonText}>{copied ? 'Copied' : 'Copy'}</span>
+      </button>
+    </div>
+  );
+}

--- a/packages/renderers/web/src/CodeBlock.tsx
+++ b/packages/renderers/web/src/CodeBlock.tsx
@@ -62,7 +62,12 @@ export function CodeBlock({ node, classNames, children }: CodeBlockProps): React
     };
   }, []);
 
-  const showButton = copyButton !== false;
+  // Only fenced code blocks that declare a language (info string) get the
+  // button. The AST does not distinguish fenced from indented code (both are
+  // `type: 'code'`), so `node.lang` is the signal that the author marked a
+  // real code block; indented pre-formatted text and language-less fences
+  // stay a plain <pre> without a "Copy" button.
+  const showButton = copyButton !== false && Boolean(node.lang);
 
   const handleClick = (): void => {
     if (onCopyCode) {

--- a/packages/renderers/web/src/CodeBlock.tsx
+++ b/packages/renderers/web/src/CodeBlock.tsx
@@ -29,13 +29,17 @@ interface CodeBlockProps {
 // header / lang / button / container, the inline style is dropped so the
 // className owns it. The button lives in a header row (lang left, button
 // right) instead of an absolute overlay, so it never covers a code line.
-const INLINE_CONTAINER_STYLE: React.CSSProperties = { position: 'relative' };
+const INLINE_CONTAINER_STYLE: React.CSSProperties = {
+  backgroundColor: '#f5f5f5',
+  borderRadius: 4,
+  marginBottom: 16,
+  overflow: 'hidden',
+};
 const INLINE_HEADER_STYLE: React.CSSProperties = {
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'space-between',
   padding: '4px 8px',
-  backgroundColor: 'rgba(0, 0, 0, 0.08)',
   borderBottom: '1px solid rgba(0, 0, 0, 0.1)',
   userSelect: 'none',
 };
@@ -44,6 +48,11 @@ const INLINE_LANG_STYLE: React.CSSProperties = {
   color: 'rgba(0, 0, 0, 0.55)',
   fontFamily: 'monospace',
   userSelect: 'none',
+};
+const INLINE_CODEBLOCK_STYLE: React.CSSProperties = {
+  margin: 0,
+  padding: 16,
+  overflowX: 'auto',
 };
 const INLINE_BUTTON_STYLE: React.CSSProperties = {
   backgroundColor: 'rgba(0, 0, 0, 0.5)',
@@ -114,15 +123,16 @@ export function CodeBlock({ node, classNames, children }: CodeBlockProps): React
     })();
   };
 
-  // No button: render the pre as before (no wrapper div).
-  if (!showButton) {
-    return <pre className={classNames.codeBlock}>{children}</pre>;
-  }
-
   const containerStyle = classNames.codeBlockContainer ? undefined : INLINE_CONTAINER_STYLE;
   const headerStyle = classNames.codeBlockHeader ? undefined : INLINE_HEADER_STYLE;
   const langStyle = classNames.codeBlockLang ? undefined : INLINE_LANG_STYLE;
   const buttonStyle = classNames.codeButton ? undefined : INLINE_BUTTON_STYLE;
+  const codeBlockStyle = classNames.codeBlock ? undefined : INLINE_CODEBLOCK_STYLE;
+
+  // No button: render the pre as before (no wrapper div).
+  if (!showButton) {
+    return <pre className={classNames.codeBlock} style={codeBlockStyle}>{children}</pre>;
+  }
 
   return (
     <div className={classNames.codeBlockContainer} style={containerStyle}>
@@ -140,7 +150,7 @@ export function CodeBlock({ node, classNames, children }: CodeBlockProps): React
           <span className={classNames.codeButtonText}>{copied ? 'Copied' : 'Copy'}</span>
         </button>
       </div>
-      <pre className={classNames.codeBlock}>{children}</pre>
+      <pre className={classNames.codeBlock} style={codeBlockStyle}>{children}</pre>
     </div>
   );
 }

--- a/packages/renderers/web/src/CodeBlock.tsx
+++ b/packages/renderers/web/src/CodeBlock.tsx
@@ -39,6 +39,7 @@ const INLINE_BUTTON_STYLE: React.CSSProperties = {
   padding: '4px 8px',
   fontSize: 12,
   cursor: 'pointer',
+  userSelect: 'none',
 };
 
 /**
@@ -69,17 +70,32 @@ export function CodeBlock({ node, classNames, children }: CodeBlockProps): React
   // stay a plain <pre> without a "Copy" button.
   const showButton = copyButton !== false && Boolean(node.lang);
 
+  // Wait for the clipboard write to resolve before flipping the label: a
+  // rejected writeText (non-secure context, denied permission, locked-down
+  // iframe) or a rejected onCopyCode must leave "Copy" in place so the user
+  // does not see a fake success. The handler stays void (not async) to satisfy
+  // the onClick contract; the async IIFE carries its own catch so rejections
+  // never surface as unhandledrejection. Hosts that want to observe failures
+  // do so inside their own onCopyCode handler.
   const handleClick = (): void => {
-    if (onCopyCode) {
-      void onCopyCode(node.value, node);
-    } else if (typeof navigator !== 'undefined' && navigator.clipboard) {
-      void navigator.clipboard.writeText(node.value);
-    }
-    setCopied(true);
-    if (timerRef.current) {
-      clearTimeout(timerRef.current);
-    }
-    timerRef.current = setTimeout(() => setCopied(false), 1500);
+    void (async () => {
+      try {
+        if (onCopyCode) {
+          await onCopyCode(node.value, node);
+        } else if (typeof navigator !== 'undefined' && navigator.clipboard) {
+          await navigator.clipboard.writeText(node.value);
+        } else {
+          return;
+        }
+        setCopied(true);
+        if (timerRef.current) {
+          clearTimeout(timerRef.current);
+        }
+        timerRef.current = setTimeout(() => setCopied(false), 1500);
+      } catch {
+        // Clipboard write or host handler rejected: keep "Copy".
+      }
+    })();
   };
 
   // No button: render the pre as before (no wrapper div).
@@ -98,7 +114,7 @@ export function CodeBlock({ node, classNames, children }: CodeBlockProps): React
         className={classNames.codeButton}
         style={buttonStyle}
         onClick={handleClick}
-        aria-label="Copy code"
+        aria-label={copied ? 'Copied code' : 'Copy code'}
       >
         <span className={classNames.codeButtonText}>{copied ? 'Copied' : 'Copy'}</span>
       </button>

--- a/packages/renderers/web/src/CodeBlock.tsx
+++ b/packages/renderers/web/src/CodeBlock.tsx
@@ -71,7 +71,7 @@ export function CodeBlock({ node, classNames, children }: CodeBlockProps): React
 
   const handleClick = (): void => {
     if (onCopyCode) {
-      onCopyCode(node.value, node);
+      void onCopyCode(node.value, node);
     } else if (typeof navigator !== 'undefined' && navigator.clipboard) {
       void navigator.clipboard.writeText(node.value);
     }

--- a/packages/renderers/web/src/CodeBlock.tsx
+++ b/packages/renderers/web/src/CodeBlock.tsx
@@ -43,6 +43,7 @@ const INLINE_LANG_STYLE: React.CSSProperties = {
   fontSize: 12,
   color: 'rgba(0, 0, 0, 0.55)',
   fontFamily: 'monospace',
+  userSelect: 'none',
 };
 const INLINE_BUTTON_STYLE: React.CSSProperties = {
   backgroundColor: 'rgba(0, 0, 0, 0.5)',

--- a/packages/renderers/web/src/CodeBlock.tsx
+++ b/packages/renderers/web/src/CodeBlock.tsx
@@ -40,7 +40,6 @@ const INLINE_HEADER_STYLE: React.CSSProperties = {
   alignItems: 'center',
   justifyContent: 'space-between',
   padding: '4px 8px',
-  borderBottom: '1px solid rgba(0, 0, 0, 0.1)',
   userSelect: 'none',
 };
 const INLINE_LANG_STYLE: React.CSSProperties = {

--- a/packages/renderers/web/src/CodeBlock.tsx
+++ b/packages/renderers/web/src/CodeBlock.tsx
@@ -128,9 +128,10 @@ export function CodeBlock({ node, classNames, children }: CodeBlockProps): React
   const buttonStyle = classNames.codeButton ? undefined : INLINE_BUTTON_STYLE;
   const codeBlockStyle = classNames.codeBlock ? undefined : INLINE_CODEBLOCK_STYLE;
 
-  // No button: render the pre as before (no wrapper div).
+  // No button: render the pre as before (no wrapper div, no inline style) so
+  // conformance (copyButton false) measures the spec <pre><code> DOM.
   if (!showButton) {
-    return <pre className={classNames.codeBlock} style={codeBlockStyle}>{children}</pre>;
+    return <pre className={classNames.codeBlock}>{children}</pre>;
   }
 
   return (

--- a/packages/renderers/web/src/CodeBlock.tsx
+++ b/packages/renderers/web/src/CodeBlock.tsx
@@ -26,12 +26,25 @@ interface CodeBlockProps {
 
 // Inline fallback styles so the button works out of the box even when the host
 // uses the empty defaultClassNames. When the host supplies a className for the
-// button or container, the inline style is dropped so the className owns it.
+// header / lang / button / container, the inline style is dropped so the
+// className owns it. The button lives in a header row (lang left, button
+// right) instead of an absolute overlay, so it never covers a code line.
 const INLINE_CONTAINER_STYLE: React.CSSProperties = { position: 'relative' };
+const INLINE_HEADER_STYLE: React.CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  padding: '4px 8px',
+  backgroundColor: 'rgba(0, 0, 0, 0.08)',
+  borderBottom: '1px solid rgba(0, 0, 0, 0.1)',
+  userSelect: 'none',
+};
+const INLINE_LANG_STYLE: React.CSSProperties = {
+  fontSize: 12,
+  color: 'rgba(0, 0, 0, 0.55)',
+  fontFamily: 'monospace',
+};
 const INLINE_BUTTON_STYLE: React.CSSProperties = {
-  position: 'absolute',
-  top: 8,
-  right: 8,
   backgroundColor: 'rgba(0, 0, 0, 0.5)',
   color: '#ffffff',
   border: 'none',
@@ -43,7 +56,9 @@ const INLINE_BUTTON_STYLE: React.CSSProperties = {
 };
 
 /**
- * Renders the code-block shell with an optional top-right copy button.
+ * Renders the code-block shell with an optional header row carrying the
+ * language label (left) and a copy button (right), so the button never
+ * overlays a code line.
  *
  * Web defaults to `navigator.clipboard.writeText` (zero dependency); the host
  * can override the action via `onCopyCode`. Disable the button with
@@ -104,20 +119,27 @@ export function CodeBlock({ node, classNames, children }: CodeBlockProps): React
   }
 
   const containerStyle = classNames.codeBlockContainer ? undefined : INLINE_CONTAINER_STYLE;
+  const headerStyle = classNames.codeBlockHeader ? undefined : INLINE_HEADER_STYLE;
+  const langStyle = classNames.codeBlockLang ? undefined : INLINE_LANG_STYLE;
   const buttonStyle = classNames.codeButton ? undefined : INLINE_BUTTON_STYLE;
 
   return (
     <div className={classNames.codeBlockContainer} style={containerStyle}>
+      <div className={classNames.codeBlockHeader} style={headerStyle}>
+        <span className={classNames.codeBlockLang} style={langStyle}>
+          {node.lang}
+        </span>
+        <button
+          type="button"
+          className={classNames.codeButton}
+          style={buttonStyle}
+          onClick={handleClick}
+          aria-label={copied ? 'Copied code' : 'Copy code'}
+        >
+          <span className={classNames.codeButtonText}>{copied ? 'Copied' : 'Copy'}</span>
+        </button>
+      </div>
       <pre className={classNames.codeBlock}>{children}</pre>
-      <button
-        type="button"
-        className={classNames.codeButton}
-        style={buttonStyle}
-        onClick={handleClick}
-        aria-label={copied ? 'Copied code' : 'Copy code'}
-      >
-        <span className={classNames.codeButtonText}>{copied ? 'Copied' : 'Copy'}</span>
-      </button>
     </div>
   );
 }

--- a/packages/renderers/web/src/CodeBlock.tsx
+++ b/packages/renderers/web/src/CodeBlock.tsx
@@ -26,7 +26,7 @@ interface CodeBlockProps {
 
 // Inline fallback styles so the button works out of the box even when the host
 // uses the empty defaultClassNames. When the host supplies a className for the
-// header / lang / button / container, the inline style is dropped so the
+// container / header / lang / button / body, the inline style is dropped so
 // className owns it. The button lives in a header row (lang left, button
 // right) instead of an absolute overlay, so it never covers a code line.
 const INLINE_CONTAINER_STYLE: React.CSSProperties = {
@@ -48,7 +48,7 @@ const INLINE_LANG_STYLE: React.CSSProperties = {
   fontFamily: 'monospace',
   userSelect: 'none',
 };
-const INLINE_CODEBLOCK_STYLE: React.CSSProperties = {
+const INLINE_CODEBLOCK_BODY_STYLE: React.CSSProperties = {
   margin: 0,
   padding: 16,
   overflowX: 'auto',
@@ -126,7 +126,7 @@ export function CodeBlock({ node, classNames, children }: CodeBlockProps): React
   const headerStyle = classNames.codeBlockHeader ? undefined : INLINE_HEADER_STYLE;
   const langStyle = classNames.codeBlockLang ? undefined : INLINE_LANG_STYLE;
   const buttonStyle = classNames.codeButton ? undefined : INLINE_BUTTON_STYLE;
-  const codeBlockStyle = classNames.codeBlock ? undefined : INLINE_CODEBLOCK_STYLE;
+  const codeBlockBodyStyle = classNames.codeBlockBody ? undefined : INLINE_CODEBLOCK_BODY_STYLE;
 
   // No button: render the pre as before (no wrapper div, no inline style) so
   // conformance (copyButton false) measures the spec <pre><code> DOM.
@@ -150,7 +150,9 @@ export function CodeBlock({ node, classNames, children }: CodeBlockProps): React
           <span className={classNames.codeButtonText}>{copied ? 'Copied' : 'Copy'}</span>
         </button>
       </div>
-      <pre className={classNames.codeBlock} style={codeBlockStyle}>{children}</pre>
+      <pre className={classNames.codeBlockBody} style={codeBlockBodyStyle}>
+        {children}
+      </pre>
     </div>
   );
 }

--- a/packages/renderers/web/src/CodeBlock.tsx
+++ b/packages/renderers/web/src/CodeBlock.tsx
@@ -72,6 +72,10 @@ const INLINE_BUTTON_STYLE: React.CSSProperties = {
  * Web defaults to `navigator.clipboard.writeText` (zero dependency); the host
  * can override the action via `onCopyCode`. Disable the button with
  * `copyButton: false`.
+ *
+ * Mouse clicks do not focus the button (mousedown default is prevented) so
+ * Safari/Firefox do not draw a focus outline after copying; keyboard Tab
+ * focus still shows the browser focus ring.
  */
 export function CodeBlock({ node, classNames, children }: CodeBlockProps): React.ReactElement {
   const { onCopyCode, copyButton } = useContext(CodeCopyContext);
@@ -144,6 +148,7 @@ export function CodeBlock({ node, classNames, children }: CodeBlockProps): React
           type="button"
           className={classNames.codeButton}
           style={buttonStyle}
+          onMouseDown={(event) => event.preventDefault()}
           onClick={handleClick}
           aria-label={copied ? 'Copied code' : 'Copy code'}
         >

--- a/packages/renderers/web/src/CodeBlock.tsx
+++ b/packages/renderers/web/src/CodeBlock.tsx
@@ -29,8 +29,13 @@ interface CodeBlockProps {
 // container / header / lang / button / body, the inline style is dropped so
 // className owns it. The button lives in a header row (lang left, button
 // right) instead of an absolute overlay, so it never covers a code line.
+//
+// Colors go through CSS variables with the old values as fallbacks, so a host
+// can restyle the card (including a dark branch) from plain CSS without
+// fighting inline-style specificity:
+//   :root { --sm-code-bg: #2d2d2d; --sm-code-lang-color: rgba(255,255,255,0.6); }
 const INLINE_CONTAINER_STYLE: React.CSSProperties = {
-  backgroundColor: '#f5f5f5',
+  backgroundColor: 'var(--sm-code-bg, #f5f5f5)',
   borderRadius: 4,
   marginBottom: 16,
   overflow: 'hidden',
@@ -44,7 +49,7 @@ const INLINE_HEADER_STYLE: React.CSSProperties = {
 };
 const INLINE_LANG_STYLE: React.CSSProperties = {
   fontSize: 12,
-  color: 'rgba(0, 0, 0, 0.55)',
+  color: 'var(--sm-code-lang-color, rgba(0, 0, 0, 0.55))',
   fontFamily: 'monospace',
   userSelect: 'none',
 };
@@ -54,8 +59,8 @@ const INLINE_CODEBLOCK_BODY_STYLE: React.CSSProperties = {
   overflowX: 'auto',
 };
 const INLINE_BUTTON_STYLE: React.CSSProperties = {
-  backgroundColor: 'rgba(0, 0, 0, 0.5)',
-  color: '#ffffff',
+  backgroundColor: 'var(--sm-code-btn-bg, rgba(0, 0, 0, 0.5))',
+  color: 'var(--sm-code-btn-color, #ffffff)',
   border: 'none',
   borderRadius: 4,
   padding: '4px 8px',
@@ -65,13 +70,15 @@ const INLINE_BUTTON_STYLE: React.CSSProperties = {
 };
 
 /**
- * Renders the code-block shell with an optional header row carrying the
- * language label (left) and a copy button (right), so the button never
- * overlays a code line.
+ * Renders the code-block shell: a card around every code block, with a header
+ * row (language label left, copy button right) on fenced blocks that declare a
+ * language, so the button never overlays a code line and neighbouring blocks
+ * look alike whether or not they carry a language.
  *
  * Web defaults to `navigator.clipboard.writeText` (zero dependency); the host
- * can override the action via `onCopyCode`. Disable the button with
- * `copyButton: false`.
+ * can override the action via `onCopyCode`. `copyButton: false` opts out of
+ * the card entirely and renders the bare spec `<pre><code>` tree (the shape
+ * the conformance harness measures).
  *
  * Mouse clicks do not focus the button (mousedown default is prevented) so
  * Safari/Firefox do not draw a focus outline after copying; keyboard Tab
@@ -80,23 +87,50 @@ const INLINE_BUTTON_STYLE: React.CSSProperties = {
 export function CodeBlock({ node, classNames, children }: CodeBlockProps): React.ReactElement {
   const { onCopyCode, copyButton } = useContext(CodeCopyContext);
   const [copied, setCopied] = useState(false);
+  // Clipboard capability is detected post-mount so SSR and the first client
+  // render produce the same tree (hydration-safe); environments without
+  // navigator.clipboard (insecure context, older browser) and no onCopyCode
+  // then hide the button instead of leaving an inert one.
+  const [canCopy, setCanCopy] = useState(true);
+  // Prevent a copy Promise that settles after unmount from updating state or
+  // creating a feedback timer that no mounted block can consume.
+  const mountedRef = useRef(true);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  // Clear the "Copied" reset timer if the block unmounts mid-feedback.
   useEffect(() => {
+    // A partial Clipboard object without writeText is not actionable; checking
+    // the function avoids rendering an inert control in older/custom hosts.
+    setCanCopy(
+      Boolean(onCopyCode) ||
+        (typeof navigator !== 'undefined' && typeof navigator.clipboard?.writeText === 'function')
+    );
+  }, [onCopyCode]);
+
+  // Timer cleanup is mount-scoped: tying it to onCopyCode would cancel the
+  // pending label reset whenever a host replaces its callback reference.
+  useEffect(() => {
+    // StrictMode replays effect setup, so mark the live setup as mounted too.
+    mountedRef.current = true;
+    // Clear the "Copied" reset timer if the block unmounts mid-feedback.
     return () => {
+      mountedRef.current = false;
       if (timerRef.current) {
         clearTimeout(timerRef.current);
       }
     };
   }, []);
 
-  // Only fenced code blocks that declare a language (info string) get the
-  // button. The AST does not distinguish fenced from indented code (both are
-  // `type: 'code'`), so `node.lang` is the signal that the author marked a
-  // real code block; indented pre-formatted text and language-less fences
-  // stay a plain <pre> without a "Copy" button.
-  const showButton = copyButton !== false && Boolean(node.lang);
+  // copyButton !== false wraps every code block in the card, so a fence with a
+  // language and one without do not look unrelated in the same document. The
+  // header row (language label + copy button) still requires node.lang: the
+  // AST does not distinguish fenced from indented code (both are
+  // `type: 'code'`), so lang is the only signal that the author marked a real
+  // code block. Documented decision: language-less fences and indented code
+  // get the card but no header/button; giving them a button needs a `fenced`
+  // flag in the parser.
+  const showCard = copyButton !== false;
+  const showHeader = Boolean(node.lang);
+  const showButton = showHeader && canCopy;
 
   // Wait for the clipboard write to resolve before flipping the label: a
   // rejected writeText (non-secure context, denied permission, locked-down
@@ -110,9 +144,16 @@ export function CodeBlock({ node, classNames, children }: CodeBlockProps): React
       try {
         if (onCopyCode) {
           await onCopyCode(node.value, node);
-        } else if (typeof navigator !== 'undefined' && navigator.clipboard) {
+        } else if (
+          typeof navigator !== 'undefined' &&
+          typeof navigator.clipboard?.writeText === 'function'
+        ) {
           await navigator.clipboard.writeText(node.value);
         } else {
+          return;
+        }
+        // The clipboard may resolve after navigation removed this block.
+        if (!mountedRef.current) {
           return;
         }
         setCopied(true);
@@ -132,29 +173,33 @@ export function CodeBlock({ node, classNames, children }: CodeBlockProps): React
   const buttonStyle = classNames.codeButton ? undefined : INLINE_BUTTON_STYLE;
   const codeBlockBodyStyle = classNames.codeBlockBody ? undefined : INLINE_CODEBLOCK_BODY_STYLE;
 
-  // No button: render the pre as before (no wrapper div, no inline style) so
-  // conformance (copyButton false) measures the spec <pre><code> DOM.
-  if (!showButton) {
+  // copyButton: false renders the pre as before (no wrapper div, no inline
+  // style) so conformance measures the spec <pre><code> DOM.
+  if (!showCard) {
     return <pre className={classNames.codeBlock}>{children}</pre>;
   }
 
   return (
     <div className={classNames.codeBlockContainer} style={containerStyle}>
-      <div className={classNames.codeBlockHeader} style={headerStyle}>
-        <span className={classNames.codeBlockLang} style={langStyle}>
-          {node.lang}
-        </span>
-        <button
-          type="button"
-          className={classNames.codeButton}
-          style={buttonStyle}
-          onMouseDown={event => event.preventDefault()}
-          onClick={handleClick}
-          aria-label={copied ? 'Copied code' : 'Copy code'}
-        >
-          <span className={classNames.codeButtonText}>{copied ? 'Copied' : 'Copy'}</span>
-        </button>
-      </div>
+      {showHeader && (
+        <div className={classNames.codeBlockHeader} style={headerStyle}>
+          <span className={classNames.codeBlockLang} style={langStyle}>
+            {node.lang}
+          </span>
+          {showButton && (
+            <button
+              type="button"
+              className={classNames.codeButton}
+              style={buttonStyle}
+              onMouseDown={event => event.preventDefault()}
+              onClick={handleClick}
+              aria-label={copied ? 'Copied code' : 'Copy code'}
+            >
+              <span className={classNames.codeButtonText}>{copied ? 'Copied' : 'Copy'}</span>
+            </button>
+          )}
+        </div>
+      )}
       <pre className={classNames.codeBlockBody} style={codeBlockBodyStyle}>
         {children}
       </pre>

--- a/packages/renderers/web/src/CodeBlock.tsx
+++ b/packages/renderers/web/src/CodeBlock.tsx
@@ -148,7 +148,7 @@ export function CodeBlock({ node, classNames, children }: CodeBlockProps): React
           type="button"
           className={classNames.codeButton}
           style={buttonStyle}
-          onMouseDown={(event) => event.preventDefault()}
+          onMouseDown={event => event.preventDefault()}
           onClick={handleClick}
           aria-label={copied ? 'Copied code' : 'Copy code'}
         >

--- a/packages/renderers/web/src/Supramark.tsx
+++ b/packages/renderers/web/src/Supramark.tsx
@@ -8,6 +8,7 @@ import React, {
   useState,
   type ReactNode,
 } from 'react';
+import { CodeBlock, CodeCopyContext } from './CodeBlock.js';
 import type {
   SupramarkRootNode,
   SupramarkNode,
@@ -47,11 +48,7 @@ import { DiagramEngineContext } from './DiagramEngineProvider.js';
 import { ErrorBoundary, type ErrorInfo, ErrorDisplay } from './ErrorBoundary.js';
 import { MathBlockWeb, MathInlineWeb } from './MathBlockWeb.js';
 import { SourceStateContext } from './SourceStateContext.js';
-import {
-  getRendererCache,
-  resolveDiagramCachePolicy,
-  stableSerialize,
-} from './renderCache.js';
+import { getRendererCache, resolveDiagramCachePolicy, stableSerialize } from './renderCache.js';
 
 export interface ContainerRendererWeb {
   (args: {
@@ -79,6 +76,13 @@ export interface SupramarkWebProps {
   codeHighlighter?: SupramarkCodeHighlighter;
   codeHighlightTheme?: string;
   onRenderStateChange?: (state: SupramarkRenderState) => void;
+  /**
+   * Copy handler for fenced code blocks. When provided, the copy button
+   * calls it instead of the default `navigator.clipboard.writeText`.
+   */
+  onCopyCode?: (code: string, node: SupramarkCodeNode) => void | Promise<void>;
+  /** Whether to show the code-block copy button (default: true). */
+  copyButton?: boolean;
 }
 
 export interface SupramarkRenderState {
@@ -210,6 +214,8 @@ export const Supramark: React.FC<SupramarkWebProps> = ({
   codeHighlighter,
   codeHighlightTheme,
   onRenderStateChange,
+  onCopyCode,
+  copyButton,
 }) => {
   const diagramEngine = useContext(DiagramEngineContext) ?? defaultDiagramEngine;
   // Parsing, engine output, highlighting, and source state form one renderable source version.
@@ -345,7 +351,7 @@ export const Supramark: React.FC<SupramarkWebProps> = ({
   const footnoteStyle = isGfmFootnoteStyle(config);
   const footnoteMeta = useMemo(
     () => (footnoteStyle && parsedDocument ? buildFootnoteMeta(parsedDocument.root) : null),
-    [footnoteStyle, parsedDocument],
+    [footnoteStyle, parsedDocument]
   );
   // In GFM footnote-section mode, definitions are hoisted to a trailing
   // <section>; filter them out of the body so they don't also render in place
@@ -355,8 +361,8 @@ export const Supramark: React.FC<SupramarkWebProps> = ({
     () =>
       footnoteStyle && parsedDocument
         ? parsedDocument.root.children.filter(n => n.type !== 'footnote_definition')
-        : parsedDocument?.root.children ?? [],
-    [footnoteStyle, parsedDocument],
+        : (parsedDocument?.root.children ?? []),
+    [footnoteStyle, parsedDocument]
   );
 
   if (parseError) {
@@ -385,34 +391,36 @@ export const Supramark: React.FC<SupramarkWebProps> = ({
     >
       <SourceStateContext.Provider value={parsedDocument.sourceState}>
         <FootnoteMetaContext.Provider value={footnoteMeta}>
-          <div className={mergedClassNames.root}>
-            {mergeRawNodes(
-              bodyChildren,
-              (node, index) =>
-                renderNode(
-                  node,
-                  index,
-                  mergedClassNames,
-                  parsedDocument.rendered,
-                  parsedDocument.highlighted,
-                  config,
-                  mergedContainerRenderers,
-                ),
-              mergedClassNames,
-              config,
-              parsedDocument.highlighted
-            )}
-            {footnoteMeta && footnoteMeta.defs.length > 0 && (
-              <FootnoteSection
-                defs={footnoteMeta.defs}
-                classNames={mergedClassNames}
-                rendered={parsedDocument.rendered}
-                highlighted={parsedDocument.highlighted}
-                config={config}
-                containerRenderers={mergedContainerRenderers}
-              />
-            )}
-          </div>
+          <CodeCopyContext.Provider value={{ onCopyCode, copyButton }}>
+            <div className={mergedClassNames.root}>
+              {mergeRawNodes(
+                bodyChildren,
+                (node, index) =>
+                  renderNode(
+                    node,
+                    index,
+                    mergedClassNames,
+                    parsedDocument.rendered,
+                    parsedDocument.highlighted,
+                    config,
+                    mergedContainerRenderers
+                  ),
+                mergedClassNames,
+                config,
+                parsedDocument.highlighted
+              )}
+              {footnoteMeta && footnoteMeta.defs.length > 0 && (
+                <FootnoteSection
+                  defs={footnoteMeta.defs}
+                  classNames={mergedClassNames}
+                  rendered={parsedDocument.rendered}
+                  highlighted={parsedDocument.highlighted}
+                  config={config}
+                  containerRenderers={mergedContainerRenderers}
+                />
+              )}
+            </div>
+          </CodeCopyContext.Provider>
         </FootnoteMetaContext.Provider>
       </SourceStateContext.Provider>
     </ErrorBoundary>
@@ -449,10 +457,7 @@ function parseRawAttrs(attrPart: string): Record<string, string> {
 }
 
 function escapeHtmlText(value: string): string {
-  return value
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;');
+  return value.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
 }
 
 function escapeHtmlAttr(value: string): string {
@@ -494,8 +499,10 @@ function isTagfilterEnabled(config?: SupramarkConfig): boolean {
 // Replace the leading `<` of every disallowed tag (open or close,
 // case-insensitive) with `&lt;`; allowed tags and non-tag `<` pass through.
 function tagfilterEscape(html: string): string {
-  return html.replace(/<(\/?)([a-zA-Z][a-zA-Z0-9-]*)/g, (match: string, slash: string, name: string) =>
-    TAGFILTER_DISALLOWED_TAGS.has(name.toLowerCase()) ? `&lt;${slash}${name}` : match
+  return html.replace(
+    /<(\/?)([a-zA-Z][a-zA-Z0-9-]*)/g,
+    (match: string, slash: string, name: string) =>
+      TAGFILTER_DISALLOWED_TAGS.has(name.toLowerCase()) ? `&lt;${slash}${name}` : match
   );
 }
 
@@ -605,10 +612,7 @@ function buildFootnoteMeta(root: SupramarkRootNode): FootnoteMeta {
 
   for (const def of defsById.values()) {
     if (referenced.has(def.identifier)) {
-      def.occurrences = Array.from(
-        { length: occCount.get(def.identifier) ?? 0 },
-        (_, i) => i + 1,
-      );
+      def.occurrences = Array.from({ length: occCount.get(def.identifier) ?? 0 }, (_, i) => i + 1);
     }
   }
   const defs = [...defsById.values()]
@@ -636,13 +640,7 @@ function FootnoteRef({ node }: { node: SupramarkFootnoteReferenceNode }) {
   );
 }
 
-function FootnoteBackref({
-  def,
-  occurrence,
-}: {
-  def: FootnoteDefMeta;
-  occurrence: number;
-}) {
+function FootnoteBackref({ def, occurrence }: { def: FootnoteDefMeta; occurrence: number }) {
   const suffix = occurrence === 1 ? '' : `-${occurrence}`;
   const id = footnoteHrefEscape(def.identifier);
   const idx = occurrence === 1 ? `${def.index}` : `${def.index}-${occurrence}`;
@@ -654,8 +652,7 @@ function FootnoteBackref({
       data-footnote-backref-idx={idx}
       aria-label={`Back to reference ${idx}`}
     >
-      ↩
-      {occurrence > 1 && <sup className="footnote-ref">{occurrence}</sup>}
+      ↩{occurrence > 1 && <sup className="footnote-ref">{occurrence}</sup>}
     </a>
   );
 }
@@ -693,21 +690,11 @@ function FootnoteDefLi({
       const para = child as { type: 'paragraph'; children: SupramarkNode[] };
       return (
         <p key={index} className={classNames.paragraph}>
-          {renderInlineNodes(para.children, classNames, rendered, highlighted, config)}
-          {' '}
-          {backrefs}
+          {renderInlineNodes(para.children, classNames, rendered, highlighted, config)} {backrefs}
         </p>
       );
     }
-    return renderNode(
-      child,
-      index,
-      classNames,
-      rendered,
-      highlighted,
-      config,
-      containerRenderers,
-    );
+    return renderNode(child, index, classNames, rendered, highlighted, config, containerRenderers);
   });
   return (
     <li id={`fn-${footnoteHrefEscape(def.identifier)}`}>
@@ -932,7 +919,9 @@ function mergeRawNodes(
       if (inlineHtml !== null && unclosedInlineFormattingTags(inlineHtml).length > 0) {
         const following = children.slice(i + 1);
         const serializedFollowing =
-          following.length > 0 ? serializeBlocksToHtml(following, classNames, config, highlighted) : '';
+          following.length > 0
+            ? serializeBlocksToHtml(following, classNames, config, highlighted)
+            : '';
         if (serializedFollowing !== null) {
           const classAttr = classNames.paragraph
             ? ` class="${escapeHtmlAttr(classNames.paragraph)}"`
@@ -957,10 +946,7 @@ function mergeRawNodes(
         let closeIdx = -1;
         for (let j = i + 1; j < children.length; j++) {
           const sib = children[j];
-          if (
-            sib.type === 'raw' &&
-            rawCloseTagName(sib.value ?? '') === tagLower
-          ) {
+          if (sib.type === 'raw' && rawCloseTagName(sib.value ?? '') === tagLower) {
             closeIdx = j;
             break;
           }
@@ -974,8 +960,7 @@ function mergeRawNodes(
           // HTML relies on, and a React host element drops them.
           if (inner.some(hasBlockChild) && classNames) {
             const serialized = serializeBlocksToHtml(inner, classNames, config, highlighted);
-            const closeValue =
-              (children[closeIdx] as SupramarkRawNode).value ?? '';
+            const closeValue = (children[closeIdx] as SupramarkRawNode).value ?? '';
             if (serialized !== null) {
               result.push(
                 React.createElement(RawHtml, {
@@ -1009,16 +994,9 @@ function mergeRawNodes(
         // every following sibling serializes to static HTML.
         if (unclosedBlockContainerOpen(value, rawNode.block) && classNames) {
           const following = children.slice(i + 1);
-          const serialized = serializeBlocksToHtml(
-            following,
-            classNames,
-            config,
-            highlighted
-          );
+          const serialized = serializeBlocksToHtml(following, classNames, config, highlighted);
           if (serialized !== null) {
-            result.push(
-              React.createElement(RawHtml, { key: i, value: value + serialized })
-            );
+            result.push(React.createElement(RawHtml, { key: i, value: value + serialized }));
             i = children.length;
             continue;
           }
@@ -1062,8 +1040,7 @@ function renderListItemChildren(
   children.forEach((child, index) => {
     if (index > 0) {
       const prev = children[index - 1];
-      const bothInline =
-        INLINE_NODE_TYPES.has(prev.type) && INLINE_NODE_TYPES.has(child.type);
+      const bothInline = INLINE_NODE_TYPES.has(prev.type) && INLINE_NODE_TYPES.has(child.type);
       if (!bothInline) result.push('\n');
     }
     result.push(
@@ -1101,13 +1078,7 @@ function renderNode(
       }
       return (
         <p key={key} className={classNames.paragraph}>
-          {renderInlineNodes(
-            node.children,
-            classNames,
-            rendered,
-            highlighted,
-            config
-          )}
+          {renderInlineNodes(node.children, classNames, rendered, highlighted, config)}
         </p>
       );
     }
@@ -1166,7 +1137,15 @@ function renderNode(
           {mergeRawNodes(
             quote.children,
             (child, index) =>
-              renderNode(child, index, classNames, rendered, highlighted, config, containerRenderers),
+              renderNode(
+                child,
+                index,
+                classNames,
+                rendered,
+                highlighted,
+                config,
+                containerRenderers
+              ),
             classNames,
             config,
             highlighted
@@ -1178,7 +1157,11 @@ function renderNode(
       return <hr key={key} className={classNames.thematicBreak} />;
     case 'code': {
       const codeBlock = node;
-      return renderCodeBlock(codeBlock, key, classNames, highlighted);
+      return (
+        <CodeBlock key={key} node={codeBlock} classNames={classNames}>
+          {renderCodeContent(codeBlock, classNames, highlighted)}
+        </CodeBlock>
+      );
     }
     case 'math_block': {
       const mathBlock = node;
@@ -1204,8 +1187,7 @@ function renderNode(
         renderNode(item, index, classNames, rendered, highlighted, config, containerRenderers)
       );
       if (list.ordered) {
-        const start =
-          list.start !== undefined && list.start !== 1 ? list.start : undefined;
+        const start = list.start !== undefined && list.start !== 1 ? list.start : undefined;
         return (
           <ol key={key} className={classNames.listOrdered} start={start}>
             {items}
@@ -1234,8 +1216,7 @@ function renderNode(
             />
             {/* cmark-gfm html_render emits `<input ... /> ` with a trailing
               space before the item text; the parser consumes the separator
-              whitespace, so emit the literal space here to keep DOM parity. */}
-            {' '}
+              whitespace, so emit the literal space here to keep DOM parity. */}{' '}
             {renderListItemChildren(
               item.children,
               classNames,
@@ -1268,12 +1249,7 @@ function renderNode(
       }
 
       return (
-        <WebDiagramNode
-          key={key}
-          node={diagram}
-          classNames={classNames}
-          rendered={rendered}
-        />
+        <WebDiagramNode key={key} node={diagram} classNames={classNames} rendered={rendered} />
       );
     }
     case 'container': {
@@ -1558,7 +1534,7 @@ function renderNode(
       const table = node;
       const rows = table.children;
       let firstBodyRow = rows.findIndex(
-        (row) => !(row as { children?: Array<{ header?: boolean }> }).children?.[0]?.header
+        row => !(row as { children?: Array<{ header?: boolean }> }).children?.[0]?.header
       );
       if (firstBodyRow < 0) firstBodyRow = rows.length;
       const headRows = rows.slice(0, firstBodyRow);
@@ -1568,14 +1544,30 @@ function renderNode(
           {headRows.length > 0 && (
             <thead className={classNames.tableHead}>
               {headRows.map((row, index) =>
-                renderNode(row, index, classNames, rendered, highlighted, config, containerRenderers)
+                renderNode(
+                  row,
+                  index,
+                  classNames,
+                  rendered,
+                  highlighted,
+                  config,
+                  containerRenderers
+                )
               )}
             </thead>
           )}
           {bodyRows.length > 0 && (
             <tbody className={classNames.tableBody}>
               {bodyRows.map((row, index) =>
-                renderNode(row, index, classNames, rendered, highlighted, config, containerRenderers)
+                renderNode(
+                  row,
+                  index,
+                  classNames,
+                  rendered,
+                  highlighted,
+                  config,
+                  containerRenderers
+                )
               )}
             </tbody>
           )}
@@ -1658,9 +1650,7 @@ function renderNode(
       // Flatten once: if children is a single paragraph, spread its inline content
       // directly; otherwise render as block-level nodes (allows multi-paragraph footnotes).
       const soleParagraph =
-        def.children.length === 1 && def.children[0]?.type === 'paragraph'
-          ? def.children[0]
-          : null;
+        def.children.length === 1 && def.children[0]?.type === 'paragraph' ? def.children[0] : null;
       const body = soleParagraph
         ? renderInlineNodes(soleParagraph.children, classNames, rendered, highlighted, config)
         : def.children.map((child, index) =>
@@ -1715,9 +1705,8 @@ function renderNode(
   }
 }
 
-function renderCodeBlock(
+function renderCodeContent(
   codeBlock: SupramarkCodeNode,
-  key: number,
   classNames: SupramarkClassNames,
   highlighted: Map<string, SupramarkCodeHighlightResult>
 ): React.ReactNode {
@@ -1728,28 +1717,22 @@ function renderCodeBlock(
   const codeClassName = [classNames.code, languageClass].filter(Boolean).join(' ') || undefined;
 
   if (!highlight) {
-    return (
-      <pre key={key} className={classNames.codeBlock}>
-        <code className={codeClassName}>{codeBlock.value}</code>
-      </pre>
-    );
+    return <code className={codeClassName}>{codeBlock.value}</code>;
   }
 
   return (
-    <pre key={key} className={classNames.codeBlock}>
-      <code className={codeClassName} data-language={highlight.language ?? codeBlock.lang}>
-        {highlight.lines.map((line, lineIndex) => (
-          <React.Fragment key={lineIndex}>
-            {line.tokens.map((token, tokenIndex) => (
-              <span key={tokenIndex} style={codeTokenStyle(token)}>
-                {token.text}
-              </span>
-            ))}
-            {lineIndex < highlight.lines.length - 1 ? '\n' : null}
-          </React.Fragment>
-        ))}
-      </code>
-    </pre>
+    <code className={codeClassName} data-language={highlight.language ?? codeBlock.lang}>
+      {highlight.lines.map((line, lineIndex) => (
+        <React.Fragment key={lineIndex}>
+          {line.tokens.map((token, tokenIndex) => (
+            <span key={tokenIndex} style={codeTokenStyle(token)}>
+              {token.text}
+            </span>
+          ))}
+          {lineIndex < highlight.lines.length - 1 ? '\n' : null}
+        </React.Fragment>
+      ))}
+    </code>
   );
 }
 
@@ -1795,7 +1778,7 @@ function inlineNodesToHtml(
   config?: SupramarkConfig
 ): string | null {
   if (!isDangerousHtmlAllowed(config)) return null;
-  if (!nodes.some((n) => n.type === 'raw')) return null;
+  if (!nodes.some(n => n.type === 'raw')) return null;
   return serializeInlineList(nodes, classNames, config);
 }
 
@@ -1900,17 +1883,13 @@ function serializeBlockToHtml(
     case 'paragraph': {
       const inline = serializeInlineList(node.children, classNames, config);
       if (inline === null) return null;
-      const cls = classNames.paragraph
-        ? ` class="${escapeHtmlAttr(classNames.paragraph)}"`
-        : '';
+      const cls = classNames.paragraph ? ` class="${escapeHtmlAttr(classNames.paragraph)}"` : '';
       return `<p${cls}>${inline}</p>\n`;
     }
     case 'code': {
       const lang = node.lang ?? '';
       const languageClass = lang ? `language-${escapeHtmlAttr(lang)}` : '';
-      const codeClass = [classNames.code ?? '', languageClass]
-        .filter(Boolean)
-        .join(' ');
+      const codeClass = [classNames.code ?? '', languageClass].filter(Boolean).join(' ');
       const codeClassAttr = codeClass ? ` class="${escapeHtmlAttr(codeClass)}"` : '';
       const preClassAttr = classNames.codeBlock
         ? ` class="${escapeHtmlAttr(classNames.codeBlock)}"`
@@ -2003,10 +1982,7 @@ function codeTokenInlineCss(token: {
 // the value itself — e.g. `<div>\n*foo*\n` or `  <div>\n`. cmark leaves such a
 // container unclosed and the reference HTML relies on the final parser folding
 // following blocks into it. Used to absorb following siblings into one RawHtml.
-function unclosedBlockContainerOpen(
-  value: string,
-  isBlock: boolean | undefined
-): string | null {
+function unclosedBlockContainerOpen(value: string, isBlock: boolean | undefined): string | null {
   if (!isBlock) return null;
   const m = value.match(/^\s*<([a-zA-Z][\w-]*)\b/);
   if (!m) return null;
@@ -2028,8 +2004,20 @@ function unclosedBlockContainerOpen(
 // one RawHtml fragment so the browser's tree-construction reproduces cmark's
 // reconstruction in a single parse.
 const HTML_FORMATTING_TAGS = new Set([
-  'a', 'b', 'big', 'code', 'em', 'font', 'i', 'nobr', 's', 'small', 'strike',
-  'strong', 'tt', 'u',
+  'a',
+  'b',
+  'big',
+  'code',
+  'em',
+  'font',
+  'i',
+  'nobr',
+  's',
+  'small',
+  'strike',
+  'strong',
+  'tt',
+  'u',
 ]);
 function unclosedInlineFormattingTags(html: string): string[] {
   const counts: Record<string, number> = {};
@@ -2041,7 +2029,7 @@ function unclosedInlineFormattingTags(html: string): string[] {
     const closing = m[0].charCodeAt(1) === 47; // '</'
     counts[tag] = (counts[tag] ?? 0) + (closing ? -1 : 1);
   }
-  return Object.keys(counts).filter((t) => counts[t] > 0);
+  return Object.keys(counts).filter(t => counts[t] > 0);
 }
 
 function renderInlineNode(
@@ -2069,13 +2057,27 @@ function renderInlineNode(
       if (parentType === 'strong' && isFlattenNestedStrongEnabled(config)) {
         return (
           <React.Fragment key={key}>
-            {renderInlineNodes(strongNode.children, classNames, rendered, highlighted, config, 'strong')}
+            {renderInlineNodes(
+              strongNode.children,
+              classNames,
+              rendered,
+              highlighted,
+              config,
+              'strong'
+            )}
           </React.Fragment>
         );
       }
       return (
         <strong key={key} className={classNames.strong}>
-          {renderInlineNodes(strongNode.children, classNames, rendered, highlighted, config, 'strong')}
+          {renderInlineNodes(
+            strongNode.children,
+            classNames,
+            rendered,
+            highlighted,
+            config,
+            'strong'
+          )}
         </strong>
       );
     }
@@ -2083,7 +2085,14 @@ function renderInlineNode(
       const emphasisNode = node;
       return (
         <em key={key} className={classNames.emphasis}>
-          {renderInlineNodes(emphasisNode.children, classNames, rendered, highlighted, config, 'emphasis')}
+          {renderInlineNodes(
+            emphasisNode.children,
+            classNames,
+            rendered,
+            highlighted,
+            config,
+            'emphasis'
+          )}
         </em>
       );
     }
@@ -2135,17 +2144,32 @@ function renderInlineNode(
       // so emit it explicitly to match the expected DOM.
       return (
         <React.Fragment key={key}>
-          <br />{'\n'}
+          <br />
+          {'\n'}
         </React.Fragment>
       );
     case 'delete': {
       const deleteNode = node;
       if (!isFeatureGroupEnabled(config, ['@supramark/feature-gfm'])) {
-        return renderInlineNodes(deleteNode.children, classNames, rendered, highlighted, config, 'delete');
+        return renderInlineNodes(
+          deleteNode.children,
+          classNames,
+          rendered,
+          highlighted,
+          config,
+          'delete'
+        );
       }
       return (
         <del key={key} className={classNames.delete}>
-          {renderInlineNodes(deleteNode.children, classNames, rendered, highlighted, config, 'delete')}
+          {renderInlineNodes(
+            deleteNode.children,
+            classNames,
+            rendered,
+            highlighted,
+            config,
+            'delete'
+          )}
         </del>
       );
     }

--- a/packages/renderers/web/src/Supramark.tsx
+++ b/packages/renderers/web/src/Supramark.tsx
@@ -8,7 +8,6 @@ import React, {
   useState,
   type ReactNode,
 } from 'react';
-import { CodeBlock, CodeCopyContext } from './CodeBlock.js';
 import type {
   SupramarkRootNode,
   SupramarkNode,
@@ -48,7 +47,12 @@ import { DiagramEngineContext } from './DiagramEngineProvider.js';
 import { ErrorBoundary, type ErrorInfo, ErrorDisplay } from './ErrorBoundary.js';
 import { MathBlockWeb, MathInlineWeb } from './MathBlockWeb.js';
 import { SourceStateContext } from './SourceStateContext.js';
-import { getRendererCache, resolveDiagramCachePolicy, stableSerialize } from './renderCache.js';
+import { CodeBlock, CodeCopyContext } from './CodeBlock.js';
+import {
+  getRendererCache,
+  resolveDiagramCachePolicy,
+  stableSerialize,
+} from './renderCache.js';
 
 export interface ContainerRendererWeb {
   (args: {
@@ -77,11 +81,16 @@ export interface SupramarkWebProps {
   codeHighlightTheme?: string;
   onRenderStateChange?: (state: SupramarkRenderState) => void;
   /**
-   * Copy handler for fenced code blocks. When provided, the copy button
-   * calls it instead of the default `navigator.clipboard.writeText`.
+   * Copy handler for code blocks with a language info string. When provided,
+   * the copy button calls it instead of `navigator.clipboard.writeText`.
+   * Language-less fences and indented code have no distinct AST flag, so they
+   * render the code card without a copy button.
    */
   onCopyCode?: (code: string, node: SupramarkCodeNode) => void | Promise<void>;
-  /** Whether to show the code-block copy button (default: true). */
+  /**
+   * Whether to show code-block copy chrome (default: true). False restores
+   * the standalone pre.
+   */
   copyButton?: boolean;
 }
 
@@ -351,7 +360,7 @@ export const Supramark: React.FC<SupramarkWebProps> = ({
   const footnoteStyle = isGfmFootnoteStyle(config);
   const footnoteMeta = useMemo(
     () => (footnoteStyle && parsedDocument ? buildFootnoteMeta(parsedDocument.root) : null),
-    [footnoteStyle, parsedDocument]
+    [footnoteStyle, parsedDocument],
   );
   // In GFM footnote-section mode, definitions are hoisted to a trailing
   // <section>; filter them out of the body so they don't also render in place
@@ -361,8 +370,14 @@ export const Supramark: React.FC<SupramarkWebProps> = ({
     () =>
       footnoteStyle && parsedDocument
         ? parsedDocument.root.children.filter(n => n.type !== 'footnote_definition')
-        : (parsedDocument?.root.children ?? []),
-    [footnoteStyle, parsedDocument]
+        : parsedDocument?.root.children ?? [],
+    [footnoteStyle, parsedDocument],
+  );
+
+  // Keep the provider identity stable for memoized code-block consumers.
+  const codeCopyContextValue = useMemo(
+    () => ({ onCopyCode, copyButton }),
+    [onCopyCode, copyButton],
   );
 
   if (parseError) {
@@ -391,7 +406,7 @@ export const Supramark: React.FC<SupramarkWebProps> = ({
     >
       <SourceStateContext.Provider value={parsedDocument.sourceState}>
         <FootnoteMetaContext.Provider value={footnoteMeta}>
-          <CodeCopyContext.Provider value={{ onCopyCode, copyButton }}>
+          <CodeCopyContext.Provider value={codeCopyContextValue}>
             <div className={mergedClassNames.root}>
               {mergeRawNodes(
                 bodyChildren,
@@ -403,7 +418,7 @@ export const Supramark: React.FC<SupramarkWebProps> = ({
                     parsedDocument.rendered,
                     parsedDocument.highlighted,
                     config,
-                    mergedContainerRenderers
+                    mergedContainerRenderers,
                   ),
                 mergedClassNames,
                 config,
@@ -457,7 +472,10 @@ function parseRawAttrs(attrPart: string): Record<string, string> {
 }
 
 function escapeHtmlText(value: string): string {
-  return value.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
 }
 
 function escapeHtmlAttr(value: string): string {
@@ -499,10 +517,8 @@ function isTagfilterEnabled(config?: SupramarkConfig): boolean {
 // Replace the leading `<` of every disallowed tag (open or close,
 // case-insensitive) with `&lt;`; allowed tags and non-tag `<` pass through.
 function tagfilterEscape(html: string): string {
-  return html.replace(
-    /<(\/?)([a-zA-Z][a-zA-Z0-9-]*)/g,
-    (match: string, slash: string, name: string) =>
-      TAGFILTER_DISALLOWED_TAGS.has(name.toLowerCase()) ? `&lt;${slash}${name}` : match
+  return html.replace(/<(\/?)([a-zA-Z][a-zA-Z0-9-]*)/g, (match: string, slash: string, name: string) =>
+    TAGFILTER_DISALLOWED_TAGS.has(name.toLowerCase()) ? `&lt;${slash}${name}` : match
   );
 }
 
@@ -612,7 +628,10 @@ function buildFootnoteMeta(root: SupramarkRootNode): FootnoteMeta {
 
   for (const def of defsById.values()) {
     if (referenced.has(def.identifier)) {
-      def.occurrences = Array.from({ length: occCount.get(def.identifier) ?? 0 }, (_, i) => i + 1);
+      def.occurrences = Array.from(
+        { length: occCount.get(def.identifier) ?? 0 },
+        (_, i) => i + 1,
+      );
     }
   }
   const defs = [...defsById.values()]
@@ -640,7 +659,13 @@ function FootnoteRef({ node }: { node: SupramarkFootnoteReferenceNode }) {
   );
 }
 
-function FootnoteBackref({ def, occurrence }: { def: FootnoteDefMeta; occurrence: number }) {
+function FootnoteBackref({
+  def,
+  occurrence,
+}: {
+  def: FootnoteDefMeta;
+  occurrence: number;
+}) {
   const suffix = occurrence === 1 ? '' : `-${occurrence}`;
   const id = footnoteHrefEscape(def.identifier);
   const idx = occurrence === 1 ? `${def.index}` : `${def.index}-${occurrence}`;
@@ -652,7 +677,8 @@ function FootnoteBackref({ def, occurrence }: { def: FootnoteDefMeta; occurrence
       data-footnote-backref-idx={idx}
       aria-label={`Back to reference ${idx}`}
     >
-      ↩{occurrence > 1 && <sup className="footnote-ref">{occurrence}</sup>}
+      ↩
+      {occurrence > 1 && <sup className="footnote-ref">{occurrence}</sup>}
     </a>
   );
 }
@@ -690,11 +716,21 @@ function FootnoteDefLi({
       const para = child as { type: 'paragraph'; children: SupramarkNode[] };
       return (
         <p key={index} className={classNames.paragraph}>
-          {renderInlineNodes(para.children, classNames, rendered, highlighted, config)} {backrefs}
+          {renderInlineNodes(para.children, classNames, rendered, highlighted, config)}
+          {' '}
+          {backrefs}
         </p>
       );
     }
-    return renderNode(child, index, classNames, rendered, highlighted, config, containerRenderers);
+    return renderNode(
+      child,
+      index,
+      classNames,
+      rendered,
+      highlighted,
+      config,
+      containerRenderers,
+    );
   });
   return (
     <li id={`fn-${footnoteHrefEscape(def.identifier)}`}>
@@ -919,9 +955,7 @@ function mergeRawNodes(
       if (inlineHtml !== null && unclosedInlineFormattingTags(inlineHtml).length > 0) {
         const following = children.slice(i + 1);
         const serializedFollowing =
-          following.length > 0
-            ? serializeBlocksToHtml(following, classNames, config, highlighted)
-            : '';
+          following.length > 0 ? serializeBlocksToHtml(following, classNames, config, highlighted) : '';
         if (serializedFollowing !== null) {
           const classAttr = classNames.paragraph
             ? ` class="${escapeHtmlAttr(classNames.paragraph)}"`
@@ -946,7 +980,10 @@ function mergeRawNodes(
         let closeIdx = -1;
         for (let j = i + 1; j < children.length; j++) {
           const sib = children[j];
-          if (sib.type === 'raw' && rawCloseTagName(sib.value ?? '') === tagLower) {
+          if (
+            sib.type === 'raw' &&
+            rawCloseTagName(sib.value ?? '') === tagLower
+          ) {
             closeIdx = j;
             break;
           }
@@ -960,7 +997,8 @@ function mergeRawNodes(
           // HTML relies on, and a React host element drops them.
           if (inner.some(hasBlockChild) && classNames) {
             const serialized = serializeBlocksToHtml(inner, classNames, config, highlighted);
-            const closeValue = (children[closeIdx] as SupramarkRawNode).value ?? '';
+            const closeValue =
+              (children[closeIdx] as SupramarkRawNode).value ?? '';
             if (serialized !== null) {
               result.push(
                 React.createElement(RawHtml, {
@@ -994,9 +1032,16 @@ function mergeRawNodes(
         // every following sibling serializes to static HTML.
         if (unclosedBlockContainerOpen(value, rawNode.block) && classNames) {
           const following = children.slice(i + 1);
-          const serialized = serializeBlocksToHtml(following, classNames, config, highlighted);
+          const serialized = serializeBlocksToHtml(
+            following,
+            classNames,
+            config,
+            highlighted
+          );
           if (serialized !== null) {
-            result.push(React.createElement(RawHtml, { key: i, value: value + serialized }));
+            result.push(
+              React.createElement(RawHtml, { key: i, value: value + serialized })
+            );
             i = children.length;
             continue;
           }
@@ -1040,7 +1085,8 @@ function renderListItemChildren(
   children.forEach((child, index) => {
     if (index > 0) {
       const prev = children[index - 1];
-      const bothInline = INLINE_NODE_TYPES.has(prev.type) && INLINE_NODE_TYPES.has(child.type);
+      const bothInline =
+        INLINE_NODE_TYPES.has(prev.type) && INLINE_NODE_TYPES.has(child.type);
       if (!bothInline) result.push('\n');
     }
     result.push(
@@ -1078,7 +1124,13 @@ function renderNode(
       }
       return (
         <p key={key} className={classNames.paragraph}>
-          {renderInlineNodes(node.children, classNames, rendered, highlighted, config)}
+          {renderInlineNodes(
+            node.children,
+            classNames,
+            rendered,
+            highlighted,
+            config
+          )}
         </p>
       );
     }
@@ -1137,15 +1189,7 @@ function renderNode(
           {mergeRawNodes(
             quote.children,
             (child, index) =>
-              renderNode(
-                child,
-                index,
-                classNames,
-                rendered,
-                highlighted,
-                config,
-                containerRenderers
-              ),
+              renderNode(child, index, classNames, rendered, highlighted, config, containerRenderers),
             classNames,
             config,
             highlighted
@@ -1187,7 +1231,8 @@ function renderNode(
         renderNode(item, index, classNames, rendered, highlighted, config, containerRenderers)
       );
       if (list.ordered) {
-        const start = list.start !== undefined && list.start !== 1 ? list.start : undefined;
+        const start =
+          list.start !== undefined && list.start !== 1 ? list.start : undefined;
         return (
           <ol key={key} className={classNames.listOrdered} start={start}>
             {items}
@@ -1216,7 +1261,8 @@ function renderNode(
             />
             {/* cmark-gfm html_render emits `<input ... /> ` with a trailing
               space before the item text; the parser consumes the separator
-              whitespace, so emit the literal space here to keep DOM parity. */}{' '}
+              whitespace, so emit the literal space here to keep DOM parity. */}
+            {' '}
             {renderListItemChildren(
               item.children,
               classNames,
@@ -1249,7 +1295,12 @@ function renderNode(
       }
 
       return (
-        <WebDiagramNode key={key} node={diagram} classNames={classNames} rendered={rendered} />
+        <WebDiagramNode
+          key={key}
+          node={diagram}
+          classNames={classNames}
+          rendered={rendered}
+        />
       );
     }
     case 'container': {
@@ -1534,7 +1585,7 @@ function renderNode(
       const table = node;
       const rows = table.children;
       let firstBodyRow = rows.findIndex(
-        row => !(row as { children?: Array<{ header?: boolean }> }).children?.[0]?.header
+        (row) => !(row as { children?: Array<{ header?: boolean }> }).children?.[0]?.header
       );
       if (firstBodyRow < 0) firstBodyRow = rows.length;
       const headRows = rows.slice(0, firstBodyRow);
@@ -1544,30 +1595,14 @@ function renderNode(
           {headRows.length > 0 && (
             <thead className={classNames.tableHead}>
               {headRows.map((row, index) =>
-                renderNode(
-                  row,
-                  index,
-                  classNames,
-                  rendered,
-                  highlighted,
-                  config,
-                  containerRenderers
-                )
+                renderNode(row, index, classNames, rendered, highlighted, config, containerRenderers)
               )}
             </thead>
           )}
           {bodyRows.length > 0 && (
             <tbody className={classNames.tableBody}>
               {bodyRows.map((row, index) =>
-                renderNode(
-                  row,
-                  index,
-                  classNames,
-                  rendered,
-                  highlighted,
-                  config,
-                  containerRenderers
-                )
+                renderNode(row, index, classNames, rendered, highlighted, config, containerRenderers)
               )}
             </tbody>
           )}
@@ -1650,7 +1685,9 @@ function renderNode(
       // Flatten once: if children is a single paragraph, spread its inline content
       // directly; otherwise render as block-level nodes (allows multi-paragraph footnotes).
       const soleParagraph =
-        def.children.length === 1 && def.children[0]?.type === 'paragraph' ? def.children[0] : null;
+        def.children.length === 1 && def.children[0]?.type === 'paragraph'
+          ? def.children[0]
+          : null;
       const body = soleParagraph
         ? renderInlineNodes(soleParagraph.children, classNames, rendered, highlighted, config)
         : def.children.map((child, index) =>
@@ -1778,7 +1815,7 @@ function inlineNodesToHtml(
   config?: SupramarkConfig
 ): string | null {
   if (!isDangerousHtmlAllowed(config)) return null;
-  if (!nodes.some(n => n.type === 'raw')) return null;
+  if (!nodes.some((n) => n.type === 'raw')) return null;
   return serializeInlineList(nodes, classNames, config);
 }
 
@@ -1883,21 +1920,25 @@ function serializeBlockToHtml(
     case 'paragraph': {
       const inline = serializeInlineList(node.children, classNames, config);
       if (inline === null) return null;
-      const cls = classNames.paragraph ? ` class="${escapeHtmlAttr(classNames.paragraph)}"` : '';
+      const cls = classNames.paragraph
+        ? ` class="${escapeHtmlAttr(classNames.paragraph)}"`
+        : '';
       return `<p${cls}>${inline}</p>\n`;
     }
     case 'code': {
       const lang = node.lang ?? '';
       const languageClass = lang ? `language-${escapeHtmlAttr(lang)}` : '';
-      const codeClass = [classNames.code ?? '', languageClass].filter(Boolean).join(' ');
+      const codeClass = [classNames.code ?? '', languageClass]
+        .filter(Boolean)
+        .join(' ');
       const codeClassAttr = codeClass ? ` class="${escapeHtmlAttr(codeClass)}"` : '';
       const preClassAttr = classNames.codeBlock
         ? ` class="${escapeHtmlAttr(classNames.codeBlock)}"`
         : '';
       // When this code block was folded into a RawHtml fragment (cross-block
-      // active-formatting reconstruction), the normal React renderCodeBlock
+      // active-formatting reconstruction), the normal React renderCodeContent
       // path is bypassed — so emit the highlighted spans here too, mirroring
-      // renderCodeBlock's token structure, otherwise the fold silently drops
+      // renderCodeContent's token structure, otherwise the fold silently drops
       // syntax highlighting for any code block following an unclosed-inline
       // paragraph.
       const inner = serializeCodeInner(node, highlighted);
@@ -1937,7 +1978,7 @@ function serializeBlocksToHtml(
 }
 
 // Emits the inner HTML for a fenced code block when it is serialized into a
-// RawHtml fragment. Mirrors renderCodeBlock: highlighted spans when a result
+// RawHtml fragment. Mirrors renderCodeContent: highlighted spans when a result
 // exists for this block's key, otherwise the plain escaped source.
 function serializeCodeInner(
   codeBlock: SupramarkCodeNode,
@@ -1982,7 +2023,10 @@ function codeTokenInlineCss(token: {
 // the value itself — e.g. `<div>\n*foo*\n` or `  <div>\n`. cmark leaves such a
 // container unclosed and the reference HTML relies on the final parser folding
 // following blocks into it. Used to absorb following siblings into one RawHtml.
-function unclosedBlockContainerOpen(value: string, isBlock: boolean | undefined): string | null {
+function unclosedBlockContainerOpen(
+  value: string,
+  isBlock: boolean | undefined
+): string | null {
   if (!isBlock) return null;
   const m = value.match(/^\s*<([a-zA-Z][\w-]*)\b/);
   if (!m) return null;
@@ -2004,20 +2048,8 @@ function unclosedBlockContainerOpen(value: string, isBlock: boolean | undefined)
 // one RawHtml fragment so the browser's tree-construction reproduces cmark's
 // reconstruction in a single parse.
 const HTML_FORMATTING_TAGS = new Set([
-  'a',
-  'b',
-  'big',
-  'code',
-  'em',
-  'font',
-  'i',
-  'nobr',
-  's',
-  'small',
-  'strike',
-  'strong',
-  'tt',
-  'u',
+  'a', 'b', 'big', 'code', 'em', 'font', 'i', 'nobr', 's', 'small', 'strike',
+  'strong', 'tt', 'u',
 ]);
 function unclosedInlineFormattingTags(html: string): string[] {
   const counts: Record<string, number> = {};
@@ -2029,7 +2061,7 @@ function unclosedInlineFormattingTags(html: string): string[] {
     const closing = m[0].charCodeAt(1) === 47; // '</'
     counts[tag] = (counts[tag] ?? 0) + (closing ? -1 : 1);
   }
-  return Object.keys(counts).filter(t => counts[t] > 0);
+  return Object.keys(counts).filter((t) => counts[t] > 0);
 }
 
 function renderInlineNode(
@@ -2057,27 +2089,13 @@ function renderInlineNode(
       if (parentType === 'strong' && isFlattenNestedStrongEnabled(config)) {
         return (
           <React.Fragment key={key}>
-            {renderInlineNodes(
-              strongNode.children,
-              classNames,
-              rendered,
-              highlighted,
-              config,
-              'strong'
-            )}
+            {renderInlineNodes(strongNode.children, classNames, rendered, highlighted, config, 'strong')}
           </React.Fragment>
         );
       }
       return (
         <strong key={key} className={classNames.strong}>
-          {renderInlineNodes(
-            strongNode.children,
-            classNames,
-            rendered,
-            highlighted,
-            config,
-            'strong'
-          )}
+          {renderInlineNodes(strongNode.children, classNames, rendered, highlighted, config, 'strong')}
         </strong>
       );
     }
@@ -2085,14 +2103,7 @@ function renderInlineNode(
       const emphasisNode = node;
       return (
         <em key={key} className={classNames.emphasis}>
-          {renderInlineNodes(
-            emphasisNode.children,
-            classNames,
-            rendered,
-            highlighted,
-            config,
-            'emphasis'
-          )}
+          {renderInlineNodes(emphasisNode.children, classNames, rendered, highlighted, config, 'emphasis')}
         </em>
       );
     }
@@ -2144,32 +2155,17 @@ function renderInlineNode(
       // so emit it explicitly to match the expected DOM.
       return (
         <React.Fragment key={key}>
-          <br />
-          {'\n'}
+          <br />{'\n'}
         </React.Fragment>
       );
     case 'delete': {
       const deleteNode = node;
       if (!isFeatureGroupEnabled(config, ['@supramark/feature-gfm'])) {
-        return renderInlineNodes(
-          deleteNode.children,
-          classNames,
-          rendered,
-          highlighted,
-          config,
-          'delete'
-        );
+        return renderInlineNodes(deleteNode.children, classNames, rendered, highlighted, config, 'delete');
       }
       return (
         <del key={key} className={classNames.delete}>
-          {renderInlineNodes(
-            deleteNode.children,
-            classNames,
-            rendered,
-            highlighted,
-            config,
-            'delete'
-          )}
+          {renderInlineNodes(deleteNode.children, classNames, rendered, highlighted, config, 'delete')}
         </del>
       );
     }

--- a/packages/renderers/web/src/classNames.ts
+++ b/packages/renderers/web/src/classNames.ts
@@ -108,7 +108,7 @@ export const tailwindClassNames: SupramarkClassNames = {
   codeBlockContainer: 'rounded-md mb-4 overflow-hidden',
   codeBlockHeader:
     'flex items-center justify-between px-2 py-1 bg-gray-200 dark:bg-gray-700 select-none',
-  codeBlockLang: 'text-xs text-gray-600 dark:text-gray-300 font-mono',
+  codeBlockLang: 'text-xs text-gray-600 dark:text-gray-300 font-mono select-none',
   codeButton:
     'bg-gray-700 dark:bg-gray-600 text-white text-xs rounded px-2 py-1 hover:bg-gray-600 dark:hover:bg-gray-500 select-none',
   codeButtonText: '',

--- a/packages/renderers/web/src/classNames.ts
+++ b/packages/renderers/web/src/classNames.ts
@@ -103,7 +103,7 @@ export const tailwindClassNames: SupramarkClassNames = {
   code: 'font-mono text-sm',
   codeBlockContainer: 'relative',
   codeButton:
-    'absolute top-2 right-2 bg-gray-700 dark:bg-gray-600 text-white text-xs rounded px-2 py-1 hover:bg-gray-600 dark:hover:bg-gray-500',
+    'absolute top-2 right-2 bg-gray-700 dark:bg-gray-600 text-white text-xs rounded px-2 py-1 hover:bg-gray-600 dark:hover:bg-gray-500 select-none',
   codeButtonText: '',
   listOrdered: 'list-decimal ml-6 mb-4',
   listUnordered: 'list-disc ml-6 mb-4',

--- a/packages/renderers/web/src/classNames.ts
+++ b/packages/renderers/web/src/classNames.ts
@@ -23,6 +23,12 @@ export interface SupramarkClassNames {
   // Code blocks
   codeBlock?: string; // pre element
   code?: string; // code element
+  /** Relative wrapper around a code block and its copy button. */
+  codeBlockContainer?: string;
+  /** Copy button overlay on a code block. */
+  codeButton?: string;
+  /** Label text inside the copy button. */
+  codeButtonText?: string;
 
   // Lists
   listOrdered?: string; // ol element
@@ -95,6 +101,10 @@ export const tailwindClassNames: SupramarkClassNames = {
   thematicBreak: 'border-t border-gray-300 dark:border-gray-700 my-4',
   codeBlock: 'bg-gray-100 dark:bg-gray-800 rounded-md p-4 mb-4 overflow-x-auto',
   code: 'font-mono text-sm',
+  codeBlockContainer: 'relative',
+  codeButton:
+    'absolute top-2 right-2 bg-gray-700 dark:bg-gray-600 text-white text-xs rounded px-2 py-1 hover:bg-gray-600 dark:hover:bg-gray-500',
+  codeButtonText: '',
   listOrdered: 'list-decimal ml-6 mb-4',
   listUnordered: 'list-disc ml-6 mb-4',
   listItem: 'mb-1',
@@ -134,6 +144,9 @@ export const minimalClassNames: SupramarkClassNames = {
   thematicBreak: 'sm-hr',
   codeBlock: 'sm-code-block',
   code: 'sm-code',
+  codeBlockContainer: 'sm-code-block-container',
+  codeButton: 'sm-code-btn',
+  codeButtonText: 'sm-code-btn-text',
   listOrdered: 'sm-ol',
   listUnordered: 'sm-ul',
   listItem: 'sm-li',

--- a/packages/renderers/web/src/classNames.ts
+++ b/packages/renderers/web/src/classNames.ts
@@ -23,9 +23,13 @@ export interface SupramarkClassNames {
   // Code blocks
   codeBlock?: string; // pre element
   code?: string; // code element
-  /** Relative wrapper around a code block and its copy button. */
+  /** Wrapper around a code block header (lang + button) and the pre. */
   codeBlockContainer?: string;
-  /** Copy button overlay on a code block. */
+  /** Header row: language label on the left, copy button on the right. */
+  codeBlockHeader?: string;
+  /** Language label in the header (the fenced info string). */
+  codeBlockLang?: string;
+  /** Copy button in the header. */
   codeButton?: string;
   /** Label text inside the copy button. */
   codeButtonText?: string;
@@ -101,9 +105,12 @@ export const tailwindClassNames: SupramarkClassNames = {
   thematicBreak: 'border-t border-gray-300 dark:border-gray-700 my-4',
   codeBlock: 'bg-gray-100 dark:bg-gray-800 rounded-md p-4 mb-4 overflow-x-auto',
   code: 'font-mono text-sm',
-  codeBlockContainer: 'relative',
+  codeBlockContainer: 'rounded-md mb-4 overflow-hidden',
+  codeBlockHeader:
+    'flex items-center justify-between px-2 py-1 bg-gray-200 dark:bg-gray-700 select-none',
+  codeBlockLang: 'text-xs text-gray-600 dark:text-gray-300 font-mono',
   codeButton:
-    'absolute top-2 right-2 bg-gray-700 dark:bg-gray-600 text-white text-xs rounded px-2 py-1 hover:bg-gray-600 dark:hover:bg-gray-500 select-none',
+    'bg-gray-700 dark:bg-gray-600 text-white text-xs rounded px-2 py-1 hover:bg-gray-600 dark:hover:bg-gray-500 select-none',
   codeButtonText: '',
   listOrdered: 'list-decimal ml-6 mb-4',
   listUnordered: 'list-disc ml-6 mb-4',
@@ -145,6 +152,8 @@ export const minimalClassNames: SupramarkClassNames = {
   codeBlock: 'sm-code-block',
   code: 'sm-code',
   codeBlockContainer: 'sm-code-block-container',
+  codeBlockHeader: 'sm-code-block-header',
+  codeBlockLang: 'sm-code-block-lang',
   codeButton: 'sm-code-btn',
   codeButtonText: 'sm-code-btn-text',
   listOrdered: 'sm-ol',

--- a/packages/renderers/web/src/classNames.ts
+++ b/packages/renderers/web/src/classNames.ts
@@ -103,11 +103,10 @@ export const tailwindClassNames: SupramarkClassNames = {
   h6: 'text-base font-medium mb-2 mt-2',
   blockquote: 'border-l-4 border-gray-300 dark:border-gray-600 pl-4 mb-4',
   thematicBreak: 'border-t border-gray-300 dark:border-gray-700 my-4',
-  codeBlock: 'p-4 overflow-x-auto',
+  codeBlock: 'm-0 p-4 overflow-x-auto',
   code: 'font-mono text-sm',
   codeBlockContainer: 'bg-gray-100 dark:bg-gray-800 rounded-md mb-4 overflow-hidden',
-  codeBlockHeader:
-    'flex items-center justify-between px-2 py-1 border-b border-gray-300 dark:border-gray-700 select-none',
+  codeBlockHeader: 'flex items-center justify-between px-2 py-1 select-none',
   codeBlockLang: 'text-xs text-gray-600 dark:text-gray-300 font-mono select-none',
   codeButton:
     'bg-gray-700 dark:bg-gray-600 text-white text-xs rounded px-2 py-1 hover:bg-gray-600 dark:hover:bg-gray-500 select-none',

--- a/packages/renderers/web/src/classNames.ts
+++ b/packages/renderers/web/src/classNames.ts
@@ -103,11 +103,11 @@ export const tailwindClassNames: SupramarkClassNames = {
   h6: 'text-base font-medium mb-2 mt-2',
   blockquote: 'border-l-4 border-gray-300 dark:border-gray-600 pl-4 mb-4',
   thematicBreak: 'border-t border-gray-300 dark:border-gray-700 my-4',
-  codeBlock: 'bg-gray-100 dark:bg-gray-800 rounded-md p-4 mb-4 overflow-x-auto',
+  codeBlock: 'p-4 overflow-x-auto',
   code: 'font-mono text-sm',
-  codeBlockContainer: 'rounded-md mb-4 overflow-hidden',
+  codeBlockContainer: 'bg-gray-100 dark:bg-gray-800 rounded-md mb-4 overflow-hidden',
   codeBlockHeader:
-    'flex items-center justify-between px-2 py-1 bg-gray-200 dark:bg-gray-700 select-none',
+    'flex items-center justify-between px-2 py-1 border-b border-gray-300 dark:border-gray-700 select-none',
   codeBlockLang: 'text-xs text-gray-600 dark:text-gray-300 font-mono select-none',
   codeButton:
     'bg-gray-700 dark:bg-gray-600 text-white text-xs rounded px-2 py-1 hover:bg-gray-600 dark:hover:bg-gray-500 select-none',

--- a/packages/renderers/web/src/classNames.ts
+++ b/packages/renderers/web/src/classNames.ts
@@ -21,7 +21,9 @@ export interface SupramarkClassNames {
   thematicBreak?: string; // hr element
 
   // Code blocks
-  codeBlock?: string; // pre element
+  codeBlock?: string; // standalone pre element (no header): owns the full chrome
+  /** Body pre inside the headered code block container (container owns the chrome). */
+  codeBlockBody?: string;
   code?: string; // code element
   /** Wrapper around a code block header (lang + button) and the pre. */
   codeBlockContainer?: string;
@@ -103,7 +105,8 @@ export const tailwindClassNames: SupramarkClassNames = {
   h6: 'text-base font-medium mb-2 mt-2',
   blockquote: 'border-l-4 border-gray-300 dark:border-gray-600 pl-4 mb-4',
   thematicBreak: 'border-t border-gray-300 dark:border-gray-700 my-4',
-  codeBlock: 'm-0 p-4 overflow-x-auto',
+  codeBlock: 'bg-gray-100 dark:bg-gray-800 rounded-md p-4 mb-4 overflow-x-auto',
+  codeBlockBody: 'm-0 p-4 overflow-x-auto',
   code: 'font-mono text-sm',
   codeBlockContainer: 'bg-gray-100 dark:bg-gray-800 rounded-md mb-4 overflow-hidden',
   codeBlockHeader: 'flex items-center justify-between px-2 py-1 select-none',
@@ -149,6 +152,7 @@ export const minimalClassNames: SupramarkClassNames = {
   blockquote: 'sm-blockquote',
   thematicBreak: 'sm-hr',
   codeBlock: 'sm-code-block',
+  codeBlockBody: 'sm-code-block-body',
   code: 'sm-code',
   codeBlockContainer: 'sm-code-block-container',
   codeBlockHeader: 'sm-code-block-header',

--- a/packages/renderers/web/src/classNames.ts
+++ b/packages/renderers/web/src/classNames.ts
@@ -113,7 +113,6 @@ export const tailwindClassNames: SupramarkClassNames = {
   codeBlockLang: 'text-xs text-gray-600 dark:text-gray-300 font-mono select-none',
   codeButton:
     'bg-gray-700 dark:bg-gray-600 text-white text-xs rounded px-2 py-1 hover:bg-gray-600 dark:hover:bg-gray-500 select-none',
-  codeButtonText: '',
   listOrdered: 'list-decimal ml-6 mb-4',
   listUnordered: 'list-disc ml-6 mb-4',
   listItem: 'mb-1',

--- a/tests/markdown-conformance/browser/commonmark-renderer/src/main.tsx
+++ b/tests/markdown-conformance/browser/commonmark-renderer/src/main.tsx
@@ -77,6 +77,11 @@ function RenderCase({
           ...(request.flattenNestedStrong ? { flattenNestedStrong: true } : {}),
         },
       }}
+      // Conformance measures Markdown→DOM spec compliance. The copy button is
+      // a host UI decoration (library-added interaction), not part of the spec
+      // DOM, so the harness opts out of it to keep the measured DOM on the
+      // spec <pre><code> baseline.
+      copyButton={false}
       onError={onError}
       onRenderStateChange={onRenderStateChange}
     />


### PR DESCRIPTION
Closes #204

## What

Adds a top-right copy button to fenced code blocks in both the React Native and Web renderers. The button UI and "Copied" feedback are library-owned; the clipboard action is host-injectable via `onCopyCode`, mirroring the existing `onOpenHtmlPage` callback pattern.

## Why

Fenced code blocks had no affordance to copy the contained source. A small copy button is a near-universal affordance in Markdown renderers. Per the core contract (`PlatformRenderer.render` is a type-signature reference only — no JSX), the button **cannot** be injected via a feature's `renderers.{rn,web}` — it must live in `@supramark/rn` / `@supramark/web`. So the split is: library owns the button UI + feedback; the clipboard action is host-injectable (RN stays dependency-free; Web defaults to `navigator.clipboard`).

## How

- New `CodeBlock` FC + `CodeCopyContext` in `packages/renderers/rn/src/CodeBlock.tsx` and `packages/renderers/web/src/CodeBlock.tsx`.
- `CodeCopyContext.Provider` wraps the rendered tree so `onCopyCode`/`copyButton` reach `CodeBlock` without touching the `renderNode` signature (no recursive call-site updates).
- `renderCodeBlock` is split into `renderCodeContent` (inner tree) + `CodeBlock` (relative wrapper + button).
- **RN**: button renders only when `onCopyCode` is provided (clipboard-free); `copyButton: false` opts out. New styles `codeButton`/`codeButtonText` (light + dark via deep-merge).
- **Web**: defaults to `navigator.clipboard.writeText`; `onCopyCode` overrides; `copyButton: false` opts out. New classNames `codeBlockContainer`/`codeButton`/`codeButtonText` + tailwind/minimal presets; inline fallback when no className.

## Behavior contract

| Platform | Default | `onCopyCode` provided | `copyButton: false` |
|---|---|---|---|
| RN | **no button** (clipboard-free) | button shown, host owns clipboard | no button |
| Web | button, `navigator.clipboard` | overrides default | no button |

Both show a 1.5s "Copied" feedback (library-owned state; reset timer cleared on unmount).

## Tests

- New `code-block-copy.test.tsx` (RN 4 + Web 4): button visibility, `onPress` invokes `onCopyCode`/`navigator.clipboard`, `copyButton: false` hides, "Copied" feedback.
- Full suites green after rebasing onto `upstream/main`: RN 126 pass / 0 fail; Web 71 pass / 0 fail.
- `tsc --noEmit` clean on both renderer packages.

## Out of scope / host verification

- **RN real-device**: host must inject `onCopyCode` for the button to appear and copy; call chain verified via `react-test-renderer`, actual clipboard write needs a host integration test on device.
- **Web**: `navigator.clipboard` requires a secure context (HTTPS/localhost); tested via happy-dom mock.
- No new runtime dependency added.