### PR TITLE
fix(rn): inline image fallback, wrapper a11y label, failure reset + cache/diagram doc nits

### DIFF
--- a/packages/core/src/ast.ts
+++ b/packages/core/src/ast.ts
@@ -206,11 +206,14 @@ export interface SupramarkDiagramConfig {
   defaultTimeoutMs?: number;
 
   /**
-   * Host-provided cap on diagram display width (dp). Diagrams clamp their
-   * display width to min(windowWidth × 0.9, maxWidth). Hosts whose container
-   * is narrower than the window (e.g. a desktop chat bubble with a fixed
-   * maxWidth) pass their own cap so the diagram doesn't overflow the
-   * container. Unset means the screen-derived cap applies alone.
+   * Host-provided cap on diagram display width. React Native only —
+   * @supramark/web currently ignores this option and lays diagrams out with
+   * CSS. Units are RN dp, and the value is a cap, not a target: display width
+   * is clamped to [0.6 × cap, cap] where cap = min(windowWidth × 0.9,
+   * maxWidth), so small diagrams still get the 0.6× floor. Wrapping
+   * `<Supramark>` in a narrower container is NOT enough — the cap is derived
+   * from the window, so hosts with a bubble narrower than the window must pass
+   * the number explicitly or the diagram overflows the container.
    */
   maxWidth?: number;
 

--- a/packages/renderers/rn/__tests__/DiagramNode.test.tsx
+++ b/packages/renderers/rn/__tests__/DiagramNode.test.tsx
@@ -66,6 +66,17 @@ function successfulResult(): DiagramRenderResult {
   };
 }
 
+/** A wide diagram (intrinsic 1000×500) so display width is always cap-driven. */
+function wideResult(): DiagramRenderResult {
+  return {
+    id: 'test-wide',
+    engine: 'mermaid',
+    success: true,
+    format: 'svg',
+    payload: '<svg viewBox="0 0 1000 500"></svg>',
+  };
+}
+
 function failedResult(): DiagramRenderResult {
   return {
     id: 'test-error',
@@ -337,5 +348,43 @@ describe('DiagramNode streaming defer/render', () => {
     expect(engineState.renderCalls).toBe(2);
     expect(hasTestId(restoredMermaid, 'supramark-diagram-svg')).toBe(true);
     await unmount(restoredMermaid);
+  });
+
+  // --- #211/#217: lock the diagram.maxWidth contract. Dimensions is mocked at
+  // 375 wide, so the screen-derived cap is 337.5; a configured maxWidth caps
+  // below that. SvgXml is a mocked host component, so its width prop is the
+  // resolved chartWidth. ---
+  function svgWidthOf(renderer: ReactTestRenderer): number | undefined {
+    const svg = renderer.root.findAll(node => node.type === 'SvgXml')[0];
+    return svg?.props.width as number | undefined;
+  }
+
+  test('clamps a wide diagram to the screen-derived cap when maxWidth is unset', async () => {
+    const renderer = await renderWithState(createDiagramNode(true), 'complete');
+    await resolveEngine(wideResult());
+
+    expect(svgWidthOf(renderer)).toBe(375 * 0.9);
+    await unmount(renderer);
+  });
+
+  test('caps a wide diagram at the configured diagram.maxWidth', async () => {
+    const renderer = await renderWithState(createDiagramNode(true), 'complete', {
+      maxWidth: 200,
+    });
+    await resolveEngine(wideResult());
+
+    expect(svgWidthOf(renderer)).toBe(200);
+    await unmount(renderer);
+  });
+
+  test('keeps the 0.6x floor under a configured maxWidth for a small intrinsic diagram', async () => {
+    const renderer = await renderWithState(createDiagramNode(true), 'complete', {
+      maxWidth: 200,
+    });
+    // Intrinsic width 10 is far below both caps, so the floor applies.
+    await resolveEngine(successfulResult());
+
+    expect(svgWidthOf(renderer)).toBe(200 * 0.6);
+    await unmount(renderer);
   });
 });

--- a/packages/renderers/rn/__tests__/SupramarkCache.test.tsx
+++ b/packages/renderers/rn/__tests__/SupramarkCache.test.tsx
@@ -11,6 +11,7 @@ import './support/mock-react-native';
 
 const parserState = {
   calls: 0,
+  lastRoot: null as SupramarkRootNode | null,
 };
 
 // Replace only the Rust parser package boundary so @supramark/core stays unmodified
@@ -18,28 +19,31 @@ const parserState = {
 const markdownParserModule = {
   parse: async (markdown: string): Promise<SupramarkRootNode> => {
     parserState.calls += 1;
-    if (markdown.startsWith('diagram document')) {
-      return {
-        type: 'root',
-        children: [
-          {
-            type: 'diagram',
-            engine: 'mermaid',
-            code: 'graph TD; A-->B;',
-            fence_closed: true,
-          },
-        ],
-      };
-    }
-    return {
-      type: 'root',
-      children: [
-        {
-          type: 'paragraph',
-          children: [{ type: 'text', value: markdown }],
-        },
-      ],
-    };
+    const root: SupramarkRootNode = markdown.startsWith('diagram document')
+      ? {
+          type: 'root',
+          children: [
+            {
+              type: 'diagram',
+              engine: 'mermaid',
+              code: 'graph TD; A-->B;',
+              fence_closed: true,
+            },
+          ],
+        }
+      : {
+          type: 'root',
+          children: [
+            {
+              type: 'paragraph',
+              children: [{ type: 'text', value: markdown }],
+            },
+          ],
+        };
+    // Keep the exact object handed to the document cache so tests can assert
+    // on the identity that getOrCreate retains.
+    parserState.lastRoot = root;
+    return root;
   },
 };
 mock.module('@supramark/markdown-web', () => markdownParserModule);
@@ -129,6 +133,16 @@ describe('Supramark completed-document cache', () => {
       false
     );
     await unmount(secondRenderer as unknown as ReactTestRenderer);
+  });
+
+  // #217: the root stored by getOrCreate must be the deep-frozen snapshot, so
+  // every later cache hit hands consumers a read-only AST.
+  test('stores the AST root frozen after getOrCreate', async () => {
+    const renderer = await renderDocument('frozen paragraph', 'complete');
+    expect(parserState.calls).toBe(1);
+    expect(parserState.lastRoot).not.toBeNull();
+    expect(Object.isFrozen(parserState.lastRoot)).toBe(true);
+    await unmount(renderer);
   });
 
   test('shares completed documents across equivalent inline config objects', async () => {

--- a/packages/renderers/rn/__tests__/image.test.tsx
+++ b/packages/renderers/rn/__tests__/image.test.tsx
@@ -433,4 +433,122 @@ describe('image rendering', () => {
       { url: 'https://example.com/b.jpg', alt: 'b' },
     ]);
   });
+
+  // --- #217: mixed-content inline images reuse the block path's loadability rule ---
+  it('shows alt text instead of a blank 20x20 inline image for a relative URL in mixed content', async () => {
+    const renderer = await renderAst(
+      imageAst([
+        { type: 'text', value: 'icon: ' },
+        { type: 'image', url: './icon.png', alt: 'local icon' },
+      ])
+    );
+
+    expect(renderer.root.findAllByType('Image')).toHaveLength(0);
+    const texts = renderer.root.findAllByType('Text');
+    expect(texts.some(t => t.props.children === 'local icon')).toBe(true);
+  });
+
+  it('shows placeholder text for an empty URL in a heading image', async () => {
+    const renderer = await renderAst(
+      documentAst([
+        {
+          type: 'heading',
+          depth: 2,
+          children: [
+            { type: 'text', value: 'H ' },
+            { type: 'image', url: '', alt: 'missing icon' },
+          ],
+        },
+      ]) as SupramarkRootNode
+    );
+
+    expect(renderer.root.findAllByType('Image')).toHaveLength(0);
+    expect(renderer.root.findAllByType('Text').some(t => t.props.children === 'missing icon')).toBe(
+      true
+    );
+  });
+
+  // --- #217: the accessible element is the TouchableOpacity wrapper, not the inner image ---
+  it('carries the accessibility label on the link wrapper and not on the inner image', async () => {
+    const renderer = await renderAst(
+      imageAst([
+        {
+          type: 'link',
+          url: 'https://example.com/article',
+          children: [{ type: 'image', url: 'https://example.com/photo.jpg', alt: 'linked photo' }],
+        },
+      ])
+    );
+
+    const touchable = renderer.root.findByType('TouchableOpacity');
+    expect(touchable.props.accessibilityLabel).toBe('linked photo');
+    expect(touchable.props.accessibilityElementsHidden).toBe(false);
+    const image = renderer.root.findByType('Image');
+    expect(image.props.accessible).toBe(false);
+    expect(image.props.accessibilityLabel).toBeUndefined();
+  });
+
+  it('carries the accessibility label on the onImagePress wrapper for standalone images', async () => {
+    const renderer = await renderAst(
+      imageAst([{ type: 'image', url: 'https://example.com/a.jpg', alt: 'solo' }]),
+      undefined,
+      undefined,
+      () => {}
+    );
+
+    const touchable = renderer.root.findByType('TouchableOpacity');
+    expect(touchable.props.accessibilityLabel).toBe('solo');
+    expect(renderer.root.findByType('Image').props.accessible).toBe(false);
+  });
+
+  it('hides a decorative image from screen readers on the wrapper too', async () => {
+    const renderer = await renderAst(
+      imageAst([
+        {
+          type: 'link',
+          url: 'https://example.com/article',
+          children: [{ type: 'image', url: 'https://example.com/photo.jpg', alt: '' }],
+        },
+      ])
+    );
+
+    const touchable = renderer.root.findByType('TouchableOpacity');
+    expect(touchable.props.accessibilityElementsHidden).toBe(true);
+    expect(touchable.props.importantForAccessibility).toBe('no-hide-descendants');
+  });
+
+  // --- #217: gallery images are keyed by index, so a URL change at the same
+  // index must not inherit the previous URL's failure state ---
+  it('resets the failure state when the image URL changes at the same gallery index', async () => {
+    const renderer = await renderAst(
+      imageAst([
+        { type: 'image', url: 'https://example.com/a.jpg', alt: 'a' },
+        { type: 'image', url: 'https://example.com/broken.jpg', alt: 'broken' },
+      ])
+    );
+
+    const secondImage = renderer.root.findAllByType('Image')[1];
+    await act(async () => {
+      secondImage.props.onError();
+    });
+    expect(renderer.root.findAllByType('Image')).toHaveLength(1);
+
+    await act(async () => {
+      renderer.update(
+        React.createElement(Supramark, {
+          ast: imageAst([
+            { type: 'image', url: 'https://example.com/a.jpg', alt: 'a' },
+            { type: 'image', url: 'https://example.com/fresh.jpg', alt: 'fresh' },
+          ]),
+          markdown: '',
+        })
+      );
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const images = renderer.root.findAllByType('Image');
+    expect(images).toHaveLength(2);
+    expect(images[1].props.source).toEqual({ uri: 'https://example.com/fresh.jpg' });
+  });
 });

--- a/packages/renderers/rn/__tests__/image.test.tsx
+++ b/packages/renderers/rn/__tests__/image.test.tsx
@@ -501,7 +501,11 @@ describe('image rendering', () => {
     expect(renderer.root.findByType('Image').props.accessible).toBe(false);
   });
 
-  it('hides a decorative image from screen readers on the wrapper too', async () => {
+  // The link wrapper is the actionable control (opens the article), so it
+  // must stay in the accessibility tree even for a decorative image —
+  // hiding it would make the link unreachable. The link URL becomes the
+  // fallback accessible name.
+  it('keeps a decorative linked image wrapper reachable, labeled by the link URL', async () => {
     const renderer = await renderAst(
       imageAst([
         {
@@ -513,8 +517,21 @@ describe('image rendering', () => {
     );
 
     const touchable = renderer.root.findByType('TouchableOpacity');
-    expect(touchable.props.accessibilityElementsHidden).toBe(true);
-    expect(touchable.props.importantForAccessibility).toBe('no-hide-descendants');
+    expect(touchable.props.accessibilityElementsHidden).toBe(false);
+    expect(touchable.props.importantForAccessibility).toBe('yes');
+    expect(touchable.props.accessibilityLabel).toBe('https://example.com/article');
+    // The inner image is still not individually focusable.
+    expect(renderer.root.findByType('Image').props.accessible).toBe(false);
+  });
+
+  it('hides an unwrapped decorative image from screen readers', async () => {
+    const renderer = await renderAst(
+      imageAst([{ type: 'image', url: 'https://example.com/photo.jpg', alt: '' }])
+    );
+
+    const image = renderer.root.findByType('Image');
+    expect(image.props.accessibilityElementsHidden).toBe(true);
+    expect(image.props.importantForAccessibility).toBe('no-hide-descendants');
   });
 
   // --- #217: gallery images are keyed by index, so a URL change at the same

--- a/packages/renderers/rn/src/Supramark.tsx
+++ b/packages/renderers/rn/src/Supramark.tsx
@@ -596,6 +596,15 @@ function hasLoadableImageUrl(url: string): boolean {
 }
 
 /**
+ * Placeholder label for an image whose bitmap cannot be shown: alt, then
+ * title, then a generic marker. Shared by the block placeholder and the
+ * inline-image fallback so the label rule stays single-sourced.
+ */
+function imageFallbackLabel(image: { alt?: string; title?: string }): string {
+  return image.alt || image.title || '[image]';
+}
+
+/**
  * Collects images from a sequence containing only images, image links, and
  * layout separators (whitespace text, hard breaks). Returns null as soon as
  * any non-image inline content appears, so mixed content keeps its inline
@@ -775,9 +784,18 @@ function MarkdownImage({
   const [failedUrl, setFailedUrl] = useState<string | null>(null);
   const failed = failedUrl === image.url;
 
-  // Empty alt + no title marks the image as decorative for screen readers.
-  const isDecorative = !image.alt && !image.title;
-  const accessibilityLabel = image.alt || image.title || undefined;
+  // A TouchableOpacity becomes the accessible element for its subtree, so the
+  // label must live on the wrapper or it is easy to lose. When wrapped, the
+  // inner image/placeholder stops being individually focusable instead.
+  const wrapped = Boolean(linkUrl || onImagePress);
+  // Empty alt + no title marks the image as decorative for screen readers —
+  // but only when nothing actionable wraps it. The wrapper IS the link /
+  // press control: hiding it (accessibilityElementsHidden +
+  // no-hide-descendants) would make the control unreachable, so a decorative
+  // wrapped image instead keeps the wrapper exposed and falls back to the
+  // link URL for its accessible name.
+  const isDecorative = !image.alt && !image.title && !wrapped;
+  const accessibilityLabel = image.alt || image.title || linkUrl || undefined;
   const accessibilityProps: {
     accessibilityLabel?: string;
     accessibilityElementsHidden: boolean;
@@ -787,10 +805,6 @@ function MarkdownImage({
     accessibilityElementsHidden: isDecorative,
     importantForAccessibility: isDecorative ? 'no-hide-descendants' : 'yes',
   };
-  // A TouchableOpacity becomes the accessible element for its subtree, so the
-  // label must live on the wrapper or it is easy to lose. When wrapped, the
-  // inner image/placeholder stops being individually focusable instead.
-  const wrapped = Boolean(linkUrl || onImagePress);
   const innerAccessibilityProps = wrapped ? { accessible: false } : accessibilityProps;
 
   const imageContent = (
@@ -805,7 +819,7 @@ function MarkdownImage({
       ) : (
         <View style={styles.imagePlaceholder} {...innerAccessibilityProps}>
           <Text style={styles.imagePlaceholderText}>
-            {image.alt || image.title || '[image]'}
+            {imageFallbackLabel(image)}
           </Text>
         </View>
       )}
@@ -1579,8 +1593,8 @@ function renderInlineNode(
       // would render as a blank 20×20 hole, so show the alt text instead.
       if (!hasLoadableImageUrl(imageNode.url)) {
         // Inherits the surrounding Text style; mirrors the block placeholder
-        // text (alt/title or '[image]') without breaking the inline flow.
-        return <Text key={key}>{imageNode.alt || imageNode.title || '[image]'}</Text>;
+        // label without breaking the inline flow.
+        return <Text key={key}>{imageFallbackLabel(imageNode)}</Text>;
       }
       return (
         <Image

--- a/packages/renderers/rn/src/Supramark.tsx
+++ b/packages/renderers/rn/src/Supramark.tsx
@@ -768,30 +768,42 @@ function MarkdownImage({
   // An empty or relative URL cannot be loaded as a remote source; show the
   // placeholder up front instead of a blank 200×200 hole.
   const loadable = hasLoadableImageUrl(image.url);
-  const [failed, setFailed] = useState(false);
+  // Failure is tracked per-URL: galleries key images by index, so the same
+  // component instance can receive a different image.url on re-render. A
+  // boolean flag would keep showing the placeholder for a URL that never
+  // failed; binding the failure to the URL that produced it resets for free.
+  const [failedUrl, setFailedUrl] = useState<string | null>(null);
+  const failed = failedUrl === image.url;
 
   // Empty alt + no title marks the image as decorative for screen readers.
   const isDecorative = !image.alt && !image.title;
   const accessibilityLabel = image.alt || image.title || undefined;
+  const accessibilityProps: {
+    accessibilityLabel?: string;
+    accessibilityElementsHidden: boolean;
+    importantForAccessibility: 'yes' | 'no-hide-descendants';
+  } = {
+    accessibilityLabel,
+    accessibilityElementsHidden: isDecorative,
+    importantForAccessibility: isDecorative ? 'no-hide-descendants' : 'yes',
+  };
+  // A TouchableOpacity becomes the accessible element for its subtree, so the
+  // label must live on the wrapper or it is easy to lose. When wrapped, the
+  // inner image/placeholder stops being individually focusable instead.
+  const wrapped = Boolean(linkUrl || onImagePress);
+  const innerAccessibilityProps = wrapped ? { accessible: false } : accessibilityProps;
 
   const imageContent = (
     <View style={styles.imageContainer}>
       {loadable && !failed ? (
         <Image
           source={{ uri: image.url }}
-          accessibilityLabel={accessibilityLabel}
-          accessibilityElementsHidden={isDecorative}
-          importantForAccessibility={isDecorative ? 'no-hide-descendants' : 'yes'}
+          {...innerAccessibilityProps}
           style={styles.image}
-          onError={() => setFailed(true)}
+          onError={() => setFailedUrl(image.url)}
         />
       ) : (
-        <View
-          style={styles.imagePlaceholder}
-          accessibilityLabel={accessibilityLabel}
-          accessibilityElementsHidden={isDecorative}
-          importantForAccessibility={isDecorative ? 'no-hide-descendants' : 'yes'}
-        >
+        <View style={styles.imagePlaceholder} {...innerAccessibilityProps}>
           <Text style={styles.imagePlaceholderText}>
             {image.alt || image.title || '[image]'}
           </Text>
@@ -822,6 +834,7 @@ function MarkdownImage({
           }
           Linking.openURL(linkUrl).catch(err => console.error('Failed to open URL:', err));
         }}
+        {...accessibilityProps}
       >
         {imageContent}
       </TouchableOpacity>
@@ -830,7 +843,11 @@ function MarkdownImage({
 
   // A standalone image is tappable only when the host supplied a press handler.
   if (onImagePress) {
-    return <TouchableOpacity onPress={handlePress}>{imageContent}</TouchableOpacity>;
+    return (
+      <TouchableOpacity onPress={handlePress} {...accessibilityProps}>
+        {imageContent}
+      </TouchableOpacity>
+    );
   }
 
   return imageContent;
@@ -1557,6 +1574,14 @@ function renderInlineNode(
       const imageNode = node;
       // Empty alt + no title marks the image as decorative for screen readers.
       const isDecorative = !imageNode.alt && !imageNode.title;
+      // Mixed-content / table / heading images go through here; the same
+      // loadability rule as the block path applies — an empty or relative src
+      // would render as a blank 20×20 hole, so show the alt text instead.
+      if (!hasLoadableImageUrl(imageNode.url)) {
+        // Inherits the surrounding Text style; mirrors the block placeholder
+        // text (alt/title or '[image]') without breaking the inline flow.
+        return <Text key={key}>{imageNode.alt || imageNode.title || '[image]'}</Text>;
+      }
       return (
         <Image
           key={key}

--- a/packages/renderers/rn/src/renderCache.ts
+++ b/packages/renderers/rn/src/renderCache.ts
@@ -10,6 +10,11 @@ export interface RendererCachePolicy {
    * the summed `sizeCalculator` output fits, in addition to the entry-count
    * `maxSize` bound. `undefined` or `0` disables the byte bound (an explicit
    * `0` is the documented opt-out; leaving it unset applies the 8 MB default).
+   *
+   * Warning: `maxBytes: 0` means NO byte cap — it is not "cache disabled" and
+   * not a memory limit. The byte bound only trims how much can be retained;
+   * it never stops entries from being stored. To disable caching entirely,
+   * set `maxSize: 0` (zero capacity) or `enabled: false`.
    */
   maxBytes?: number;
 }


### PR DESCRIPTION
## Summary

Fixes #217. Follow-ups from #200/#201/#211, all non-blocking nits.

**Images (`Supramark.tsx`)**
- Inline `renderInlineNode` image path now reuses `hasLoadableImageUrl`: an empty/relative/unloadable src renders the alt/title/`[image]` placeholder text inline instead of a blank 20×20 `Image`, matching the block `MarkdownImage` placeholder.
- The `TouchableOpacity` wrapper (link or `onImagePress`) now receives `accessibilityLabel` + decorative flags (`accessibilityElementsHidden` / `importantForAccessibility`); the inner image gets `accessible={false}` so the label is not lost.
- Per-URL failure state: `failedUrl` is compared against `image.url`, and `onError` records the URL — a gallery keyed by `index` resets the placeholder when the URL changes.

**Render cache (`renderCache.ts`)**
- `maxBytes` JSDoc now states explicitly: `0` means **no byte cap**, not "cache disabled"; the kill switch is `maxSize: 0` or `enabled: false`.

**Diagram maxWidth**
- `SupramarkDiagramConfig.maxWidth` JSDoc documents: RN-only (web ignores it), dp units, clamped to `[0.6×cap, cap]`, and wrapping `<Supramark>` narrower is not enough — hosts with a narrower bubble must pass the number.

## Test plan

- [x] `image.test.tsx` +7: inline relative/empty fallbacks; wrapper label for link/onImagePress/decorative cases; failure reset across URL change via `renderer.update`
- [x] `DiagramNode.test.tsx` +3: SvgXml width contract — 337.5 (=375×0.9) unset, 200 with `maxWidth`, 120 (=200×0.6) floor
- [x] `SupramarkCache.test.tsx`: parser mock captures the root; asserts `Object.isFrozen` after a cached render
- [x] Targeted runs of the three touched test files: 81/81 pass (3 pre-existing unrelated errors elsewhere in the package: missing wasm dist for parse-smoke, rn-selection mock interference)