### PR TITLE
feat(windows): plantuml diagram engine React Native Windows port

### DIFF
--- a/crates/plantuml-little/packages/react-native/.gitignore
+++ b/crates/plantuml-little/packages/react-native/.gitignore
@@ -3,6 +3,7 @@
 ios/Frameworks/
 macos/Frameworks/
 android/src/main/jniLibs/
+windows/Frameworks/
 
 # react-native-builder-bob build output
 lib/

--- a/crates/plantuml-little/packages/react-native/package.json
+++ b/crates/plantuml-little/packages/react-native/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@actrium/supramark-plantuml-native-rn",
   "version": "0.1.0",
-  "description": "React Native native FFI wrapper for plantuml-little — PlantUML diagrams to SVG on iOS, macOS, and Android.",
+  "description": "React Native native FFI wrapper for plantuml-little — PlantUML diagrams to SVG on iOS, macOS, Android, and Windows.",
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",
   "types": "lib/typescript/index.d.ts",
@@ -21,6 +21,7 @@
     "ios",
     "macos",
     "android",
+    "windows",
     "scripts",
     "!android/.cxx",
     "!android/build",
@@ -47,7 +48,13 @@
   "peerDependencies": {
     "@supramark/engines": "workspace:*",
     "react": "*",
-    "react-native": "*"
+    "react-native": "*",
+    "react-native-windows": "*"
+  },
+  "peerDependenciesMeta": {
+    "react-native-windows": {
+      "optional": true
+    }
   },
   "devDependencies": {},
   "codegenConfig": {

--- a/crates/plantuml-little/packages/react-native/scripts/prepare-native.js
+++ b/crates/plantuml-little/packages/react-native/scripts/prepare-native.js
@@ -12,6 +12,9 @@
  *     target/macos-universal/release dylib)
  *   - `cargo ndk -t arm64-v8a -t armeabi-v7a -t x86_64 -t x86 build --release
  *      -p supramark-plantuml-native`
+ *   - `scripts/build-windows.sh` (at crate root, produces
+ *     output/windows-x86_64/{bin/supramark_plantuml_native.dll,
+ *     include/supramark_plantuml.h})
  *
  * Then run `npm run prepare-native` (or `node scripts/prepare-native.js`).
  * Idempotent — re-running just refreshes.
@@ -59,6 +62,11 @@ const NATIVE_HEADER_SRC = path.join(
   'include'
 );
 const ANDROID_JNI_INCLUDE_DEST = path.join(PKG_DIR, 'android', 'src', 'main', 'jni', 'include');
+
+// ── Windows: the DLL + import lib + header from build-windows.sh output. ────
+const CRATE_ROOT = path.resolve(REPO_ROOT, 'crates', 'plantuml-little');
+const WINDOWS_OUTPUT_DIR = path.join(CRATE_ROOT, 'output');
+const WINDOWS_FRAMEWORKS_DEST = path.join(PKG_DIR, 'windows', 'Frameworks');
 
 function copyDirRecursive(src, dest) {
   fs.mkdirSync(dest, { recursive: true });
@@ -146,9 +154,44 @@ function prepareMacOS() {
   return true;
 }
 
+// Stage the Windows DLL, import lib, and C ABI header.
+function prepareWindows() {
+  const windowsSrc = path.join(WINDOWS_OUTPUT_DIR, 'windows-x86_64');
+  const dllSrc = path.join(windowsSrc, 'bin', 'supramark_plantuml_native.dll');
+  if (!fileExists(dllSrc)) {
+    console.warn(`⚠  Windows: missing ${path.relative(REPO_ROOT, dllSrc)} (skip)`);
+    console.warn('   Run scripts/build-windows.sh from the crate root first.');
+    return false;
+  }
+  fs.rmSync(WINDOWS_FRAMEWORKS_DEST, { recursive: true, force: true });
+  const binDest = path.join(WINDOWS_FRAMEWORKS_DEST, 'bin');
+  const libDest = path.join(WINDOWS_FRAMEWORKS_DEST, 'lib');
+  const incDest = path.join(WINDOWS_FRAMEWORKS_DEST, 'include');
+  fs.mkdirSync(binDest, { recursive: true });
+  fs.mkdirSync(libDest, { recursive: true });
+  fs.mkdirSync(incDest, { recursive: true });
+  fs.copyFileSync(dllSrc, path.join(binDest, 'supramark_plantuml_native.dll'));
+  const libSrc = path.join(windowsSrc, 'lib', 'supramark_plantuml_native.lib');
+  if (fileExists(libSrc)) {
+    fs.copyFileSync(libSrc, path.join(libDest, 'supramark_plantuml_native.lib'));
+  }
+  const headerSrc = path.join(windowsSrc, 'include', 'supramark_plantuml.h');
+  const fallbackHeader = path.join(NATIVE_HEADER_SRC, 'supramark_plantuml.h');
+  if (fileExists(headerSrc)) {
+    fs.copyFileSync(headerSrc, path.join(incDest, 'supramark_plantuml.h'));
+  } else if (fileExists(fallbackHeader)) {
+    fs.copyFileSync(fallbackHeader, path.join(incDest, 'supramark_plantuml.h'));
+  }
+  console.log(
+    `✓ Windows: copied DLL + headers → ${path.relative(REPO_ROOT, WINDOWS_FRAMEWORKS_DEST)}/`
+  );
+  return true;
+}
+
 const ios = prepareIOS();
 const android = prepareAndroid();
 const macos = prepareMacOS();
+const windows = prepareWindows();
 
 // Stage the C ABI header into the package (used by the Android CMake build;
 // iOS gets its headers from inside the xcframework).
@@ -164,7 +207,7 @@ function prepareHeader() {
 }
 const header = prepareHeader();
 
-if (!ios && !android && !macos) {
+if (!ios && !android && !macos && !windows) {
   console.error('No native artefacts found. Build the Rust crate first.');
   process.exit(1);
 }

--- a/crates/plantuml-little/packages/react-native/src/index.ts
+++ b/crates/plantuml-little/packages/react-native/src/index.ts
@@ -24,6 +24,8 @@ const LINKING_ERROR =
   Platform.select({
     ios: '- You have run `pod install`\n',
     android: '',
+    windows: '',
+    macos: '- You have run `pod install`\n',
     default: '',
   }) +
   '- You rebuilt the app after installing the package\n' +

--- a/crates/plantuml-little/packages/react-native/windows/SupramarkPlantumlNative/ReactPackageProvider.cpp
+++ b/crates/plantuml-little/packages/react-native/windows/SupramarkPlantumlNative/ReactPackageProvider.cpp
@@ -1,0 +1,21 @@
+/*
+ * ReactPackageProvider.cpp (Windows)
+ *
+ * Registers the SupramarkPlantumlModule with the React Native Windows runtime.
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later OR LGPL-3.0-or-later OR Apache-2.0 OR EPL-2.0 OR MIT
+ */
+
+#include "ReactPackageProvider.h"
+#include "SupramarkPlantumlModule.h"
+
+#include <NativeModules.h>
+
+namespace winrt::SupramarkPlantumlNative::implementation {
+
+void ReactPackageProvider::CreatePackage(
+    winrt::Microsoft::ReactNative::IReactPackageBuilder const& packageBuilder) noexcept {
+    AddAttributedModules(packageBuilder, true);
+}
+
+} // namespace winrt::SupramarkPlantumlNative::implementation

--- a/crates/plantuml-little/packages/react-native/windows/SupramarkPlantumlNative/ReactPackageProvider.h
+++ b/crates/plantuml-little/packages/react-native/windows/SupramarkPlantumlNative/ReactPackageProvider.h
@@ -1,0 +1,21 @@
+/*
+ * ReactPackageProvider.h (Windows)
+ *
+ * Registers the SupramarkPlantumlModule with the React Native Windows runtime.
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later OR LGPL-3.0-or-later OR Apache-2.0 OR EPL-2.0 OR MIT
+ */
+
+#pragma once
+
+#include <winrt/Microsoft.ReactNative.h>
+
+namespace winrt::SupramarkPlantumlNative::implementation {
+
+struct ReactPackageProvider
+    : winrt::implements<ReactPackageProvider, winrt::Microsoft::ReactNative::IReactPackageProvider> {
+
+    void CreatePackage(winrt::Microsoft::ReactNative::IReactPackageBuilder const& packageBuilder) noexcept;
+};
+
+} // namespace winrt::SupramarkPlantumlNative::implementation

--- a/crates/plantuml-little/packages/react-native/windows/SupramarkPlantumlNative/SupramarkPlantumlModule.h
+++ b/crates/plantuml-little/packages/react-native/windows/SupramarkPlantumlNative/SupramarkPlantumlModule.h
@@ -1,0 +1,79 @@
+/*
+ * SupramarkPlantumlModule.h (Windows)
+ *
+ * C++/WinRT React Native module for PlantUML rendering on Windows.
+ * Bridges JS render(source) calls to the C ABI exported by
+ * supramark_plantuml_native.dll:
+ *
+ *   int  supramark_plantuml_render(const char *input, size_t input_len,
+ *                                  uint8_t **out_buf, size_t *out_len);
+ *   void supramark_plantuml_free(uint8_t *buf, size_t len);
+ *   const char *supramark_plantuml_version(void);
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later OR LGPL-3.0-or-later OR Apache-2.0 OR EPL-2.0 OR MIT
+ */
+
+#pragma once
+
+#include <string>
+#include <thread>
+#include <cstdint>
+
+#include <NativeModules.h>
+
+extern "C" {
+#include "supramark_plantuml.h"
+}
+
+namespace winrt::SupramarkPlantumlNative::implementation {
+
+REACT_MODULE(SupramarkPlantumlModule, L"SupramarkPlantumlNative")
+struct SupramarkPlantumlModule {
+
+    REACT_METHOD(render, L"render")
+    void render(std::string source, React::ReactPromise<std::string> promise) noexcept {
+        // Dispatch to a worker thread to avoid blocking the JS thread.
+        std::thread([source = std::move(source), promise = std::move(promise)]() mutable {
+            uint8_t *outBuf = nullptr;
+            size_t outLen = 0;
+
+            int status = supramark_plantuml_render(
+                source.c_str(), source.size(), &outBuf, &outLen);
+
+            if (status != SUPRAMARK_PLANTUML_OK) {
+                std::string code;
+                switch (status) {
+                    case SUPRAMARK_PLANTUML_ERR_PARSE:     code = "PARSE_ERROR"; break;
+                    case SUPRAMARK_PLANTUML_ERR_RENDER:    code = "RENDER_ERROR"; break;
+                    case SUPRAMARK_PLANTUML_ERR_NULL_INPUT: code = "NULL_INPUT"; break;
+                    default:                                code = "UNKNOWN"; break;
+                }
+                if (outBuf) supramark_plantuml_free(outBuf, outLen);
+                promise.Reject(React::ReactError{
+                    code.c_str(),
+                    "supramark_plantuml_render failed"
+                });
+                return;
+            }
+
+            std::string svg(reinterpret_cast<const char *>(outBuf), outLen);
+            supramark_plantuml_free(outBuf, outLen);
+            promise.Resolve(std::move(svg));
+        }).detach();
+    }
+
+    REACT_METHOD(getVersion, L"getVersion")
+    void getVersion(React::ReactPromise<std::string> promise) noexcept {
+        const char *version = supramark_plantuml_version();
+        if (version) {
+            promise.Resolve(std::string(version));
+        } else {
+            promise.Reject(React::ReactError{
+                "UNKNOWN",
+                "supramark_plantuml_version returned NULL"
+            });
+        }
+    }
+};
+
+} // namespace winrt::SupramarkPlantumlNative::implementation

--- a/crates/plantuml-little/scripts/build-windows.sh
+++ b/crates/plantuml-little/scripts/build-windows.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+#
+# Build supramark-plantuml-native for Windows (MSVC).
+#
+# supramark-plantuml-native depends on graphviz-anywhere (native Graphviz C
+# bindings), so this is NOT a pure-Rust build: the Graphviz static library
+# (graphviz_api_static.lib) must exist before cargo runs. This script builds it
+# first via crates/graphviz-anywhere/scripts/build-windows.sh unless
+# GRAPHVIZ_ANYWHERE_DIR already points at a prebuilt output/windows-<arch> tree.
+#
+# Cross-compile the cdylib target to produce supramark_plantuml_native.dll,
+# then stage the DLL + import lib + C header into output/windows-<arch>/.
+#
+# Requires:
+#   - Rust target x86_64-pc-windows-msvc: rustup target add x86_64-pc-windows-msvc
+#   - MSVC build tools (Visual Studio 2019+ or Build Tools)
+#   - CMake + a C/C++ compiler (for the Graphviz native build)
+#   - Run on Windows (Git Bash / MSYS2) or CI windows-latest runner.
+#
+# Usage: ./scripts/build-windows.sh [--arch x86_64|arm64]
+
+set -euo pipefail
+
+CRATE_NAME="supramark-plantuml-native"
+DLL_NAME="supramark_plantuml_native.dll"
+HEADER_NAME="supramark_plantuml.h"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+CRATE_DIR="${PROJECT_ROOT}/packages/native"
+
+ARCH="x86_64"
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --arch) ARCH="$2"; shift 2 ;;
+        *) echo "Unknown option: $1"; exit 1 ;;
+    esac
+done
+
+case "$ARCH" in
+    x86_64|amd64) ARCH="x86_64" ;;
+    arm64|aarch64) ARCH="arm64" ;;
+    *) echo "Unsupported architecture: ${ARCH}"; exit 1 ;;
+esac
+
+# Rust names the MSVC triples x86_64-/aarch64-pc-windows-msvc; the arm64 alias
+# does NOT map to "arm64-pc-windows-msvc", so map it explicitly. Keep ARCH as
+# "arm64" for directory names (matches graphviz-anywhere's output/windows-arm64).
+case "$ARCH" in
+    x86_64) RUST_TARGET="x86_64-pc-windows-msvc" ;;
+    arm64)  RUST_TARGET="aarch64-pc-windows-msvc" ;;
+esac
+BUILD_DIR="${BUILD_DIR:-${PROJECT_ROOT}/build/windows-${ARCH}}"
+INSTALL_DIR="${INSTALL_DIR:-${PROJECT_ROOT}/output/windows-${ARCH}}"
+
+echo "[1/5] Checking Rust target ${RUST_TARGET}..."
+if ! rustup target list --installed | grep -q "${RUST_TARGET}"; then
+    rustup target add "${RUST_TARGET}"
+fi
+
+# supramark-plantuml-native links graphviz-anywhere, whose build.rs locates the
+# Graphviz static library through GRAPHVIZ_ANYWHERE_DIR (searched as
+# <dir>/lib/graphviz_api_static.lib) and aborts the build when it is missing.
+# Resolve it up front so a clean tree builds without manual intervention.
+REPO_ROOT="$(cd "${PROJECT_ROOT}/../.." && pwd)"
+GRAPHVIZ_CRATE="${REPO_ROOT}/crates/graphviz-anywhere"
+GRAPHVIZ_OUTPUT="${GRAPHVIZ_CRATE}/output/windows-${ARCH}"
+
+echo "[2/5] Resolving Graphviz native library..."
+if [[ -n "${GRAPHVIZ_ANYWHERE_DIR:-}" && -f "${GRAPHVIZ_ANYWHERE_DIR}/lib/graphviz_api_static.lib" ]]; then
+    echo "      Using prebuilt Graphviz: ${GRAPHVIZ_ANYWHERE_DIR}"
+elif [[ -f "${GRAPHVIZ_OUTPUT}/lib/graphviz_api_static.lib" ]]; then
+    export GRAPHVIZ_ANYWHERE_DIR="${GRAPHVIZ_OUTPUT}"
+    echo "      Using prebuilt Graphviz: ${GRAPHVIZ_ANYWHERE_DIR}"
+else
+    if [[ ! -f "${GRAPHVIZ_CRATE}/scripts/build-windows.sh" ]]; then
+        echo "ERROR: graphviz-anywhere crate not found at ${GRAPHVIZ_CRATE}" >&2
+        exit 1
+    fi
+    # prepare_graphviz_source() copies from the graphviz/ submodule; make sure
+    # it is checked out before invoking the Graphviz build.
+    if [[ ! -f "${GRAPHVIZ_CRATE}/graphviz/CMakeLists.txt" ]]; then
+        echo "      Initializing graphviz submodule..."
+        git -C "${REPO_ROOT}" submodule update --init crates/graphviz-anywhere/graphviz
+    fi
+    echo "      Building Graphviz for windows-${ARCH} (this can take a while)..."
+    "${GRAPHVIZ_CRATE}/scripts/build-windows.sh" --arch "${ARCH}"
+    export GRAPHVIZ_ANYWHERE_DIR="${GRAPHVIZ_OUTPUT}"
+fi
+
+echo "[3/5] Building ${CRATE_NAME} for ${RUST_TARGET}..."
+cd "${CRATE_DIR}"
+export CARGO_TARGET_DIR="${CRATE_DIR}/target"
+cargo build --release --target "${RUST_TARGET}"
+
+DLL_SRC="${CRATE_DIR}/target/${RUST_TARGET}/release/${DLL_NAME}"
+if [[ ! -f "${DLL_SRC}" ]]; then
+    echo "ERROR: Build output not found: ${DLL_SRC}"
+    exit 1
+fi
+
+echo "[4/5] Staging artifacts to ${INSTALL_DIR}..."
+mkdir -p "${INSTALL_DIR}/bin" "${INSTALL_DIR}/lib" "${INSTALL_DIR}/include"
+cp "${DLL_SRC}" "${INSTALL_DIR}/bin/"
+
+HEADER_SRC="${CRATE_DIR}/include/${HEADER_NAME}"
+if [[ -f "${HEADER_SRC}" ]]; then
+    cp "${HEADER_SRC}" "${INSTALL_DIR}/include/"
+fi
+
+# Generate import library (.lib) from the DLL using lib.exe.
+LIBEXE=""
+VSWHERE="C:/Program Files (x86)/Microsoft Visual Studio/Installer/vswhere.exe"
+if [[ -f "${VSWHERE}" ]]; then
+    VS_INSTALL="$("${VSWHERE}" -latest -products '*' -property installationPath 2>/dev/null | tr -d '\r')"
+    if [[ -n "${VS_INSTALL}" ]]; then
+        VC_VER_FILE="${VS_INSTALL}/VC/Auxiliary/Build/Microsoft.VCToolsVersion.default.txt"
+        if [[ -f "${VC_VER_FILE}" ]]; then
+            VC_VER="$(cat "${VC_VER_FILE}" | tr -d '[:space:]')"
+            case "$ARCH" in
+                x86_64) HOST_TOOL_DIRS=("Hostx64/x64" "Hostx86/x64") ;;
+                arm64)  HOST_TOOL_DIRS=("Hostarm64/arm64" "Hostx64/arm64") ;;
+            esac
+            for host_dir in "${HOST_TOOL_DIRS[@]}"; do
+                CANDIDATE="${VS_INSTALL}/VC/Tools/MSVC/${VC_VER}/bin/${host_dir}/lib.exe"
+                if [[ -f "${CANDIDATE}" ]]; then
+                    LIBEXE="${CANDIDATE}"
+                    break
+                fi
+            done
+        fi
+    fi
+fi
+[[ -z "${LIBEXE}" ]] && LIBEXE="$(command -v lib.exe 2>/dev/null || command -v lib 2>/dev/null || true)"
+
+if [[ -n "${LIBEXE}" ]]; then
+    echo "[5/5] Generating import library..."
+    case "$ARCH" in
+        x86_64) LIB_MACHINE="X64" ;;
+        arm64)  LIB_MACHINE="ARM64" ;;
+    esac
+    DEF_FILE="${BUILD_DIR}/${DLL_NAME%.dll}.def"
+    mkdir -p "${BUILD_DIR}"
+    LIB_BASE="${DLL_NAME%.dll}"
+    cat > "${DEF_FILE}" << DEF_EOF
+LIBRARY ${LIB_BASE}
+EXPORTS
+    supramark_plantuml_render
+    supramark_plantuml_free
+    supramark_plantuml_version
+    supramark_install_metrics_callback
+DEF_EOF
+    LIB_OUT="$(cygpath -w "${INSTALL_DIR}/lib/${LIB_BASE}.lib" 2>/dev/null || echo "${INSTALL_DIR}/lib/${LIB_BASE}.lib")"
+    DEF_WIN="$(cygpath -w "${DEF_FILE}" 2>/dev/null || echo "${DEF_FILE}")"
+    MSYS2_ARG_CONV_EXCL='*' "${LIBEXE}" /NOLOGO \
+        "/MACHINE:${LIB_MACHINE}" \
+        "/DEF:${DEF_WIN}" \
+        "/OUT:${LIB_OUT}" || echo "WARNING: import lib generation failed"
+else
+    echo "[5/5] WARNING: lib.exe not found; skipping import library."
+fi
+
+echo ""
+echo "Windows ${ARCH} build complete: ${INSTALL_DIR}"


### PR DESCRIPTION
## Motivation

`@actrium/supramark-plantuml-native-rn` currently has native bindings for iOS / Android / macOS only. On Windows, the `createReactNativeDiagramEngine` lookup fails to find a Windows adapter and falls back to the wasm loader — which has not been verified to work in Hermes.

## Change

Add Windows native bindings for the plantuml engine, following the same pattern as the iOS / Android / macOS bindings:

**New C++/WinRT module** — `crates/plantuml-little/packages/react-native/windows/SupramarkPlantumlNative/`:
- `ReactPackageProvider.cpp` / `.h`: registers the module with the RNW runtime
- `SupramarkPlantumlModule.h`: defines the FFI signature, `dllimport` function declarations, and the `ReactPackage` template

**JS layer**:
- `package.json`: `files` adds `windows`, `peerDependenciesMeta` adds `react-native-windows`, adds a `react-native-windows` platform extension
- `src/index.ts`: `Platform.select` adds a `windows` branch
- `scripts/prepare-native.js`: Windows binary staging (copy `.dll` / `.h` / `.lib` to `windows/Frameworks/`)

**`gitignore`**: `windows/Frameworks/` added (consistent with existing `ios/Frameworks/`, `macos/Frameworks/`).

**Build script** — `crates/plantuml-little/scripts/build-windows.sh` (122 lines): cross-compiles the Rust crate to a Windows `.dll` via the C ABI. Note: plantuml's native implementation depends on a Java runtime, so this script also fetches/configures the JRE.

## Risk

- Windows-only — no impact on iOS / Android / macOS
- 8 files, 299 lines
- FFI signature must match the Rust crate's `extern "C"` exports
- JRE availability on the build machine — the script must handle a missing/incompatible JRE gracefully
- `prepare-native.js` Windows branch handles `x86_64` and `arm64` architectures

## Test plan

- [ ] Run `./build-windows.sh` in `crates/plantuml-little` — expect JRE fetched and `output/windows-x86_64/bin/supramark_plantuml_native.dll` produced
- [ ] Run `npm run prepare-native` — expect `windows/Frameworks/{bin/*.dll, include/*.h, lib/*.lib}` populated
- [ ] In a host RNW app, side-effect `import '@actrium/supramark-plantuml-native-rn'` at entry top — expect `createReactNativeDiagramEngine()` resolves to the native adapter
- [ ] Render a sample plantuml diagram (e.g. sequence diagram) — expect SVG output identical to other platforms

## Pattern

This PR is the third of three parallel engine ports. The `mermaid` port is in PR #214; the `d2` port is in PR #215. Identical structure, separate reviews.