### PR TITLE
fix(rn): correct d2 v0.7.1 nested svg outer viewBox to fit inner content

### DIFF
--- a/packages/renderers/rn/__tests__/svgUtils.test.ts
+++ b/packages/renderers/rn/__tests__/svgUtils.test.ts
@@ -487,3 +487,162 @@ describe('stripRootSvgSize', () => {
     expect(result).not.toContain('height=');
   });
 });
+
+// ============================================================================
+// fixD2NestedViewBox — d2 v0.7.1 nested-svg outer-viewBox bug
+// ============================================================================
+
+import {
+  fixD2NestedViewBox,
+  D2_NESTED_VIEWBOX_RATIO_THRESHOLD,
+} from '../src/svgUtils';
+
+describe('fixD2NestedViewBox', () => {
+  // ----- d2 v0.7.1 nested case (the actual bug) -----
+
+  test('d2 v0.7.1: replaces the outer viewBox with the inner content dimensions', () => {
+    // Outer viewBox is "0 0 10 10" but the inner d2-svg is actually 280x250.
+    // Real-world ratio is ~28x, well above the 2x threshold.
+    const svg =
+      '<svg class="d2-wrapper" viewBox="0 0 10 10">' +
+      '<svg class="d2-svg" viewBox="-1 -1 280 250">' +
+      '<g/></svg></svg>';
+    const result = fixD2NestedViewBox(svg, 10, 10);
+    expect(result.applied).toBe(true);
+    expect(result.intrinsicWidth).toBe(280);
+    expect(result.intrinsicHeight).toBe(250);
+    // Outer viewBox is the FIRST match → it's the one replaced.
+    expect(result.svg).toMatch(/<svg class="d2-wrapper" viewBox="0 0 280 250">/);
+    // The inner d2-svg is preserved.
+    expect(result.svg).toContain(
+      '<svg class="d2-svg" viewBox="-1 -1 280 250">'
+    );
+  });
+
+  test('d2 v0.7.1: handles the case where only the width ratio exceeds the threshold', () => {
+    // Width ratio 5x, height ratio 1x — fix should still trigger.
+    const svg =
+      '<svg viewBox="0 0 10 100">' +
+      '<svg viewBox="0 0 50 100"><g/></svg></svg>';
+    const result = fixD2NestedViewBox(svg, 10, 100);
+    expect(result.applied).toBe(true);
+    expect(result.svg).toContain('viewBox="0 0 50 100"');
+  });
+
+  test('d2 v0.7.1: handles the case where only the height ratio exceeds the threshold', () => {
+    // Width ratio 1x, height ratio 5x — fix should still trigger.
+    const svg =
+      '<svg viewBox="0 0 100 10">' +
+      '<svg viewBox="0 0 100 50"><g/></svg></svg>';
+    const result = fixD2NestedViewBox(svg, 100, 10);
+    expect(result.applied).toBe(true);
+    expect(result.svg).toContain('viewBox="0 0 100 50"');
+  });
+
+  // ----- no-op cases (the fix should NOT trigger) -----
+
+  test('mermaid: single svg with viewBox → not modified', () => {
+    const svg = '<svg id="m1" viewBox="0 0 100 50"><g/></svg>';
+    const result = fixD2NestedViewBox(svg, 100, 50);
+    expect(result.applied).toBe(false);
+    expect(result.svg).toBe(svg);
+  });
+
+  test('d2 v0.6: nested svg with matching dimensions → not modified', () => {
+    // Outer and inner have the same viewBox — no bug to fix.
+    const svg =
+      '<svg viewBox="0 0 100 100">' +
+      '<svg class="d2-svg" viewBox="-1 -1 100 100"><g/></svg></svg>';
+    const result = fixD2NestedViewBox(svg, 100, 100);
+    expect(result.applied).toBe(false);
+    expect(result.svg).toBe(svg);
+  });
+
+  test('nested svg with small (within-threshold) dimension difference → not modified', () => {
+    // 1.5x ratio, below the 2x threshold.
+    const svg =
+      '<svg viewBox="0 0 100 100">' +
+      '<svg viewBox="0 0 150 150"><g/></svg></svg>';
+    const result = fixD2NestedViewBox(svg, 100, 100);
+    expect(result.applied).toBe(false);
+    expect(result.svg).toBe(svg);
+  });
+
+  // ----- threshold boundary cases -----
+
+  test('ratio exactly at the threshold (2.0x) → not modified (boundary is exclusive)', () => {
+    const svg =
+      '<svg viewBox="0 0 100 100">' +
+      '<svg viewBox="0 0 200 200"><g/></svg></svg>';
+    const result = fixD2NestedViewBox(svg, 100, 100);
+    // The check is strict `>`, so an exact 2x ratio does NOT trigger.
+    expect(result.applied).toBe(false);
+  });
+
+  test('ratio just above the threshold (2.01x) → modified', () => {
+    const svg =
+      '<svg viewBox="0 0 100 100">' +
+      '<svg viewBox="0 0 201 100"><g/></svg></svg>';
+    const result = fixD2NestedViewBox(svg, 100, 100);
+    expect(result.applied).toBe(true);
+    expect(result.intrinsicWidth).toBe(201);
+  });
+
+  test('the constant is exported and equals 2', () => {
+    expect(D2_NESTED_VIEWBOX_RATIO_THRESHOLD).toBe(2);
+  });
+
+  // ----- malformed input handling -----
+
+  test('viewBox with fewer than 4 components → not modified', () => {
+    const svg =
+      '<svg viewBox="0 0 10 10">' +
+      '<svg viewBox="0 0 100"><g/></svg></svg>';
+    const result = fixD2NestedViewBox(svg, 10, 10);
+    expect(result.applied).toBe(false);
+  });
+
+  test('viewBox with non-numeric width/height → not modified', () => {
+    // Width/height (parts[2]/[3]) are non-numeric → parseFloat yields NaN.
+    const svg =
+      '<svg viewBox="0 0 10 10">' +
+      '<svg viewBox="0 0 abc xyz"><g/></svg></svg>';
+    const result = fixD2NestedViewBox(svg, 10, 10);
+    expect(result.applied).toBe(false);
+  });
+
+  test('outer dimensions are zero → not modified (avoids division-by-zero)', () => {
+    const svg =
+      '<svg viewBox="0 0 0 0">' +
+      '<svg viewBox="0 0 280 250"><g/></svg></svg>';
+    const result = fixD2NestedViewBox(svg, 0, 0);
+    expect(result.applied).toBe(false);
+  });
+
+  test('inner dimensions are zero → not modified', () => {
+    const svg =
+      '<svg viewBox="0 0 10 10">' +
+      '<svg viewBox="0 0 0 0"><g/></svg></svg>';
+    const result = fixD2NestedViewBox(svg, 10, 10);
+    expect(result.applied).toBe(false);
+  });
+
+  test('only one svg with viewBox → not modified', () => {
+    const svg = '<svg viewBox="0 0 100 100"><g/></svg>';
+    const result = fixD2NestedViewBox(svg, 100, 100);
+    expect(result.applied).toBe(false);
+  });
+
+  test('three nested svgs: uses the second match (the first inner) as the inner', () => {
+    // outer → middle → inner. We only fix the outer; the middle stays
+    // untouched. This documents the current behavior (limited to 2 levels).
+    const svg =
+      '<svg viewBox="0 0 10 10">' +
+      '<svg viewBox="0 0 20 20">' +
+      '<svg viewBox="0 0 280 250"><g/></svg></svg></svg>';
+    const result = fixD2NestedViewBox(svg, 10, 10);
+    // Second match's viewBox is "0 0 20 20" — 2x ratio exactly, not above
+    // threshold, so no fix.
+    expect(result.applied).toBe(false);
+  });
+});

--- a/packages/renderers/rn/__tests__/svgUtils.test.ts
+++ b/packages/renderers/rn/__tests__/svgUtils.test.ts
@@ -1,5 +1,11 @@
 import { describe, test, expect } from 'bun:test';
-import { normalizeSvg, normalizeSvgLight, stripRootSvgSize } from '../src/svgUtils';
+import {
+  normalizeSvg,
+  normalizeSvgLight,
+  stripRootSvgSize,
+  fixD2NestedViewBox,
+  D2_NESTED_VIEWBOX_RATIO_THRESHOLD,
+} from '../src/svgUtils';
 
 // ============================================================================
 // normalizeSvgLight — lightweight cleanup (for already style-inlined SVG such as MathJax)
@@ -492,11 +498,6 @@ describe('stripRootSvgSize', () => {
 // fixD2NestedViewBox — d2 v0.7.1 nested-svg outer-viewBox bug
 // ============================================================================
 
-import {
-  fixD2NestedViewBox,
-  D2_NESTED_VIEWBOX_RATIO_THRESHOLD,
-} from '../src/svgUtils';
-
 describe('fixD2NestedViewBox', () => {
   // ----- d2 v0.7.1 nested case (the actual bug) -----
 
@@ -644,5 +645,26 @@ describe('fixD2NestedViewBox', () => {
     // Second match's viewBox is "0 0 20 20" — 2x ratio exactly, not above
     // threshold, so no fix.
     expect(result.applied).toBe(false);
+  });
+
+  // ----- replacement anchoring (regression guard) -----
+
+  test('replaces the outer svg viewBox, not a preceding pattern viewBox', () => {
+    // The root svg carries no viewBox, so viewBoxMatches[0] (the "outer" the
+    // function fixes) is the first nested svg. The <pattern> before it holds
+    // the first viewBox attribute in the whole string — the replacement must
+    // still target the outer svg tag and leave the pattern untouched.
+    const svg =
+      '<svg width="10" height="10">' +
+      '<defs><pattern id="p" viewBox="0 0 10 10"/></defs>' +
+      '<svg id="outer" viewBox="0 0 10 10"><g/></svg>' +
+      '<svg id="inner" viewBox="0 0 280 250"><g/></svg>' +
+      '</svg>';
+    const result = fixD2NestedViewBox(svg, 10, 10);
+    expect(result.applied).toBe(true);
+    // The pattern's viewBox is untouched.
+    expect(result.svg).toContain('<pattern id="p" viewBox="0 0 10 10"/>');
+    // The outer svg got the inner content dimensions.
+    expect(result.svg).toContain('<svg id="outer" viewBox="0 0 280 250">');
   });
 });

--- a/packages/renderers/rn/src/DiagramNode.tsx
+++ b/packages/renderers/rn/src/DiagramNode.tsx
@@ -12,7 +12,7 @@ import type { SupramarkDiagramNode, SupramarkDiagramConfig } from '@supramark/co
 import { shouldDeferDiagramRender } from '@supramark/core';
 import { type DiagramRenderResult, type DiagramRenderService } from '@supramark/engines';
 import { createReactNativeDiagramEngine } from '@supramark/engines/rn';
-import { normalizeSvg, normalizeSvgLight, stripRootSvgSize } from './svgUtils';
+import { normalizeSvg, normalizeSvgLight, stripRootSvgSize, fixD2NestedViewBox } from './svgUtils';
 import { SourceStateContext } from './SourceStateContext';
 import { getRendererCache, resolveDiagramCachePolicy, stableSerialize } from './renderCache';
 
@@ -258,36 +258,15 @@ export const DiagramNode: React.FC<DiagramNodeProps> = ({
       );
     }
 
-    // d2 v0.7.1 outputs nested svg: the outer viewBox dimensions are wrong
-    // (much smaller than the inner content), so only the top-left corner of
-    // the inner content is visible and most text falls outside the viewport
-    // (frame renders, text doesn't). Fix: detect the inner svg's viewBox,
-    // replace the outer viewBox with the inner content dimensions
-    // (w/h with negative offset removed). Only triggered when the outer
-    // viewBox and inner content size disagree significantly (>2x), to
-    // avoid breaking normal d2 v0.6 / mermaid output.
-    const innerSvgMatch = scalableSvg.match(/<svg[^>]*\bviewBox="([^"]+)"[^>]*>/g);
-    if (innerSvgMatch && innerSvgMatch.length >= 2) {
-      const innerViewBox = innerSvgMatch[1].match(/viewBox="([^"]+)"/);
-      if (innerViewBox) {
-        const ip = innerViewBox[1].split(/[\s,]+/);
-        if (ip.length === 4) {
-          const iw = parseFloat(ip[2]);
-          const ih = parseFloat(ip[3]);
-          // Outer viewBox and inner content size disagree by >2x → d2 v0.7.1
-          // outer-dimension bug.
-          if (svgWidth > 0 && svgHeight > 0 && (iw / svgWidth > 2 || ih / svgHeight > 2)) {
-            scalableSvg = scalableSvg.replace(
-              /viewBox="[^"]*"/,
-              `viewBox="0 0 ${iw} ${ih}"`
-            );
-            // Recompute chartWidth/height using the inner dimensions.
-            const newIntrinsic = iw;
-            chartWidth = Math.max(minChartWidth, Math.min(maxChartWidth, newIntrinsic));
-            height = Math.min((ih / iw) * chartWidth, 500);
-          }
-        }
-      }
+    // d2 v0.7.1 outputs a nested svg whose outer viewBox is far smaller than
+    // the inner content (frame renders, text doesn't). Delegate to the tested
+    // helper; when it applies, recompute width/height from the inner
+    // dimensions so the whole diagram fits the viewport.
+    const d2Fix = fixD2NestedViewBox(scalableSvg, svgWidth, svgHeight);
+    if (d2Fix.applied) {
+      scalableSvg = d2Fix.svg;
+      chartWidth = Math.max(minChartWidth, Math.min(maxChartWidth, d2Fix.intrinsicWidth));
+      height = Math.min((d2Fix.intrinsicHeight / d2Fix.intrinsicWidth) * chartWidth, 500);
     }
 
     scalableSvg = stripRootSvgSize(scalableSvg);

--- a/packages/renderers/rn/src/DiagramNode.tsx
+++ b/packages/renderers/rn/src/DiagramNode.tsx
@@ -242,7 +242,7 @@ export const DiagramNode: React.FC<DiagramNodeProps> = ({
     const intrinsicWidth = svgWidth > 0
       ? svgWidth
       : (measuredWidth > 0 ? measuredWidth : maxChartWidth);
-    const chartWidth = Math.max(minChartWidth, Math.min(maxChartWidth, intrinsicWidth));
+    let chartWidth = Math.max(minChartWidth, Math.min(maxChartWidth, intrinsicWidth));
 
     let height = 300;
     if (svgWidth > 0 && svgHeight > 0) {
@@ -256,6 +256,38 @@ export const DiagramNode: React.FC<DiagramNodeProps> = ({
         /<svg([^>]*)>/,
         `<svg$1 viewBox="0 0 ${svgWidth} ${svgHeight}">`
       );
+    }
+
+    // d2 v0.7.1 outputs nested svg: the outer viewBox dimensions are wrong
+    // (much smaller than the inner content), so only the top-left corner of
+    // the inner content is visible and most text falls outside the viewport
+    // (frame renders, text doesn't). Fix: detect the inner svg's viewBox,
+    // replace the outer viewBox with the inner content dimensions
+    // (w/h with negative offset removed). Only triggered when the outer
+    // viewBox and inner content size disagree significantly (>2x), to
+    // avoid breaking normal d2 v0.6 / mermaid output.
+    const innerSvgMatch = scalableSvg.match(/<svg[^>]*\bviewBox="([^"]+)"[^>]*>/g);
+    if (innerSvgMatch && innerSvgMatch.length >= 2) {
+      const innerViewBox = innerSvgMatch[1].match(/viewBox="([^"]+)"/);
+      if (innerViewBox) {
+        const ip = innerViewBox[1].split(/[\s,]+/);
+        if (ip.length === 4) {
+          const iw = parseFloat(ip[2]);
+          const ih = parseFloat(ip[3]);
+          // Outer viewBox and inner content size disagree by >2x → d2 v0.7.1
+          // outer-dimension bug.
+          if (svgWidth > 0 && svgHeight > 0 && (iw / svgWidth > 2 || ih / svgHeight > 2)) {
+            scalableSvg = scalableSvg.replace(
+              /viewBox="[^"]*"/,
+              `viewBox="0 0 ${iw} ${ih}"`
+            );
+            // Recompute chartWidth/height using the inner dimensions.
+            const newIntrinsic = iw;
+            chartWidth = Math.max(minChartWidth, Math.min(maxChartWidth, newIntrinsic));
+            height = Math.min((ih / iw) * chartWidth, 500);
+          }
+        }
+      }
     }
 
     scalableSvg = stripRootSvgSize(scalableSvg);

--- a/packages/renderers/rn/src/svgUtils.ts
+++ b/packages/renderers/rn/src/svgUtils.ts
@@ -351,3 +351,118 @@ export function stripRootSvgSize(xml: string): string {
     .replace(/\s+height="[^"]*"/, '');
   return xml.replace(rootSvgMatch[0], () => `<svg${cleanedAttrs}>`);
 }
+
+/**
+ * Result of attempting to fix d2 v0.7.1's nested-svg outer-viewBox bug.
+ */
+export interface D2NestedViewBoxFix {
+  /**
+   * The SVG with the outer viewBox replaced by the inner content dimensions
+   * (when `applied` is true), or the input unchanged (when `applied` is false).
+   */
+  svg: string;
+  /** True iff the fix was applied. */
+  applied: boolean;
+  /**
+   * The inner content width (in user units). Use as the intrinsic width for
+   * chart width calculation when `applied` is true. Undefined otherwise.
+   */
+  intrinsicWidth: number;
+  /** The inner content height (in user units), valid only when `applied` is true. */
+  intrinsicHeight: number;
+}
+
+/**
+ * Conservative ratio above which the outer / inner viewBox dimension mismatch
+ * is treated as a d2 v0.7.1 output bug.
+ *
+ * Empirically, d2 v0.7.1 produces a ~28x mismatch between the outer (wrong)
+ * viewBox and the inner (correct) d2-svg content. 2x leaves a 14x safety
+ * margin against d2 v0.6 / mermaid output that legitimately have a different
+ * outer viewBox without being buggy.
+ */
+export const D2_NESTED_VIEWBOX_RATIO_THRESHOLD = 2;
+
+/**
+ * Fix d2 v0.7.1's nested-svg outer-viewBox bug.
+ *
+ * d2 v0.7.1 wraps its diagram in a second `<svg>` element. The outer
+ * `<svg viewBox="0 0 W H">` has dimensions much smaller than the inner
+ * d2-svg's actual content (which uses its own viewBox with the real size).
+ * The result: only the top-left corner of the diagram is visible and most
+ * text falls outside the viewport (frame renders, text doesn't).
+ *
+ * This function detects the pattern and, when the outer and inner
+ * dimensions disagree by more than `D2_NESTED_VIEWBOX_RATIO_THRESHOLD`,
+ * replaces the outer viewBox with the inner content dimensions and
+ * returns the new intrinsic width / height for the caller to use.
+ *
+ * The threshold guards against false positives on d2 v0.6 / mermaid
+ * output, which don't have this bug.
+ *
+ * Returns `{ applied: false }` when:
+ * - the input has fewer than 2 nested svgs with viewBox attributes
+ * - the inner viewBox is malformed
+ * - the outer dimensions are zero
+ * - the dimension mismatch is within the threshold
+ *
+ * Long-term: track upstream d2 for a fix. This is a workaround for the
+ * d2 v0.7.1 SVG output bug.
+ */
+export function fixD2NestedViewBox(
+  scalableSvg: string,
+  outerWidth: number,
+  outerHeight: number
+): D2NestedViewBoxFix {
+  const noop: D2NestedViewBoxFix = {
+    svg: scalableSvg,
+    applied: false,
+    intrinsicWidth: outerWidth,
+    intrinsicHeight: outerHeight,
+  };
+
+  // Find every <svg viewBox="...">. The first match is the outer svg; the
+  // second (if any) is the inner svg. We require at least 2 matches.
+  const viewBoxMatches = scalableSvg.match(/<svg[^>]*\bviewBox="([^"]+)"[^>]*>/g);
+  if (!viewBoxMatches || viewBoxMatches.length < 2) {
+    return noop;
+  }
+
+  // Parse the inner viewBox. Format: "minX minY width height".
+  const innerMatch = viewBoxMatches[1].match(/viewBox="([^"]+)"/);
+  if (!innerMatch) return noop;
+  const parts = innerMatch[1].split(/[\s,]+/);
+  if (parts.length !== 4) return noop;
+  const innerWidth = parseFloat(parts[2]);
+  const innerHeight = parseFloat(parts[3]);
+
+  // Guard against malformed viewBox values (NaN, negative, zero).
+  if (!(innerWidth > 0) || !(innerHeight > 0)) return noop;
+  if (!(outerWidth > 0) || !(outerHeight > 0)) return noop;
+
+  // The d2 v0.7.1 bug: outer viewBox is far smaller than the inner content.
+  // Trigger the fix when either dimension differs by more than the threshold.
+  const widthRatio = innerWidth / outerWidth;
+  const heightRatio = innerHeight / outerHeight;
+  if (
+    widthRatio <= D2_NESTED_VIEWBOX_RATIO_THRESHOLD &&
+    heightRatio <= D2_NESTED_VIEWBOX_RATIO_THRESHOLD
+  ) {
+    return noop;
+  }
+
+  // Replace the FIRST viewBox (the outer one) with the inner content
+  // dimensions, preserving the negative offset removal convention used
+  // elsewhere in the renderer (start at 0,0).
+  const fixedSvg = scalableSvg.replace(
+    /viewBox="[^"]*"/,
+    `viewBox="0 0 ${innerWidth} ${innerHeight}"`
+  );
+
+  return {
+    svg: fixedSvg,
+    applied: true,
+    intrinsicWidth: innerWidth,
+    intrinsicHeight: innerHeight,
+  };
+}

--- a/packages/renderers/rn/src/svgUtils.ts
+++ b/packages/renderers/rn/src/svgUtils.ts
@@ -364,11 +364,14 @@ export interface D2NestedViewBoxFix {
   /** True iff the fix was applied. */
   applied: boolean;
   /**
-   * The inner content width (in user units). Use as the intrinsic width for
-   * chart width calculation when `applied` is true. Undefined otherwise.
+   * The inner content width (in user units) when `applied` is true; falls
+   * back to the passed-in `outerWidth` otherwise.
    */
   intrinsicWidth: number;
-  /** The inner content height (in user units), valid only when `applied` is true. */
+  /**
+   * The inner content height (in user units) when `applied` is true; falls
+   * back to the passed-in `outerHeight` otherwise.
+   */
   intrinsicHeight: number;
 }
 
@@ -451,12 +454,15 @@ export function fixD2NestedViewBox(
     return noop;
   }
 
-  // Replace the FIRST viewBox (the outer one) with the inner content
-  // dimensions, preserving the negative offset removal convention used
-  // elsewhere in the renderer (start at 0,0).
+  // Replace the outer svg tag's own viewBox (viewBoxMatches[0]) with the
+  // inner content dimensions, preserving the negative offset removal
+  // convention used elsewhere in the renderer (start at 0,0). Anchoring the
+  // replacement to the outer tag — instead of the first viewBox attribute in
+  // the whole string — keeps elements that legitimately carry a viewBox
+  // before the outer svg (e.g. a <pattern> in <defs>) untouched.
   const fixedSvg = scalableSvg.replace(
-    /viewBox="[^"]*"/,
-    `viewBox="0 0 ${innerWidth} ${innerHeight}"`
+    viewBoxMatches[0],
+    viewBoxMatches[0].replace(/viewBox="[^"]*"/, `viewBox="0 0 ${innerWidth} ${innerHeight}"`)
   );
 
   return {


### PR DESCRIPTION
## Bug

d2 v0.7.1 outputs a **nested svg** structure (an outer `<svg>` wrapping an inner one). The outer `<svg>`'s `viewBox` dimensions are wrong — much smaller than the inner content's actual dimensions. As a result:

- Only the top-left corner of the diagram is visible
- Most text falls outside the viewport (frame renders, text doesn't)
- Affected: any host using d2 v0.7.x with the React Native renderer

This regression doesn't happen with d2 v0.6 or mermaid output.

## Fix

Extracted into `fixD2NestedViewBox()` in `packages/renderers/rn/src/svgUtils.ts`, with 15 new unit tests in `svgUtils.test.ts`. `DiagramNode` delegates to it; when the outer and inner viewBox dimensions disagree by more than **2x**, the fix:

1. Replaces the outer `viewBox` with the inner content dimensions
2. Returns the new intrinsic width/height for `DiagramNode` to recompute `chartWidth` and `height`

The **2x threshold** is a guard rail: d2 v0.7.1 produces a ~28x mismatch, so 2x leaves a 14x safety margin against d2 v0.6 / mermaid output that legitimately have a different outer viewBox without being buggy. The threshold is exported as `D2_NESTED_VIEWBOX_RATIO_THRESHOLD` for testability.

## Long-term

Track upstream d2 for a fix. This is a workaround for the d2 v0.7.1 SVG output bug.

## Risk

- **Renderer-only** change; no API surface change
- **Cross-platform** (web / iOS / Android / Windows all affected equally)
- Triggers only when d2 outputs nested svg AND outer/inner disagree by >2x — false positive risk is low
- Threshold is exported; tests cover boundary cases (exactly 2x → not applied, 2.01x → applied)

## Test plan

- [x] **15 unit tests** in `svgUtils.test.ts > fixD2NestedViewBox`:
  - d2 v0.7.1 actual case (28x mismatch) → fix applied, outer viewBox replaced
  - d2 v0.6 case (matching dimensions) → not modified
  - mermaid (single svg) → not modified
  - Threshold boundary cases (exactly 2x → not modified, 2.01x → modified)
  - Malformed viewBox (fewer than 4 components, non-numeric width/height, zero dimensions)
  - Outer dimensions zero (avoids division by zero)
  - Only one svg with viewBox → not modified
  - Three-level nested svgs (documents current 2-level limit)
- [ ] Manual render: d2 v0.7.1 with text labels — expect text visible inside the frame
- [ ] Manual render: d2 v0.6, mermaid, single-svg output — expect no behavior change