### PR TITLE
fix(build): graphviz Windows build fix for Chinese code page / MSYS2

### DIFF
--- a/crates/graphviz-anywhere/scripts/build-windows.sh
+++ b/crates/graphviz-anywhere/scripts/build-windows.sh
@@ -126,10 +126,19 @@ prepare_graphviz_source "${GV_PATCHED}"
 # htmllex.c fails with "Cannot open include file: 'expat.h'".)
 log_info "Configuring Graphviz..."
 mkdir -p "${BUILD_DIR}/graphviz"
+# MSVC 源码编码：中文 Windows（代码页 936/GBK）下 MSVC 默认按本地代码页解析源文件，
+# graphviz 源码/头文件中的 UTF-8 字符会触发 C4819 并连锁产生语法错（如 htmltable.c
+# 的「i 未声明」假错——多字节序列错读吞掉引号/分号）。强制 /utf-8 解析。
+# 仅加在 Windows 生成器调用上，不动 common.sh 的跨平台共享参数。
+# MSYS2_ARG_CONV_EXCL：Git Bash 会把值里的 /utf-8 当 Unix 路径转换成
+# C:/Program Files/Git/utf-8（见 CMakeCache 污染），需精确排除这两个参数。
+MSYS2_ARG_CONV_EXCL='-DCMAKE_C_FLAGS;-DCMAKE_CXX_FLAGS' \
 cmake -S "${GV_PATCHED}" -B "${BUILD_DIR}/graphviz" \
     -G "${VS_GENERATOR}" -A "${CMAKE_PLATFORM}" \
     "${GV_CMAKE_COMMON_ARGS[@]}" \
     "${WINDOWS_ARCH_CMAKE_ARGS[@]}" \
+    -DCMAKE_C_FLAGS="/utf-8" \
+    -DCMAKE_CXX_FLAGS="/utf-8" \
     -DCMAKE_INSTALL_PREFIX="${BUILD_DIR}/graphviz-install"
 
 log_info "Building Graphviz library targets..."
@@ -176,12 +185,15 @@ install(TARGETS graphviz_api
 )
 CMAKE_EOF
 
+MSYS2_ARG_CONV_EXCL='-DCMAKE_C_FLAGS;-DCMAKE_CXX_FLAGS' \
 cmake -S "${BUILD_DIR}/wrapper" -B "${BUILD_DIR}/wrapper/build" \
     -G "${VS_GENERATOR}" -A "${CMAKE_PLATFORM}" \
     -DSRC_DIR="${WRAPPER_SRC}" \
     -DGV_BUILD_DIR="${BUILD_DIR}/graphviz" \
     -DGV_INSTALL_DIR="${GV_INSTALL}" \
     -DGV_VERSION="${GRAPHVIZ_VERSION}" \
+    -DCMAKE_C_FLAGS="/utf-8" \
+    -DCMAKE_CXX_FLAGS="/utf-8" \
     -DCMAKE_INSTALL_PREFIX="${INSTALL_DIR}"
 
 cmake --build "${BUILD_DIR}/wrapper/build" --config Release

--- a/crates/graphviz-anywhere/scripts/build-windows.sh
+++ b/crates/graphviz-anywhere/scripts/build-windows.sh
@@ -126,12 +126,16 @@ prepare_graphviz_source "${GV_PATCHED}"
 # htmllex.c fails with "Cannot open include file: 'expat.h'".)
 log_info "Configuring Graphviz..."
 mkdir -p "${BUILD_DIR}/graphviz"
-# MSVC 源码编码：中文 Windows（代码页 936/GBK）下 MSVC 默认按本地代码页解析源文件，
-# graphviz 源码/头文件中的 UTF-8 字符会触发 C4819 并连锁产生语法错（如 htmltable.c
-# 的「i 未声明」假错——多字节序列错读吞掉引号/分号）。强制 /utf-8 解析。
-# 仅加在 Windows 生成器调用上，不动 common.sh 的跨平台共享参数。
-# MSYS2_ARG_CONV_EXCL：Git Bash 会把值里的 /utf-8 当 Unix 路径转换成
-# C:/Program Files/Git/utf-8（见 CMakeCache 污染），需精确排除这两个参数。
+# MSVC source encoding: on Chinese Windows (code page 936/GBK), MSVC parses
+# source files with the local code page by default. UTF-8 bytes in graphviz
+# sources/headers trigger C4819 and cascade into syntax errors (e.g. the
+# bogus "undeclared i" in htmltable.c — a misread multibyte sequence swallows
+# quotes/semicolons). Force /utf-8 parsing.
+# Applied to the Windows generator invocation only; keep common.sh's shared
+# cross-platform flags untouched.
+# MSYS2_ARG_CONV_EXCL: Git Bash converts the /utf-8 value as a Unix path into
+# C:/Program Files/Git/utf-8 (see CMakeCache pollution), so exclude exactly
+# these two flags from path conversion.
 MSYS2_ARG_CONV_EXCL='-DCMAKE_C_FLAGS;-DCMAKE_CXX_FLAGS' \
 cmake -S "${GV_PATCHED}" -B "${BUILD_DIR}/graphviz" \
     -G "${VS_GENERATOR}" -A "${CMAKE_PLATFORM}" \


### PR DESCRIPTION
## Bug

On Chinese Windows (system code page 936 / GBK), MSVC parses source files using the local code page by default. Graphviz's UTF-8 source files trigger C4819 warnings that cascade into bizarre syntax errors — e.g. `htmltable.c` reporting an "undeclared identifier" for `i`, because the multi-byte sequence gets mis-read and eats the surrounding quotes/semicolons.

A second, independent failure mode: Git Bash (MSYS2) auto-converts the `/utf-8` value in `-DCMAKE_C_FLAGS=/utf-8` to a Unix path, polluting CMakeCache (`C:/Program Files/Git/utf-8`).

## Fix

In `crates/graphviz-anywhere/scripts/build-windows.sh`, on the cmake invocation:

- Add `-DCMAKE_C_FLAGS=/utf-8` and `-DCMAKE_CXX_FLAGS=/utf-8` so MSVC parses sources as UTF-8
- Wrap with `MSYS2_ARG_CONV_EXCL='-DCMAKE_C_FLAGS;-DCMAKE_CXX_FLAGS'` so Git Bash's path conversion skips exactly these two arguments

The change is scoped to this script's cmake call — `common.sh` is untouched, so cross-platform shared parameters are unchanged.

## Risk

- Windows-only
- 1 file, 12 lines
- No effect on non-Windows build paths
- Both args are already optional; a non-Chinese, non-MSYS2 environment sees the same flags added but with no observable difference (the values are still `/utf-8`, which is a valid MSVC flag)

## Test plan

- [ ] Run `./build-windows.sh` on a Chinese Windows (code page 936) — expect Graphviz C4819 errors gone, full build succeeds
- [ ] Run on English Windows — expect no regression
- [ ] Confirm `common.sh` is unchanged (`git diff main...HEAD -- common.sh` should be empty)