### PR TITLE
feat(rn): add maxWidth to SupramarkDiagramConfig for host-driven chart cap

### DIFF
--- a/packages/core/src/ast.ts
+++ b/packages/core/src/ast.ts
@@ -205,6 +205,15 @@ export interface SupramarkDiagramConfig {
   /** Default timeout (milliseconds), used for engines without their own config */
   defaultTimeoutMs?: number;
 
+  /**
+   * Host-provided cap on diagram display width (dp). Diagrams clamp their
+   * display width to min(windowWidth × 0.9, maxWidth). Hosts whose container
+   * is narrower than the window (e.g. a desktop chat bubble with a fixed
+   * maxWidth) pass their own cap so the diagram doesn't overflow the
+   * container. Unset means the screen-derived cap applies alone.
+   */
+  maxWidth?: number;
+
   /** Default cache configuration */
   defaultCache?: {
     enabled?: boolean;

--- a/packages/renderers/rn/src/DiagramNode.tsx
+++ b/packages/renderers/rn/src/DiagramNode.tsx
@@ -215,7 +215,15 @@ export const DiagramNode: React.FC<DiagramNodeProps> = ({
     // Diagram width cap: 90% of the screen width, leaving room for the
     // bubble's padding so the diagram doesn't touch the edge.
     // Uses a percentage rather than a fixed pixel value to adapt to different hosts' padding.
-    const maxChartWidth = screenWidth * 0.9;
+    // diagram.maxWidth (host config) caps it further for containers narrower
+    // than the window (e.g. a desktop chat bubble with a fixed maxWidth);
+    // unset keeps the screen-derived cap alone.
+    const maxChartWidth = Math.min(
+      screenWidth * 0.9,
+      typeof diagramConfig?.maxWidth === 'number' && diagramConfig.maxWidth > 0
+        ? diagramConfig.maxWidth
+        : Number.POSITIVE_INFINITY
+    );
     let svgWidth = 0;
     let svgHeight = 0;
 


### PR DESCRIPTION
## Motivation

Hosts whose diagram container is narrower than the window (e.g. a desktop chat bubble with a fixed `maxWidth`) currently cannot prevent the diagram from overflowing. The renderer uses `windowWidth × 0.9` as the chart width cap, ignoring the container's own constraints — so a narrow bubble gets a wide diagram that overflows the bubble's right edge.

## Change

Add an optional `maxWidth?: number` field to `SupramarkDiagramConfig`. The renderer now clamps chart display width to:

```
min(windowWidth × 0.9, host.maxWidth ?? Infinity)
```

Unset keeps the existing screen-derived cap. A type-guard (`typeof === 'number' && > 0`) rejects 0 / negative / NaN so junk callers don't change behavior.

## Why renderer, not core

The clamp belongs in the renderer because it's about the display surface, not about diagram semantics. Adding it to the config type is the lightest possible API surface change (one optional field).

## Cross-platform

This change benefits **every** host (iOS / Android / macOS / Windows / web), not just Windows. The motivation is from a desktop chat bubble, but the fix is universal.

## Risk

- Pure additive API: `maxWidth` is optional, default behavior unchanged
- 2 files, 18 lines
- No new types or re-exports

## Test plan

- [ ] `maxWidth` unset → behavior identical to before
- [ ] `maxWidth: 300` on a 400dp-wide container → chart capped at 300dp
- [ ] `maxWidth: 0` or negative → ignored, falls back to screen cap
- [ ] `maxWidth` larger than `windowWidth × 0.9` → screen cap wins