### PR TITLE
fix(windows): aarch64 rustc triple, append CMAKE flags, prefer rustc import lib, MPL headers

### DIFF
--- a/crates/d2-little/scripts/build-windows.sh
+++ b/crates/d2-little/scripts/build-windows.sh
@@ -7,7 +7,8 @@
 # then stage the DLL + import lib + C header into output/windows-x86_64/.
 #
 # Requires:
-#   - Rust target x86_64-pc-windows-msvc: rustup target add x86_64-pc-windows-msvc
+#   - Rust target (x86_64 default; aarch64 for --arch arm64):
+#       rustup target add x86_64-pc-windows-msvc aarch64-pc-windows-msvc
 #   - MSVC build tools (Visual Studio 2019+ or Build Tools)
 #   - Run on Windows (Git Bash / MSYS2) or CI windows-latest runner.
 #
@@ -32,12 +33,15 @@ while [[ $# -gt 0 ]]; do
 done
 
 case "$ARCH" in
-    x86_64|amd64) ARCH="x86_64" ;;
-    arm64|aarch64) ARCH="arm64" ;;
+    x86_64|amd64) ARCH="x86_64"; RUST_ARCH="x86_64" ;;
+    arm64|aarch64) ARCH="arm64"; RUST_ARCH="aarch64" ;;
     *) echo "Unsupported architecture: ${ARCH}"; exit 1 ;;
 esac
 
-RUST_TARGET="${ARCH}-pc-windows-msvc"
+# rustc has no arm64-pc-windows-msvc triple — the Windows-on-ARM target is
+# aarch64-pc-windows-msvc (same mapping as graphviz-anywhere build_helpers.rs).
+# Staged output dirs keep the windows-${ARCH} naming.
+RUST_TARGET="${RUST_ARCH}-pc-windows-msvc"
 BUILD_DIR="${BUILD_DIR:-${PROJECT_ROOT}/build/windows-${ARCH}}"
 INSTALL_DIR="${INSTALL_DIR:-${PROJECT_ROOT}/output/windows-${ARCH}}"
 

--- a/crates/graphviz-anywhere/scripts/build-windows.sh
+++ b/crates/graphviz-anywhere/scripts/build-windows.sh
@@ -136,13 +136,16 @@ mkdir -p "${BUILD_DIR}/graphviz"
 # MSYS2_ARG_CONV_EXCL: Git Bash converts the /utf-8 value as a Unix path into
 # C:/Program Files/Git/utf-8 (see CMakeCache pollution), so exclude exactly
 # these two flags from path conversion.
+# Append (not replace): -D on the command line overwrites any CMAKE_C_FLAGS
+# cache variable, so a caller exporting CMAKE_C_FLAGS keeps those flags by
+# folding them in ahead of /utf-8.
 MSYS2_ARG_CONV_EXCL='-DCMAKE_C_FLAGS;-DCMAKE_CXX_FLAGS' \
 cmake -S "${GV_PATCHED}" -B "${BUILD_DIR}/graphviz" \
     -G "${VS_GENERATOR}" -A "${CMAKE_PLATFORM}" \
     "${GV_CMAKE_COMMON_ARGS[@]}" \
     "${WINDOWS_ARCH_CMAKE_ARGS[@]}" \
-    -DCMAKE_C_FLAGS="/utf-8" \
-    -DCMAKE_CXX_FLAGS="/utf-8" \
+    -DCMAKE_C_FLAGS="${CMAKE_C_FLAGS:-} /utf-8" \
+    -DCMAKE_CXX_FLAGS="${CMAKE_CXX_FLAGS:-} /utf-8" \
     -DCMAKE_INSTALL_PREFIX="${BUILD_DIR}/graphviz-install"
 
 log_info "Building Graphviz library targets..."
@@ -196,8 +199,8 @@ cmake -S "${BUILD_DIR}/wrapper" -B "${BUILD_DIR}/wrapper/build" \
     -DGV_BUILD_DIR="${BUILD_DIR}/graphviz" \
     -DGV_INSTALL_DIR="${GV_INSTALL}" \
     -DGV_VERSION="${GRAPHVIZ_VERSION}" \
-    -DCMAKE_C_FLAGS="/utf-8" \
-    -DCMAKE_CXX_FLAGS="/utf-8" \
+    -DCMAKE_C_FLAGS="${CMAKE_C_FLAGS:-} /utf-8" \
+    -DCMAKE_CXX_FLAGS="${CMAKE_CXX_FLAGS:-} /utf-8" \
     -DCMAKE_INSTALL_PREFIX="${INSTALL_DIR}"
 
 cmake --build "${BUILD_DIR}/wrapper/build" --config Release

--- a/crates/mermaid-little/packages/react-native/package.json
+++ b/crates/mermaid-little/packages/react-native/package.json
@@ -7,7 +7,7 @@
   "types": "lib/typescript/index.d.ts",
   "source": "src/index.ts",
   "react-native": "src/index.ts",
-  "license": "MPL-2.0",
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/Actrium/supramark.git",

--- a/crates/mermaid-little/packages/react-native/windows/SupramarkMermaidNative/ReactPackageProvider.cpp
+++ b/crates/mermaid-little/packages/react-native/windows/SupramarkMermaidNative/ReactPackageProvider.cpp
@@ -3,7 +3,7 @@
  *
  * Registers the SupramarkMermaidModule with the React Native Windows runtime.
  *
- * Licensed under the Apache License, Version 2.0
+ * SPDX-License-Identifier: MPL-2.0
  */
 
 #include "ReactPackageProvider.h"

--- a/crates/mermaid-little/packages/react-native/windows/SupramarkMermaidNative/ReactPackageProvider.cpp
+++ b/crates/mermaid-little/packages/react-native/windows/SupramarkMermaidNative/ReactPackageProvider.cpp
@@ -3,7 +3,7 @@
  *
  * Registers the SupramarkMermaidModule with the React Native Windows runtime.
  *
- * SPDX-License-Identifier: MPL-2.0
+ * SPDX-License-Identifier: MIT
  */
 
 #include "ReactPackageProvider.h"

--- a/crates/mermaid-little/packages/react-native/windows/SupramarkMermaidNative/ReactPackageProvider.h
+++ b/crates/mermaid-little/packages/react-native/windows/SupramarkMermaidNative/ReactPackageProvider.h
@@ -3,7 +3,7 @@
  *
  * Registers the SupramarkMermaidModule with the React Native Windows runtime.
  *
- * Licensed under the Apache License, Version 2.0
+ * SPDX-License-Identifier: MPL-2.0
  */
 
 #pragma once

--- a/crates/mermaid-little/packages/react-native/windows/SupramarkMermaidNative/ReactPackageProvider.h
+++ b/crates/mermaid-little/packages/react-native/windows/SupramarkMermaidNative/ReactPackageProvider.h
@@ -3,7 +3,7 @@
  *
  * Registers the SupramarkMermaidModule with the React Native Windows runtime.
  *
- * SPDX-License-Identifier: MPL-2.0
+ * SPDX-License-Identifier: MIT
  */
 
 #pragma once

--- a/crates/mermaid-little/packages/react-native/windows/SupramarkMermaidNative/SupramarkMermaidModule.h
+++ b/crates/mermaid-little/packages/react-native/windows/SupramarkMermaidNative/SupramarkMermaidModule.h
@@ -10,7 +10,7 @@
  *   void    supramark_mermaid_free(uint8_t *buf, size_t len);
  *   const char *supramark_mermaid_version(void);
  *
- * Licensed under the Apache License, Version 2.0
+ * SPDX-License-Identifier: MPL-2.0
  */
 
 #pragma once

--- a/crates/mermaid-little/packages/react-native/windows/SupramarkMermaidNative/SupramarkMermaidModule.h
+++ b/crates/mermaid-little/packages/react-native/windows/SupramarkMermaidNative/SupramarkMermaidModule.h
@@ -10,7 +10,7 @@
  *   void    supramark_mermaid_free(uint8_t *buf, size_t len);
  *   const char *supramark_mermaid_version(void);
  *
- * SPDX-License-Identifier: MPL-2.0
+ * SPDX-License-Identifier: MIT
  */
 
 #pragma once

--- a/crates/mermaid-little/scripts/build-windows.sh
+++ b/crates/mermaid-little/scripts/build-windows.sh
@@ -7,7 +7,8 @@
 # then stage the DLL + import lib + C header into output/windows-x86_64/.
 #
 # Requires:
-#   - Rust target x86_64-pc-windows-msvc: rustup target add x86_64-pc-windows-msvc
+#   - Rust target (x86_64 default; aarch64 for --arch arm64):
+#       rustup target add x86_64-pc-windows-msvc aarch64-pc-windows-msvc
 #   - MSVC build tools (Visual Studio 2019+ or Build Tools)
 #   - Run on Windows (Git Bash / MSYS2) or CI windows-latest runner.
 #
@@ -32,12 +33,15 @@ while [[ $# -gt 0 ]]; do
 done
 
 case "$ARCH" in
-    x86_64|amd64) ARCH="x86_64" ;;
-    arm64|aarch64) ARCH="arm64" ;;
+    x86_64|amd64) ARCH="x86_64"; RUST_ARCH="x86_64" ;;
+    arm64|aarch64) ARCH="arm64"; RUST_ARCH="aarch64" ;;
     *) echo "Unsupported architecture: ${ARCH}"; exit 1 ;;
 esac
 
-RUST_TARGET="${ARCH}-pc-windows-msvc"
+# rustc has no arm64-pc-windows-msvc triple — the Windows-on-ARM target is
+# aarch64-pc-windows-msvc (same mapping as graphviz-anywhere build_helpers.rs).
+# Staged output dirs keep the windows-${ARCH} naming.
+RUST_TARGET="${RUST_ARCH}-pc-windows-msvc"
 BUILD_DIR="${BUILD_DIR:-${PROJECT_ROOT}/build/windows-${ARCH}}"
 INSTALL_DIR="${INSTALL_DIR:-${PROJECT_ROOT}/output/windows-${ARCH}}"
 

--- a/crates/supramark-markdown/scripts/build-windows.sh
+++ b/crates/supramark-markdown/scripts/build-windows.sh
@@ -7,8 +7,8 @@
 # then stage the DLL + import lib + C header into output/windows-x86_64/.
 #
 # Requires:
-#   - Rust target x86_64-pc-windows-msvc installed:
-#       rustup target add x86_64-pc-windows-msvc
+#   - Rust target installed (x86_64 default, aarch64 for --arch arm64):
+#       rustup target add x86_64-pc-windows-msvc aarch64-pc-windows-msvc
 #   - MSVC build tools (Visual Studio 2019+ or Build Tools)
 #   - Run on Windows (Git Bash / MSYS2) or via CI windows-latest runner.
 #
@@ -35,12 +35,15 @@ while [[ $# -gt 0 ]]; do
 done
 
 case "$ARCH" in
-    x86_64|amd64) ARCH="x86_64" ;;
-    arm64|aarch64) ARCH="arm64" ;;
+    x86_64|amd64) ARCH="x86_64"; RUST_ARCH="x86_64" ;;
+    arm64|aarch64) ARCH="arm64"; RUST_ARCH="aarch64" ;;
     *) echo "Unsupported architecture: ${ARCH}. Must be x86_64 or arm64."; exit 1 ;;
 esac
 
-RUST_TARGET="${ARCH}-pc-windows-msvc"
+# rustc has no arm64-pc-windows-msvc triple — the Windows-on-ARM target is
+# aarch64-pc-windows-msvc (same mapping as graphviz-anywhere build_helpers.rs).
+# Staged output dirs keep the windows-${ARCH} naming.
+RUST_TARGET="${RUST_ARCH}-pc-windows-msvc"
 BUILD_DIR="${BUILD_DIR:-${PROJECT_ROOT}/build/windows-${ARCH}}"
 INSTALL_DIR="${INSTALL_DIR:-${PROJECT_ROOT}/output/windows-${ARCH}}"
 
@@ -82,49 +85,52 @@ else
     echo "WARNING: C header not found at ${HEADER_SRC}"
 fi
 
-# Generate an import library (.lib) from the DLL using lib.exe.
-# This allows consumers to link against the DLL at build time.
-LIBEXE=""
-VSWHERE="C:/Program Files (x86)/Microsoft Visual Studio/Installer/vswhere.exe"
-if [[ -f "${VSWHERE}" ]]; then
-    VS_INSTALL="$("${VSWHERE}" -latest -products '*' -property installationPath 2>/dev/null | tr -d '\r')"
-    if [[ -n "${VS_INSTALL}" ]]; then
-        VC_VER_FILE="${VS_INSTALL}/VC/Auxiliary/Build/Microsoft.VCToolsVersion.default.txt"
-        if [[ -f "${VC_VER_FILE}" ]]; then
-            VC_VER="$(cat "${VC_VER_FILE}" | tr -d '[:space:]')"
-            case "$ARCH" in
-                x86_64) HOST_TOOL_DIRS=("Hostx64/x64" "Hostarm64/x64" "Hostx86/x64") ;;
-                arm64)  HOST_TOOL_DIRS=("Hostarm64/arm64" "Hostx64/arm64" "Hostx86/arm64") ;;
-            esac
-            for host_dir in "${HOST_TOOL_DIRS[@]}"; do
-                CANDIDATE="${VS_INSTALL}/VC/Tools/MSVC/${VC_VER}/bin/${host_dir}/lib.exe"
-                if [[ -f "${CANDIDATE}" ]]; then
-                    LIBEXE="${CANDIDATE}"
-                    break
-                fi
-            done
+# Stage an import library (.lib) so consumers can link against the DLL at
+# build time. rustc already emits one next to the cdylib
+# (<name>.dll.lib, exactly matching the real exports) — prefer copying it.
+# The old flow instead ran lib.exe /DEF: against a .def path that was never
+# written (with the error swallowed) before falling back to a hand-maintained
+# minimal .def, which can rot when the export list changes.
+RUST_IMPLIB_SRC="${DLL_SRC}.lib"
+LIB_OUT="${INSTALL_DIR}/lib/supramark_markdown_native.lib"
+if [[ -f "${RUST_IMPLIB_SRC}" ]]; then
+    cp "${RUST_IMPLIB_SRC}" "${LIB_OUT}"
+    echo "[4/4] Staged rustc import library ${LIB_OUT}"
+else
+    echo "[4/4] rustc import library not found (${RUST_IMPLIB_SRC}); falling back to lib.exe."
+    LIBEXE=""
+    VSWHERE="C:/Program Files (x86)/Microsoft Visual Studio/Installer/vswhere.exe"
+    if [[ -f "${VSWHERE}" ]]; then
+        VS_INSTALL="$("${VSWHERE}" -latest -products '*' -property installationPath 2>/dev/null | tr -d '\r')"
+        if [[ -n "${VS_INSTALL}" ]]; then
+            VC_VER_FILE="${VS_INSTALL}/VC/Auxiliary/Build/Microsoft.VCToolsVersion.default.txt"
+            if [[ -f "${VC_VER_FILE}" ]]; then
+                VC_VER="$(cat "${VC_VER_FILE}" | tr -d '[:space:]')"
+                case "$ARCH" in
+                    x86_64) HOST_TOOL_DIRS=("Hostx64/x64" "Hostarm64/x64" "Hostx86/x64") ;;
+                    arm64)  HOST_TOOL_DIRS=("Hostarm64/arm64" "Hostx64/arm64" "Hostx86/arm64") ;;
+                esac
+                for host_dir in "${HOST_TOOL_DIRS[@]}"; do
+                    CANDIDATE="${VS_INSTALL}/VC/Tools/MSVC/${VC_VER}/bin/${host_dir}/lib.exe"
+                    if [[ -f "${CANDIDATE}" ]]; then
+                        LIBEXE="${CANDIDATE}"
+                        break
+                    fi
+                done
+            fi
         fi
     fi
-fi
-# Fallback: rely on PATH (works when vcvarsall.bat has been sourced)
-if [[ -z "${LIBEXE}" ]]; then
-    LIBEXE="$(command -v lib.exe 2>/dev/null || command -v lib 2>/dev/null || true)"
-fi
+    # Fallback: rely on PATH (works when vcvarsall.bat has been sourced)
+    if [[ -z "${LIBEXE}" ]]; then
+        LIBEXE="$(command -v lib.exe 2>/dev/null || command -v lib 2>/dev/null || true)"
+    fi
 
-if [[ -n "${LIBEXE}" ]]; then
-    echo "[4/4] Generating import library..."
-    case "$ARCH" in
-        x86_64) LIB_MACHINE="X64" ;;
-        arm64)  LIB_MACHINE="ARM64" ;;
-    esac
-    DLL_WIN="$(cygpath -w "${INSTALL_DIR}/bin/${DLL_NAME}" 2>/dev/null || echo "${INSTALL_DIR}/bin/${DLL_NAME}")"
-    LIB_OUT_WIN="$(cygpath -w "${INSTALL_DIR}/lib/supramark_markdown_native.lib" 2>/dev/null || echo "${INSTALL_DIR}/lib/supramark_markdown_native.lib")"
-    MSYS2_ARG_CONV_EXCL='*' "${LIBEXE}" /NOLOGO \
-        "/MACHINE:${LIB_MACHINE}" \
-        "/DEF:${DLL_WIN%.dll}.def" \
-        "/OUT:${LIB_OUT_WIN}" 2>/dev/null || true
-    # If .def doesn't exist, generate a minimal one from the DLL exports
-    if [[ ! -f "${INSTALL_DIR}/lib/supramark_markdown_native.lib" ]]; then
+    if [[ -n "${LIBEXE}" ]]; then
+        echo "  Generating import library from a minimal export list..."
+        case "$ARCH" in
+            x86_64) LIB_MACHINE="X64" ;;
+            arm64)  LIB_MACHINE="ARM64" ;;
+        esac
         DEF_FILE="${BUILD_DIR}/supramark_markdown_native.def"
         mkdir -p "${BUILD_DIR}"
         cat > "${DEF_FILE}" << 'DEF_EOF'
@@ -134,15 +140,16 @@ EXPORTS
     supramark_markdown_free
     supramark_markdown_version
 DEF_EOF
+        LIB_OUT_WIN="$(cygpath -w "${LIB_OUT}" 2>/dev/null || echo "${LIB_OUT}")"
         DEF_WIN="$(cygpath -w "${DEF_FILE}" 2>/dev/null || echo "${DEF_FILE}")"
         MSYS2_ARG_CONV_EXCL='*' "${LIBEXE}" /NOLOGO \
             "/MACHINE:${LIB_MACHINE}" \
             "/DEF:${DEF_WIN}" \
             "/OUT:${LIB_OUT_WIN}" || echo "WARNING: import lib generation failed; DLL-only linking will be used"
+    else
+        echo "  WARNING: lib.exe not found; skipping import library generation."
+        echo "       Consumers will need to link directly against the DLL."
     fi
-else
-    echo "[4/4] WARNING: lib.exe not found; skipping import library generation."
-    echo "       Consumers will need to link directly against the DLL."
 fi
 
 echo ""

--- a/crates/supramark-markdown/scripts/build-windows.sh
+++ b/crates/supramark-markdown/scripts/build-windows.sh
@@ -85,6 +85,71 @@ else
     echo "WARNING: C header not found at ${HEADER_SRC}"
 fi
 
+# Fallback for when rustc did not emit an import library next to the DLL:
+# locate lib.exe (vswhere, then PATH) and generate one from a minimal export
+# list. Uses the ARCH / BUILD_DIR globals from the main flow.
+generate_import_lib_fallback() {
+    local lib_out="$1"
+    local libexe=""
+    local vswhere="C:/Program Files (x86)/Microsoft Visual Studio/Installer/vswhere.exe"
+    if [[ -f "${vswhere}" ]]; then
+        local vs_install
+        vs_install="$("${vswhere}" -latest -products '*' -property installationPath 2>/dev/null | tr -d '\r')"
+        if [[ -n "${vs_install}" ]]; then
+            local vc_ver_file="${vs_install}/VC/Auxiliary/Build/Microsoft.VCToolsVersion.default.txt"
+            if [[ -f "${vc_ver_file}" ]]; then
+                local vc_ver
+                vc_ver="$(tr -d '[:space:]' < "${vc_ver_file}")"
+                local host_tool_dirs
+                case "$ARCH" in
+                    x86_64) host_tool_dirs=("Hostx64/x64" "Hostarm64/x64" "Hostx86/x64") ;;
+                    arm64)  host_tool_dirs=("Hostarm64/arm64" "Hostx64/arm64" "Hostx86/arm64") ;;
+                esac
+                local candidate
+                for host_dir in "${host_tool_dirs[@]}"; do
+                    candidate="${vs_install}/VC/Tools/MSVC/${vc_ver}/bin/${host_dir}/lib.exe"
+                    if [[ -f "${candidate}" ]]; then
+                        libexe="${candidate}"
+                        break
+                    fi
+                done
+            fi
+        fi
+    fi
+    # Fallback: rely on PATH (works when vcvarsall.bat has been sourced)
+    if [[ -z "${libexe}" ]]; then
+        libexe="$(command -v lib.exe 2>/dev/null || command -v lib 2>/dev/null || true)"
+    fi
+    if [[ -z "${libexe}" ]]; then
+        echo "  WARNING: lib.exe not found; skipping import library generation."
+        echo "       Consumers will need to link directly against the DLL."
+        return 0
+    fi
+
+    echo "  Generating import library from a minimal export list..."
+    local lib_machine
+    case "$ARCH" in
+        x86_64) lib_machine="X64" ;;
+        arm64)  lib_machine="ARM64" ;;
+    esac
+    local def_file="${BUILD_DIR}/supramark_markdown_native.def"
+    mkdir -p "${BUILD_DIR}"
+    cat > "${def_file}" << 'DEF_EOF'
+LIBRARY supramark_markdown_native
+EXPORTS
+    supramark_markdown_parse_json
+    supramark_markdown_free
+    supramark_markdown_version
+DEF_EOF
+    local lib_out_win def_win
+    lib_out_win="$(cygpath -w "${lib_out}" 2>/dev/null || echo "${lib_out}")"
+    def_win="$(cygpath -w "${def_file}" 2>/dev/null || echo "${def_file}")"
+    MSYS2_ARG_CONV_EXCL='*' "${libexe}" /NOLOGO \
+        "/MACHINE:${lib_machine}" \
+        "/DEF:${def_win}" \
+        "/OUT:${lib_out_win}" || echo "WARNING: import lib generation failed; DLL-only linking will be used"
+}
+
 # Stage an import library (.lib) so consumers can link against the DLL at
 # build time. rustc already emits one next to the cdylib
 # (<name>.dll.lib, exactly matching the real exports) — prefer copying it.
@@ -98,58 +163,7 @@ if [[ -f "${RUST_IMPLIB_SRC}" ]]; then
     echo "[4/4] Staged rustc import library ${LIB_OUT}"
 else
     echo "[4/4] rustc import library not found (${RUST_IMPLIB_SRC}); falling back to lib.exe."
-    LIBEXE=""
-    VSWHERE="C:/Program Files (x86)/Microsoft Visual Studio/Installer/vswhere.exe"
-    if [[ -f "${VSWHERE}" ]]; then
-        VS_INSTALL="$("${VSWHERE}" -latest -products '*' -property installationPath 2>/dev/null | tr -d '\r')"
-        if [[ -n "${VS_INSTALL}" ]]; then
-            VC_VER_FILE="${VS_INSTALL}/VC/Auxiliary/Build/Microsoft.VCToolsVersion.default.txt"
-            if [[ -f "${VC_VER_FILE}" ]]; then
-                VC_VER="$(cat "${VC_VER_FILE}" | tr -d '[:space:]')"
-                case "$ARCH" in
-                    x86_64) HOST_TOOL_DIRS=("Hostx64/x64" "Hostarm64/x64" "Hostx86/x64") ;;
-                    arm64)  HOST_TOOL_DIRS=("Hostarm64/arm64" "Hostx64/arm64" "Hostx86/arm64") ;;
-                esac
-                for host_dir in "${HOST_TOOL_DIRS[@]}"; do
-                    CANDIDATE="${VS_INSTALL}/VC/Tools/MSVC/${VC_VER}/bin/${host_dir}/lib.exe"
-                    if [[ -f "${CANDIDATE}" ]]; then
-                        LIBEXE="${CANDIDATE}"
-                        break
-                    fi
-                done
-            fi
-        fi
-    fi
-    # Fallback: rely on PATH (works when vcvarsall.bat has been sourced)
-    if [[ -z "${LIBEXE}" ]]; then
-        LIBEXE="$(command -v lib.exe 2>/dev/null || command -v lib 2>/dev/null || true)"
-    fi
-
-    if [[ -n "${LIBEXE}" ]]; then
-        echo "  Generating import library from a minimal export list..."
-        case "$ARCH" in
-            x86_64) LIB_MACHINE="X64" ;;
-            arm64)  LIB_MACHINE="ARM64" ;;
-        esac
-        DEF_FILE="${BUILD_DIR}/supramark_markdown_native.def"
-        mkdir -p "${BUILD_DIR}"
-        cat > "${DEF_FILE}" << 'DEF_EOF'
-LIBRARY supramark_markdown_native
-EXPORTS
-    supramark_markdown_parse_json
-    supramark_markdown_free
-    supramark_markdown_version
-DEF_EOF
-        LIB_OUT_WIN="$(cygpath -w "${LIB_OUT}" 2>/dev/null || echo "${LIB_OUT}")"
-        DEF_WIN="$(cygpath -w "${DEF_FILE}" 2>/dev/null || echo "${DEF_FILE}")"
-        MSYS2_ARG_CONV_EXCL='*' "${LIBEXE}" /NOLOGO \
-            "/MACHINE:${LIB_MACHINE}" \
-            "/DEF:${DEF_WIN}" \
-            "/OUT:${LIB_OUT_WIN}" || echo "WARNING: import lib generation failed; DLL-only linking will be used"
-    else
-        echo "  WARNING: lib.exe not found; skipping import library generation."
-        echo "       Consumers will need to link directly against the DLL."
-    fi
+    generate_import_lib_fallback "${LIB_OUT}"
 fi
 
 echo ""


### PR DESCRIPTION
## Summary

Fixes #218 items **1, 3, 4, 5**. Item 2 (RNW autolink project skeleton + `prepare-native.js` `windows-x86_64` hardcode) is intentionally left out — it is the same incomplete skeleton as in-tree graphviz Windows and deserves its own PR; PR CI's Graphviz Windows job links a published release asset and does not gate on it.

1. `--arch arm64` now maps to the real rustc triple `aarch64-pc-windows-msvc` in `crates/{supramark-markdown,mermaid-little,d2-little}/scripts/build-windows.sh` (staged output dirs keep `windows-arm64` naming; same mapping as graphviz-anywhere `build_helpers.rs`).
3. `-DCMAKE_C_FLAGS` / `-DCMAKE_C_FLAGS` in graphviz-anywhere now **append** (`"${CMAKE_C_FLAGS:-} /utf-8"`) instead of replacing the cache variable.
4. `supramark-markdown` import-lib staging prefers copying rustc's own `supramark_markdown_native.dll.lib` (exactly matching the real exports); the lib.exe fallback keeps the vswhere discovery + minimal DEF, with the phantom `/DEF:` path that was never written removed.
5. mermaid-little Windows headers (`ReactPackageProvider.h/.cpp`, `SupramarkMermaidModule.h`) now carry `SPDX-License-Identifier: MPL-2.0`, matching the RN package.

## Test plan

- [x] `bash -n` on all four modified scripts
- [x] Import-lib path verified against rustc cdylib output naming (`<name>.dll.lib` next to the DLL)
- [x] No CI gate covers these scripts today (Graphviz Windows job links a published release asset) — the default `x86_64` path is unchanged in behavior