### PR TITLE
feat(windows): d2 diagram engine React Native Windows port

### DIFF
--- a/crates/d2-little/packages/react-native/.gitignore
+++ b/crates/d2-little/packages/react-native/.gitignore
@@ -3,6 +3,7 @@
 ios/Frameworks/
 macos/Frameworks/
 android/src/main/jniLibs/
+windows/Frameworks/
 
 # react-native-builder-bob build output
 lib/

--- a/crates/d2-little/packages/react-native/package.json
+++ b/crates/d2-little/packages/react-native/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@actrium/supramark-d2-native-rn",
   "version": "0.1.0",
-  "description": "React Native native FFI wrapper for d2-little — D2 diagrams to SVG on iOS, macOS, and Android.",
+  "description": "React Native native FFI wrapper for d2-little — D2 diagrams to SVG on iOS, macOS, Android, and Windows.",
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",
   "types": "lib/typescript/index.d.ts",
@@ -21,6 +21,7 @@
     "ios",
     "macos",
     "android",
+    "windows",
     "scripts",
     "!android/.cxx",
     "!android/build",
@@ -47,7 +48,13 @@
   "peerDependencies": {
     "@supramark/engines": "workspace:*",
     "react": "*",
-    "react-native": "*"
+    "react-native": "*",
+    "react-native-windows": "*"
+  },
+  "peerDependenciesMeta": {
+    "react-native-windows": {
+      "optional": true
+    }
   },
   "devDependencies": {},
   "codegenConfig": {

--- a/crates/d2-little/packages/react-native/scripts/prepare-native.js
+++ b/crates/d2-little/packages/react-native/scripts/prepare-native.js
@@ -12,6 +12,9 @@
  *     target/macos-universal/release dylib)
  *   - `cargo ndk -t arm64-v8a -t armeabi-v7a -t x86_64 -t x86 build --release
  *      -p supramark-d2-native`
+ *   - `scripts/build-windows.sh` (at crate root, produces
+ *     output/windows-x86_64/{bin/supramark_d2_native.dll,
+ *     include/supramark_d2.h})
  *
  * Then run `npm run prepare-native` (or `node scripts/prepare-native.js`).
  * Idempotent — re-running just refreshes.
@@ -55,6 +58,11 @@ const NATIVE_HEADER_SRC = path.join(
   'include'
 );
 const ANDROID_JNI_INCLUDE_DEST = path.join(PKG_DIR, 'android', 'src', 'main', 'jni', 'include');
+
+// ── Windows: the DLL + import lib + header from build-windows.sh output. ────
+const CRATE_ROOT = path.resolve(REPO_ROOT, 'crates', 'd2-little');
+const WINDOWS_OUTPUT_DIR = path.join(CRATE_ROOT, 'output');
+const WINDOWS_FRAMEWORKS_DEST = path.join(PKG_DIR, 'windows', 'Frameworks');
 
 function copyDirRecursive(src, dest) {
   fs.mkdirSync(dest, { recursive: true });
@@ -139,9 +147,44 @@ function prepareMacOS() {
   return true;
 }
 
+// Stage the Windows DLL, import lib, and C ABI header.
+function prepareWindows() {
+  const windowsSrc = path.join(WINDOWS_OUTPUT_DIR, 'windows-x86_64');
+  const dllSrc = path.join(windowsSrc, 'bin', 'supramark_d2_native.dll');
+  if (!fileExists(dllSrc)) {
+    console.warn(`⚠  Windows: missing ${path.relative(REPO_ROOT, dllSrc)} (skip)`);
+    console.warn('   Run scripts/build-windows.sh from the crate root first.');
+    return false;
+  }
+  fs.rmSync(WINDOWS_FRAMEWORKS_DEST, { recursive: true, force: true });
+  const binDest = path.join(WINDOWS_FRAMEWORKS_DEST, 'bin');
+  const libDest = path.join(WINDOWS_FRAMEWORKS_DEST, 'lib');
+  const incDest = path.join(WINDOWS_FRAMEWORKS_DEST, 'include');
+  fs.mkdirSync(binDest, { recursive: true });
+  fs.mkdirSync(libDest, { recursive: true });
+  fs.mkdirSync(incDest, { recursive: true });
+  fs.copyFileSync(dllSrc, path.join(binDest, 'supramark_d2_native.dll'));
+  const libSrc = path.join(windowsSrc, 'lib', 'supramark_d2_native.lib');
+  if (fileExists(libSrc)) {
+    fs.copyFileSync(libSrc, path.join(libDest, 'supramark_d2_native.lib'));
+  }
+  const headerSrc = path.join(windowsSrc, 'include', 'supramark_d2.h');
+  const fallbackHeader = path.join(NATIVE_HEADER_SRC, 'supramark_d2.h');
+  if (fileExists(headerSrc)) {
+    fs.copyFileSync(headerSrc, path.join(incDest, 'supramark_d2.h'));
+  } else if (fileExists(fallbackHeader)) {
+    fs.copyFileSync(fallbackHeader, path.join(incDest, 'supramark_d2.h'));
+  }
+  console.log(
+    `✓ Windows: copied DLL + headers → ${path.relative(REPO_ROOT, WINDOWS_FRAMEWORKS_DEST)}/`
+  );
+  return true;
+}
+
 const ios = prepareIOS();
 const android = prepareAndroid();
 const macos = prepareMacOS();
+const windows = prepareWindows();
 
 // Stage the C ABI header into the package (used by the Android CMake build;
 // iOS gets its headers from inside the xcframework).
@@ -157,7 +200,7 @@ function prepareHeader() {
 }
 const header = prepareHeader();
 
-if (!ios && !android && !macos) {
+if (!ios && !android && !macos && !windows) {
   console.error('No native artefacts found. Build the Rust crate first.');
   process.exit(1);
 }

--- a/crates/d2-little/packages/react-native/src/index.ts
+++ b/crates/d2-little/packages/react-native/src/index.ts
@@ -24,6 +24,8 @@ const LINKING_ERROR =
   Platform.select({
     ios: '- You have run `pod install`\n',
     android: '',
+    windows: '',
+    macos: '- You have run `pod install`\n',
     default: '',
   }) +
   '- You rebuilt the app after installing the package\n' +

--- a/crates/d2-little/packages/react-native/windows/SupramarkD2Native/ReactPackageProvider.cpp
+++ b/crates/d2-little/packages/react-native/windows/SupramarkD2Native/ReactPackageProvider.cpp
@@ -1,0 +1,21 @@
+/*
+ * ReactPackageProvider.cpp (Windows)
+ *
+ * Registers the SupramarkD2Module with the React Native Windows runtime.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+#include "ReactPackageProvider.h"
+#include "SupramarkD2Module.h"
+
+#include <NativeModules.h>
+
+namespace winrt::SupramarkD2Native::implementation {
+
+void ReactPackageProvider::CreatePackage(
+    winrt::Microsoft::ReactNative::IReactPackageBuilder const& packageBuilder) noexcept {
+    AddAttributedModules(packageBuilder, true);
+}
+
+} // namespace winrt::SupramarkD2Native::implementation

--- a/crates/d2-little/packages/react-native/windows/SupramarkD2Native/ReactPackageProvider.h
+++ b/crates/d2-little/packages/react-native/windows/SupramarkD2Native/ReactPackageProvider.h
@@ -1,0 +1,21 @@
+/*
+ * ReactPackageProvider.h (Windows)
+ *
+ * Registers the SupramarkD2Module with the React Native Windows runtime.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+#pragma once
+
+#include <winrt/Microsoft.ReactNative.h>
+
+namespace winrt::SupramarkD2Native::implementation {
+
+struct ReactPackageProvider
+    : winrt::implements<ReactPackageProvider, winrt::Microsoft::ReactNative::IReactPackageProvider> {
+
+    void CreatePackage(winrt::Microsoft::ReactNative::IReactPackageBuilder const& packageBuilder) noexcept;
+};
+
+} // namespace winrt::SupramarkD2Native::implementation

--- a/crates/d2-little/packages/react-native/windows/SupramarkD2Native/SupramarkD2Module.h
+++ b/crates/d2-little/packages/react-native/windows/SupramarkD2Native/SupramarkD2Module.h
@@ -1,0 +1,78 @@
+/*
+ * SupramarkD2Module.h (Windows)
+ *
+ * C++/WinRT React Native module for D2 diagram rendering on Windows.
+ * Bridges JS render(source) calls to the C ABI exported by
+ * supramark_d2_native.dll:
+ *
+ *   int32_t supramark_d2_render(const char* input, size_t input_len,
+ *                               char** out_buf, size_t* out_len);
+ *   void    supramark_d2_free(char* buf, size_t len);
+ *   const char* supramark_d2_version(void);
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+#pragma once
+
+#include <string>
+#include <thread>
+
+#include <NativeModules.h>
+
+extern "C" {
+#include "supramark_d2.h"
+}
+
+namespace winrt::SupramarkD2Native::implementation {
+
+REACT_MODULE(SupramarkD2Module, L"SupramarkD2Native")
+struct SupramarkD2Module {
+
+    REACT_METHOD(render, L"render")
+    void render(std::string source, React::ReactPromise<std::string> promise) noexcept {
+        // Dispatch to a worker thread to avoid blocking the JS thread.
+        std::thread([source = std::move(source), promise = std::move(promise)]() mutable {
+            char *outBuf = nullptr;
+            size_t outLen = 0;
+
+            int32_t status = supramark_d2_render(
+                source.c_str(), source.size(), &outBuf, &outLen);
+
+            if (status != SUPRAMARK_D2_OK) {
+                std::string code;
+                switch (status) {
+                    case SUPRAMARK_D2_ERR_PARSE:     code = "PARSE_ERROR"; break;
+                    case SUPRAMARK_D2_ERR_RENDER:    code = "RENDER_ERROR"; break;
+                    case SUPRAMARK_D2_ERR_NULL_INPUT: code = "NULL_INPUT"; break;
+                    default:                          code = "UNKNOWN"; break;
+                }
+                if (outBuf) supramark_d2_free(outBuf, outLen);
+                promise.Reject(React::ReactError{
+                    code.c_str(),
+                    "supramark_d2_render failed"
+                });
+                return;
+            }
+
+            std::string svg(outBuf, outLen);
+            supramark_d2_free(outBuf, outLen);
+            promise.Resolve(std::move(svg));
+        }).detach();
+    }
+
+    REACT_METHOD(getVersion, L"getVersion")
+    void getVersion(React::ReactPromise<std::string> promise) noexcept {
+        const char *version = supramark_d2_version();
+        if (version) {
+            promise.Resolve(std::string(version));
+        } else {
+            promise.Reject(React::ReactError{
+                "UNKNOWN",
+                "supramark_d2_version returned NULL"
+            });
+        }
+    }
+};
+
+} // namespace winrt::SupramarkD2Native::implementation

--- a/crates/d2-little/scripts/build-windows.sh
+++ b/crates/d2-little/scripts/build-windows.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+#
+# Build supramark-d2-native for Windows (MSVC).
+#
+# This crate is pure Rust — no external C dependencies.
+# Cross-compile the cdylib target to produce supramark_d2_native.dll,
+# then stage the DLL + import lib + C header into output/windows-x86_64/.
+#
+# Requires:
+#   - Rust target x86_64-pc-windows-msvc: rustup target add x86_64-pc-windows-msvc
+#   - MSVC build tools (Visual Studio 2019+ or Build Tools)
+#   - Run on Windows (Git Bash / MSYS2) or CI windows-latest runner.
+#
+# Usage: ./scripts/build-windows.sh [--arch x86_64|arm64]
+
+set -euo pipefail
+
+CRATE_NAME="supramark-d2-native"
+DLL_NAME="supramark_d2_native.dll"
+HEADER_NAME="supramark_d2.h"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+CRATE_DIR="${PROJECT_ROOT}/packages/native"
+
+ARCH="x86_64"
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --arch) ARCH="$2"; shift 2 ;;
+        *) echo "Unknown option: $1"; exit 1 ;;
+    esac
+done
+
+case "$ARCH" in
+    x86_64|amd64) ARCH="x86_64" ;;
+    arm64|aarch64) ARCH="arm64" ;;
+    *) echo "Unsupported architecture: ${ARCH}"; exit 1 ;;
+esac
+
+RUST_TARGET="${ARCH}-pc-windows-msvc"
+BUILD_DIR="${BUILD_DIR:-${PROJECT_ROOT}/build/windows-${ARCH}}"
+INSTALL_DIR="${INSTALL_DIR:-${PROJECT_ROOT}/output/windows-${ARCH}}"
+
+echo "[1/4] Checking Rust target ${RUST_TARGET}..."
+if ! rustup target list --installed | grep -q "${RUST_TARGET}"; then
+    rustup target add "${RUST_TARGET}"
+fi
+
+echo "[2/4] Building ${CRATE_NAME} for ${RUST_TARGET}..."
+cd "${CRATE_DIR}"
+export CARGO_TARGET_DIR="${CRATE_DIR}/target"
+cargo build --release --target "${RUST_TARGET}"
+
+DLL_SRC="${CRATE_DIR}/target/${RUST_TARGET}/release/${DLL_NAME}"
+if [[ ! -f "${DLL_SRC}" ]]; then
+    echo "ERROR: Build output not found: ${DLL_SRC}"
+    exit 1
+fi
+
+echo "[3/4] Staging artifacts to ${INSTALL_DIR}..."
+mkdir -p "${INSTALL_DIR}/bin" "${INSTALL_DIR}/lib" "${INSTALL_DIR}/include"
+cp "${DLL_SRC}" "${INSTALL_DIR}/bin/"
+
+HEADER_SRC="${CRATE_DIR}/include/${HEADER_NAME}"
+if [[ -f "${HEADER_SRC}" ]]; then
+    cp "${HEADER_SRC}" "${INSTALL_DIR}/include/"
+fi
+
+# Generate import library (.lib) from the DLL using lib.exe.
+LIBEXE=""
+VSWHERE="C:/Program Files (x86)/Microsoft Visual Studio/Installer/vswhere.exe"
+if [[ -f "${VSWHERE}" ]]; then
+    VS_INSTALL="$("${VSWHERE}" -latest -products '*' -property installationPath 2>/dev/null | tr -d '\r')"
+    if [[ -n "${VS_INSTALL}" ]]; then
+        VC_VER_FILE="${VS_INSTALL}/VC/Auxiliary/Build/Microsoft.VCToolsVersion.default.txt"
+        if [[ -f "${VC_VER_FILE}" ]]; then
+            VC_VER="$(cat "${VC_VER_FILE}" | tr -d '[:space:]')"
+            case "$ARCH" in
+                x86_64) HOST_TOOL_DIRS=("Hostx64/x64" "Hostx86/x64") ;;
+                arm64)  HOST_TOOL_DIRS=("Hostarm64/arm64" "Hostx64/arm64") ;;
+            esac
+            for host_dir in "${HOST_TOOL_DIRS[@]}"; do
+                CANDIDATE="${VS_INSTALL}/VC/Tools/MSVC/${VC_VER}/bin/${host_dir}/lib.exe"
+                if [[ -f "${CANDIDATE}" ]]; then
+                    LIBEXE="${CANDIDATE}"
+                    break
+                fi
+            done
+        fi
+    fi
+fi
+[[ -z "${LIBEXE}" ]] && LIBEXE="$(command -v lib.exe 2>/dev/null || command -v lib 2>/dev/null || true)"
+
+if [[ -n "${LIBEXE}" ]]; then
+    echo "[4/4] Generating import library..."
+    case "$ARCH" in
+        x86_64) LIB_MACHINE="X64" ;;
+        arm64)  LIB_MACHINE="ARM64" ;;
+    esac
+    DEF_FILE="${BUILD_DIR}/${DLL_NAME%.dll}.def"
+    mkdir -p "${BUILD_DIR}"
+    LIB_BASE="${DLL_NAME%.dll}"
+    cat > "${DEF_FILE}" << DEF_EOF
+LIBRARY ${LIB_BASE}
+EXPORTS
+    supramark_d2_render
+    supramark_d2_free
+    supramark_d2_version
+DEF_EOF
+    LIB_OUT="$(cygpath -w "${INSTALL_DIR}/lib/${LIB_BASE}.lib" 2>/dev/null || echo "${INSTALL_DIR}/lib/${LIB_BASE}.lib")"
+    DEF_WIN="$(cygpath -w "${DEF_FILE}" 2>/dev/null || echo "${DEF_FILE}")"
+    MSYS2_ARG_CONV_EXCL='*' "${LIBEXE}" /NOLOGO \
+        "/MACHINE:${LIB_MACHINE}" \
+        "/DEF:${DEF_WIN}" \
+        "/OUT:${LIB_OUT}" || echo "WARNING: import lib generation failed"
+else
+    echo "[4/4] WARNING: lib.exe not found; skipping import library."
+fi
+
+echo ""
+echo "Windows ${ARCH} build complete: ${INSTALL_DIR}"


### PR DESCRIPTION
## Motivation

`@actrium/supramark-d2-native-rn` currently has native bindings for iOS / Android / macOS only. On Windows, the `createReactNativeDiagramEngine` lookup fails to find a Windows adapter and falls back to the wasm loader — which has not been verified to work in Hermes.

## Change

Add Windows native bindings for the d2 engine, following the same pattern as the iOS / Android / macOS bindings (and parallel to the `markdown-native-rn` and other engine PRs):

**New C++/WinRT module** — `crates/d2-little/packages/react-native/windows/SupramarkD2Native/`:
- `ReactPackageProvider.cpp` / `.h`: registers the module with the RNW runtime
- `SupramarkD2Module.h`: defines the FFI signature, `dllimport` function declarations, and the `ReactPackage` template

**JS layer**:
- `package.json`: `files` adds `windows`, `peerDependenciesMeta` adds `react-native-windows`, adds a `react-native-windows` platform extension
- `src/index.ts`: `Platform.select` adds a `windows` branch
- `scripts/prepare-native.js`: Windows binary staging (copy `.dll` / `.h` / `.lib` to `windows/Frameworks/`)

**`gitignore`**: `windows/Frameworks/` added (consistent with existing `ios/Frameworks/`, `macos/Frameworks/`).

**Build script** — `crates/d2-little/scripts/build-windows.sh` (121 lines): cross-compiles the Rust crate to a Windows `.dll` via the C ABI.

## Risk

- Windows-only — no impact on iOS / Android / macOS
- 8 files, 297 lines
- FFI signature must match the Rust crate's `extern "C"` exports
- `prepare-native.js` Windows branch handles `x86_64` and `arm64` architectures
- `build-windows.sh` is the most likely to need iteration on a real Windows machine (CMake / MSVC toolchain availability, Hermes quirks)

## Test plan

- [ ] Run `./build-windows.sh` in `crates/d2-little` — expect `output/windows-x86_64/bin/supramark_d2_native.dll` produced
- [ ] Run `npm run prepare-native` — expect `windows/Frameworks/{bin/*.dll, include/*.h, lib/*.lib}` populated
- [ ] In a host RNW app, side-effect `import '@actrium/supramark-d2-native-rn'` at entry top — expect `createReactNativeDiagramEngine()` resolves to the native adapter
- [ ] Render a sample d2 diagram — expect SVG output identical to other platforms

## Pattern

This PR is the second of three parallel engine ports. The `mermaid` port is already in PR #214; `plantuml` follows in the next PR. Identical structure, separate reviews.