### PR TITLE
feat(windows): markdown-native-rn React Native Windows port

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,6 @@ docs/.vitepress/cache
 docs/public/typedoc
 docs/public/preview
 docs/public/playground
+
+# Windows native build artifacts (scripts/build-windows.sh output)
+crates/*/output/

--- a/crates/supramark-markdown/packages/react-native/.gitignore
+++ b/crates/supramark-markdown/packages/react-native/.gitignore
@@ -3,6 +3,7 @@
 ios/Frameworks/
 macos/Frameworks/
 android/src/main/jniLibs/
+windows/Frameworks/
 
 # react-native-builder-bob build output
 lib/

--- a/crates/supramark-markdown/packages/react-native/package.json
+++ b/crates/supramark-markdown/packages/react-native/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@supramark/markdown-native-rn",
   "version": "0.1.0",
-  "description": "React Native native FFI wrapper for supramark-markdown — Markdown source to AST v2 JSON on iOS, macOS, and Android.",
+  "description": "React Native native FFI wrapper for supramark-markdown — Markdown source to AST v2 JSON on iOS, macOS, Android, and Windows.",
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",
   "types": "lib/typescript/index.d.ts",
@@ -23,6 +23,7 @@
     "ios",
     "macos",
     "android",
+    "windows",
     "scripts",
     "!android/.cxx",
     "!android/build",
@@ -49,7 +50,13 @@
   "peerDependencies": {
     "@supramark/core": "workspace:*",
     "react": "*",
-    "react-native": "*"
+    "react-native": "*",
+    "react-native-windows": "*"
+  },
+  "peerDependenciesMeta": {
+    "react-native-windows": {
+      "optional": true
+    }
   },
   "devDependencies": {},
   "codegenConfig": {

--- a/crates/supramark-markdown/packages/react-native/scripts/prepare-native.js
+++ b/crates/supramark-markdown/packages/react-native/scripts/prepare-native.js
@@ -12,6 +12,9 @@
  *     target/macos-universal/release dylib)
  *   - `cargo ndk -t arm64-v8a -t armeabi-v7a -t x86_64 -t x86 build --release
  *      -p supramark-markdown-native`
+ *   - `scripts/build-windows.sh` (at crate root, produces
+ *     output/windows-x86_64/{bin/supramark_markdown_native.dll,
+ *     include/supramark_markdown.h})
  *
  * Then run `npm run prepare-native` (or `node scripts/prepare-native.js`).
  * Idempotent — re-running just refreshes.
@@ -59,6 +62,11 @@ const NATIVE_HEADER_SRC = path.join(
   'include'
 );
 const ANDROID_JNI_INCLUDE_DEST = path.join(PKG_DIR, 'android', 'src', 'main', 'jni', 'include');
+
+// ── Windows: the DLL + import lib + header from build-windows.sh output. ────
+const CRATE_ROOT = path.resolve(REPO_ROOT, 'crates', 'supramark-markdown');
+const WINDOWS_OUTPUT_DIR = path.join(CRATE_ROOT, 'output');
+const WINDOWS_FRAMEWORKS_DEST = path.join(PKG_DIR, 'windows', 'Frameworks');
 
 function copyDirRecursive(src, dest) {
   fs.mkdirSync(dest, { recursive: true });
@@ -146,9 +154,51 @@ function prepareMacOS() {
   return true;
 }
 
+// Stage the Windows DLL, import lib, and C ABI header at the paths
+// consumed by the RNW project's CMake / MSBuild build.
+function prepareWindows() {
+  // build-windows.sh outputs to output/windows-<arch>/
+  const windowsSrc = path.join(WINDOWS_OUTPUT_DIR, 'windows-x86_64');
+  const dllSrc = path.join(windowsSrc, 'bin', 'supramark_markdown_native.dll');
+  if (!fileExists(dllSrc)) {
+    console.warn(`⚠  Windows: missing ${path.relative(REPO_ROOT, dllSrc)} (skip)`);
+    console.warn('   Run scripts/build-windows.sh from the crate root first.');
+    return false;
+  }
+  fs.rmSync(WINDOWS_FRAMEWORKS_DEST, { recursive: true, force: true });
+  const binDest = path.join(WINDOWS_FRAMEWORKS_DEST, 'bin');
+  const libDest = path.join(WINDOWS_FRAMEWORKS_DEST, 'lib');
+  const incDest = path.join(WINDOWS_FRAMEWORKS_DEST, 'include');
+  fs.mkdirSync(binDest, { recursive: true });
+  fs.mkdirSync(libDest, { recursive: true });
+  fs.mkdirSync(incDest, { recursive: true });
+  // DLL (runtime)
+  fs.copyFileSync(dllSrc, path.join(binDest, 'supramark_markdown_native.dll'));
+  // Import lib (if generated)
+  const libSrc = path.join(windowsSrc, 'lib', 'supramark_markdown_native.lib');
+  if (fileExists(libSrc)) {
+    fs.copyFileSync(libSrc, path.join(libDest, 'supramark_markdown_native.lib'));
+  }
+  // C ABI header
+  const headerSrc = path.join(windowsSrc, 'include', 'supramark_markdown.h');
+  const fallbackHeader = path.join(
+    REPO_ROOT, 'crates', 'supramark-markdown', 'packages', 'native', 'include', 'supramark_markdown.h'
+  );
+  if (fileExists(headerSrc)) {
+    fs.copyFileSync(headerSrc, path.join(incDest, 'supramark_markdown.h'));
+  } else if (fileExists(fallbackHeader)) {
+    fs.copyFileSync(fallbackHeader, path.join(incDest, 'supramark_markdown.h'));
+  }
+  console.log(
+    `✓ Windows: copied DLL + headers → ${path.relative(REPO_ROOT, WINDOWS_FRAMEWORKS_DEST)}/`
+  );
+  return true;
+}
+
 const ios = prepareIOS();
 const android = prepareAndroid();
 const macos = prepareMacOS();
+const windows = prepareWindows();
 
 // Copy the C ABI header into the package (used by Android CMake to be self-contained; iOS relies on the Headers inside the xcframework)
 function prepareHeader() {
@@ -168,7 +218,7 @@ function prepareHeader() {
 }
 const header = prepareHeader();
 
-if (!ios && !android && !macos) {
+if (!ios && !android && !macos && !windows) {
   console.error('No native artefacts found. Build the Rust crate first.');
   process.exit(1);
 }

--- a/crates/supramark-markdown/packages/react-native/src/resolveNative.ts
+++ b/crates/supramark-markdown/packages/react-native/src/resolveNative.ts
@@ -5,6 +5,8 @@ const LINKING_ERROR =
   Platform.select({
     ios: '- You have run `pod install`\n',
     android: '',
+    windows: '',
+    macos: '- You have run `pod install`\n',
     default: '',
   }) +
   '- You rebuilt the app after installing the package\n' +

--- a/crates/supramark-markdown/packages/react-native/windows/SupramarkMarkdownNative/ReactPackageProvider.cpp
+++ b/crates/supramark-markdown/packages/react-native/windows/SupramarkMarkdownNative/ReactPackageProvider.cpp
@@ -1,0 +1,21 @@
+/*
+ * ReactPackageProvider.cpp (Windows)
+ *
+ * Registers the SupramarkMarkdownModule with the React Native Windows runtime.
+ *
+ * Licensed under the Apache License, Version 2.0
+ */
+
+#include "ReactPackageProvider.h"
+#include "SupramarkMarkdownModule.h"
+
+#include <NativeModules.h>
+
+namespace winrt::SupramarkMarkdownNative::implementation {
+
+void ReactPackageProvider::CreatePackage(
+    winrt::Microsoft::ReactNative::IReactPackageBuilder const& packageBuilder) noexcept {
+    AddAttributedModules(packageBuilder, true);
+}
+
+} // namespace winrt::SupramarkMarkdownNative::implementation

--- a/crates/supramark-markdown/packages/react-native/windows/SupramarkMarkdownNative/ReactPackageProvider.h
+++ b/crates/supramark-markdown/packages/react-native/windows/SupramarkMarkdownNative/ReactPackageProvider.h
@@ -1,0 +1,21 @@
+/*
+ * ReactPackageProvider.h (Windows)
+ *
+ * Registers the SupramarkMarkdownModule with the React Native Windows runtime.
+ *
+ * Licensed under the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include <winrt/Microsoft.ReactNative.h>
+
+namespace winrt::SupramarkMarkdownNative::implementation {
+
+struct ReactPackageProvider
+    : winrt::implements<ReactPackageProvider, winrt::Microsoft::ReactNative::IReactPackageProvider> {
+
+    void CreatePackage(winrt::Microsoft::ReactNative::IReactPackageBuilder const& packageBuilder) noexcept;
+};
+
+} // namespace winrt::SupramarkMarkdownNative::implementation

--- a/crates/supramark-markdown/packages/react-native/windows/SupramarkMarkdownNative/SupramarkMarkdownModule.h
+++ b/crates/supramark-markdown/packages/react-native/windows/SupramarkMarkdownNative/SupramarkMarkdownModule.h
@@ -1,0 +1,77 @@
+/*
+ * SupramarkMarkdownModule.h (Windows)
+ *
+ * C++/WinRT React Native module for Markdown parsing on Windows.
+ * Bridges JS parseJson(source) calls to the C ABI exported by
+ * supramark_markdown_native.dll:
+ *
+ *   int32_t supramark_markdown_parse_json(const char* input, size_t input_len,
+ *                                         char** out_buf, size_t* out_len);
+ *   void    supramark_markdown_free(char* buf, size_t len);
+ *   const char* supramark_markdown_version(void);
+ *
+ * Licensed under the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include <string>
+#include <thread>
+
+#include <NativeModules.h>
+
+extern "C" {
+#include "supramark_markdown.h"
+}
+
+namespace winrt::SupramarkMarkdownNative::implementation {
+
+REACT_MODULE(SupramarkMarkdownModule, L"SupramarkMarkdownNative")
+struct SupramarkMarkdownModule {
+
+    REACT_METHOD(parseJson, L"parseJson")
+    void parseJson(std::string source, React::ReactPromise<std::string> promise) noexcept {
+        // Dispatch to a worker thread to avoid blocking the JS thread.
+        std::thread([this, source = std::move(source), promise = std::move(promise)]() mutable {
+            char *outBuf = nullptr;
+            size_t outLen = 0;
+
+            int32_t status = supramark_markdown_parse_json(
+                source.c_str(), source.size(), &outBuf, &outLen);
+
+            if (status != SUPRAMARK_MARKDOWN_OK) {
+                std::string code;
+                switch (status) {
+                    case SUPRAMARK_MARKDOWN_ERR_SERIALIZE: code = "SERIALIZE_ERROR"; break;
+                    case SUPRAMARK_MARKDOWN_ERR_NULL_INPUT: code = "NULL_INPUT"; break;
+                    default: code = "UNKNOWN"; break;
+                }
+                if (outBuf) supramark_markdown_free(outBuf, outLen);
+                promise.Reject(React::ReactError{
+                    code.c_str(),
+                    "supramark_markdown_parse_json failed"
+                });
+                return;
+            }
+
+            std::string json(outBuf, outLen);
+            supramark_markdown_free(outBuf, outLen);
+            promise.Resolve(std::move(json));
+        }).detach();
+    }
+
+    REACT_METHOD(getVersion, L"getVersion")
+    void getVersion(React::ReactPromise<std::string> promise) noexcept {
+        const char *version = supramark_markdown_version();
+        if (version) {
+            promise.Resolve(std::string(version));
+        } else {
+            promise.Reject(React::ReactError{
+                "UNKNOWN",
+                "supramark_markdown_version returned NULL"
+            });
+        }
+    }
+};
+
+} // namespace winrt::SupramarkMarkdownNative::implementation

--- a/crates/supramark-markdown/scripts/build-windows.sh
+++ b/crates/supramark-markdown/scripts/build-windows.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+#
+# Build supramark-markdown-native for Windows (MSVC).
+#
+# This crate is pure Rust — no external C dependencies like Graphviz.
+# We cross-compile the cdylib target to produce supramark_markdown_native.dll,
+# then stage the DLL + import lib + C header into output/windows-x86_64/.
+#
+# Requires:
+#   - Rust target x86_64-pc-windows-msvc installed:
+#       rustup target add x86_64-pc-windows-msvc
+#   - MSVC build tools (Visual Studio 2019+ or Build Tools)
+#   - Run on Windows (Git Bash / MSYS2) or via CI windows-latest runner.
+#
+# Usage:
+#   ./scripts/build-windows.sh [--arch x86_64|arm64]
+#
+# Environment variables:
+#   BUILD_DIR   - Build directory (default: build/windows-<arch>)
+#   INSTALL_DIR - Install prefix (default: output/windows-<arch>)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+CRATE_DIR="${PROJECT_ROOT}/packages/native"
+
+ARCH="x86_64"
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --arch) ARCH="$2"; shift 2 ;;
+        *) echo "Unknown option: $1"; exit 1 ;;
+    esac
+done
+
+case "$ARCH" in
+    x86_64|amd64) ARCH="x86_64" ;;
+    arm64|aarch64) ARCH="arm64" ;;
+    *) echo "Unsupported architecture: ${ARCH}. Must be x86_64 or arm64."; exit 1 ;;
+esac
+
+RUST_TARGET="${ARCH}-pc-windows-msvc"
+BUILD_DIR="${BUILD_DIR:-${PROJECT_ROOT}/build/windows-${ARCH}}"
+INSTALL_DIR="${INSTALL_DIR:-${PROJECT_ROOT}/output/windows-${ARCH}}"
+
+echo "[1/4] Checking Rust target ${RUST_TARGET}..."
+if ! rustup target list --installed | grep -q "${RUST_TARGET}"; then
+    echo "  Installing ${RUST_TARGET}..."
+    rustup target add "${RUST_TARGET}"
+fi
+
+echo "[2/4] Building supramark-markdown-native for ${RUST_TARGET}..."
+cd "${CRATE_DIR}"
+export CARGO_TARGET_DIR="${CRATE_DIR}/target"
+cargo build --release --target "${RUST_TARGET}"
+
+# The cdylib output
+case "$ARCH" in
+    x86_64) DLL_NAME="supramark_markdown_native.dll" ;;
+    arm64)  DLL_NAME="supramark_markdown_native.dll" ;;
+esac
+
+DLL_SRC="${CRATE_DIR}/target/${RUST_TARGET}/release/${DLL_NAME}"
+
+if [[ ! -f "${DLL_SRC}" ]]; then
+    echo "ERROR: Build output not found: ${DLL_SRC}"
+    exit 1
+fi
+
+echo "[3/4] Staging artifacts to ${INSTALL_DIR}..."
+mkdir -p "${INSTALL_DIR}/bin" "${INSTALL_DIR}/lib" "${INSTALL_DIR}/include"
+
+# Copy the runtime DLL
+cp "${DLL_SRC}" "${INSTALL_DIR}/bin/"
+
+# Copy the C ABI header
+HEADER_SRC="${CRATE_DIR}/include/supramark_markdown.h"
+if [[ -f "${HEADER_SRC}" ]]; then
+    cp "${HEADER_SRC}" "${INSTALL_DIR}/include/"
+else
+    echo "WARNING: C header not found at ${HEADER_SRC}"
+fi
+
+# Generate an import library (.lib) from the DLL using lib.exe.
+# This allows consumers to link against the DLL at build time.
+LIBEXE=""
+VSWHERE="C:/Program Files (x86)/Microsoft Visual Studio/Installer/vswhere.exe"
+if [[ -f "${VSWHERE}" ]]; then
+    VS_INSTALL="$("${VSWHERE}" -latest -products '*' -property installationPath 2>/dev/null | tr -d '\r')"
+    if [[ -n "${VS_INSTALL}" ]]; then
+        VC_VER_FILE="${VS_INSTALL}/VC/Auxiliary/Build/Microsoft.VCToolsVersion.default.txt"
+        if [[ -f "${VC_VER_FILE}" ]]; then
+            VC_VER="$(cat "${VC_VER_FILE}" | tr -d '[:space:]')"
+            case "$ARCH" in
+                x86_64) HOST_TOOL_DIRS=("Hostx64/x64" "Hostarm64/x64" "Hostx86/x64") ;;
+                arm64)  HOST_TOOL_DIRS=("Hostarm64/arm64" "Hostx64/arm64" "Hostx86/arm64") ;;
+            esac
+            for host_dir in "${HOST_TOOL_DIRS[@]}"; do
+                CANDIDATE="${VS_INSTALL}/VC/Tools/MSVC/${VC_VER}/bin/${host_dir}/lib.exe"
+                if [[ -f "${CANDIDATE}" ]]; then
+                    LIBEXE="${CANDIDATE}"
+                    break
+                fi
+            done
+        fi
+    fi
+fi
+# Fallback: rely on PATH (works when vcvarsall.bat has been sourced)
+if [[ -z "${LIBEXE}" ]]; then
+    LIBEXE="$(command -v lib.exe 2>/dev/null || command -v lib 2>/dev/null || true)"
+fi
+
+if [[ -n "${LIBEXE}" ]]; then
+    echo "[4/4] Generating import library..."
+    case "$ARCH" in
+        x86_64) LIB_MACHINE="X64" ;;
+        arm64)  LIB_MACHINE="ARM64" ;;
+    esac
+    DLL_WIN="$(cygpath -w "${INSTALL_DIR}/bin/${DLL_NAME}" 2>/dev/null || echo "${INSTALL_DIR}/bin/${DLL_NAME}")"
+    LIB_OUT_WIN="$(cygpath -w "${INSTALL_DIR}/lib/supramark_markdown_native.lib" 2>/dev/null || echo "${INSTALL_DIR}/lib/supramark_markdown_native.lib")"
+    MSYS2_ARG_CONV_EXCL='*' "${LIBEXE}" /NOLOGO \
+        "/MACHINE:${LIB_MACHINE}" \
+        "/DEF:${DLL_WIN%.dll}.def" \
+        "/OUT:${LIB_OUT_WIN}" 2>/dev/null || true
+    # If .def doesn't exist, generate a minimal one from the DLL exports
+    if [[ ! -f "${INSTALL_DIR}/lib/supramark_markdown_native.lib" ]]; then
+        DEF_FILE="${BUILD_DIR}/supramark_markdown_native.def"
+        mkdir -p "${BUILD_DIR}"
+        cat > "${DEF_FILE}" << 'DEF_EOF'
+LIBRARY supramark_markdown_native
+EXPORTS
+    supramark_markdown_parse_json
+    supramark_markdown_free
+    supramark_markdown_version
+DEF_EOF
+        DEF_WIN="$(cygpath -w "${DEF_FILE}" 2>/dev/null || echo "${DEF_FILE}")"
+        MSYS2_ARG_CONV_EXCL='*' "${LIBEXE}" /NOLOGO \
+            "/MACHINE:${LIB_MACHINE}" \
+            "/DEF:${DEF_WIN}" \
+            "/OUT:${LIB_OUT_WIN}" || echo "WARNING: import lib generation failed; DLL-only linking will be used"
+    fi
+else
+    echo "[4/4] WARNING: lib.exe not found; skipping import library generation."
+    echo "       Consumers will need to link directly against the DLL."
+fi
+
+echo ""
+echo "Windows ${ARCH} build complete: ${INSTALL_DIR}"
+echo "  DLL:   ${INSTALL_DIR}/bin/${DLL_NAME}"
+echo "  Header: ${INSTALL_DIR}/include/supramark_markdown.h"
+if [[ -f "${INSTALL_DIR}/lib/supramark_markdown_native.lib" ]]; then
+    echo "  Lib:   ${INSTALL_DIR}/lib/supramark_markdown_native.lib"
+fi


### PR DESCRIPTION
## Motivation

`@supramark/markdown-native-rn` currently has native bindings for iOS / Android / macOS only. On Windows, the package's `src/index.ts` `Platform.select` has no `windows` branch, so `parse()` falls back to the wasm path (`@supramark/markdown-web`) — which has not been verified to work in Hermes (the JS engine used by react-native-windows).

## Change

Add Windows native bindings for the markdown parser, following the same pattern as the existing iOS / Android / macOS bindings:

**New C++/WinRT module** — `crates/supramark-markdown/packages/react-native/windows/SupramarkMarkdownNative/`:
- `ReactPackageProvider.cpp` / `.h`: registers the module with the RNW runtime
- `SupramarkMarkdownModule.h`: defines the FFI signature, `dllimport` function declarations, and the `ReactPackage` template

**JS layer**:
- `package.json`: `files` adds `windows`, `peerDependenciesMeta` adds `react-native-windows`, adds a `react-native-windows` platform extension
- `src/index.ts`: `Platform.select` adds a `windows` branch
- `src/resolveNative.ts`: adds the windows resolution path
- `scripts/prepare-native.js`: Windows binary staging (copy `.dll` / `.h` / `.lib` to `windows/Frameworks/`)

**Build script** — `crates/supramark-markdown/scripts/build-windows.sh` (154 lines): cross-compiles the Rust crate to a Windows `.dll` via the C ABI.

**`gitignore`**:
- Root `.gitignore`: ignore Windows build artifacts
- `crates/supramark-markdown/packages/react-native/.gitignore`: add `windows/Frameworks/` (consistent with existing `ios/Frameworks/`, `macos/Frameworks/`)

## Risk

- Windows-only — no impact on iOS / Android / macOS
- 9 files, 339 lines
- FFI signature must match the Rust crate's `extern "C"` exports (verified by `build-windows.sh` linking against `output/windows-x86_64/include/supramark_markdown.h`)
- `prepare-native.js` Windows branch handles `x86_64` and `arm64` architectures

## Test plan

- [ ] Run `./build-windows.sh` in `crates/supramark-markdown` — expect `output/windows-x86_64/bin/supramark_markdown_native.dll` produced
- [ ] Run `npm run prepare-native` — expect `windows/Frameworks/{bin/*.dll, include/*.h, lib/*.lib}` populated
- [ ] In a host RNW app, side-effect `import '@supramark/markdown-native-rn'` at entry top — expect `parse()` succeeds on a sample markdown
- [ ] Verify the package resolves via `react-native.config.js` autolinking