### PR TITLE
fix(markdown): defer inline-math scan until after adjacent-text reassembly

### DIFF
--- a/crates/supramark-markdown/src/common/utils.rs
+++ b/crates/supramark-markdown/src/common/utils.rs
@@ -13,6 +13,8 @@ static DIGITAL_ENTITY_TEST_RE: Lazy<Regex> =
     Lazy::new(|| Regex::new(r#"(?i)^&#(x[a-f0-9]{1,8}|[0-9]{1,8});$"#).unwrap());
 static UNESCAPE_ALL_RE: Lazy<Regex> =
     Lazy::new(|| Regex::new(&format!("{UNESCAPE_MD_RE}|{ENTITY_RE}")).unwrap());
+static ANCHORED_ENTITY_RE: Lazy<Regex> =
+    Lazy::new(|| Regex::new(&format!("^{ENTITY_RE}")).unwrap());
 
 #[allow(clippy::manual_range_contains)]
 /// Return true if a `code` you got from `&#xHHHH;` entity is a valid charcode.
@@ -97,6 +99,16 @@ fn replace_entity_pattern(str: &str) -> Option<String> {
     } else {
         None
     }
+}
+
+/// Decode a valid HTML entity / numeric character reference that starts at
+/// the beginning of `raw` (`&amp;`, `&#65;`, `&#x41;`), returning the decoded
+/// replacement and the raw byte length consumed. Returns `None` when `raw`
+/// does not start with a decodable entity.
+pub(crate) fn decode_entity_at_start(raw: &str) -> Option<(String, usize)> {
+    let matched = ANCHORED_ENTITY_RE.find(raw)?;
+    let replacement = replace_entity_pattern(matched.as_str())?;
+    Some((replacement, matched.as_str().len()))
 }
 
 /// Unescape both entities (`&quot; -> "`) and backslash escapes (`\" -> "`).

--- a/crates/supramark-markdown/src/common/utils.rs
+++ b/crates/supramark-markdown/src/common/utils.rs
@@ -141,29 +141,6 @@ pub(crate) fn decode_entity_at_start(raw: &str) -> Option<(String, usize)> {
     Some((decoded.to_string(), matched.as_str().len()))
 }
 
-/// Decode every entity in `raw` that the inline entity scanner would have
-/// consumed (one level, matching the parser). Used for inline-math content
-/// carved from the raw source: backslash escapes must stay raw for TeX, but
-/// an entity the parser already decoded in surrounding text should reach the
-/// math engine decoded too (`$&lt;$` is the math `<`, not the four bytes
-/// `&lt;`).
-pub(crate) fn decode_entities(raw: &str) -> String {
-    let mut out = String::with_capacity(raw.len());
-    let mut rest = raw;
-    while let Some(amp) = rest.find('&') {
-        if let Some((decoded, len)) = decode_entity_at_start(&rest[amp..]) {
-            out.push_str(&rest[..amp]);
-            out.push_str(&decoded);
-            rest = &rest[amp + len..];
-        } else {
-            out.push_str(&rest[..=amp]);
-            rest = &rest[amp + 1..];
-        }
-    }
-    out.push_str(rest);
-    out
-}
-
 /// Unescape both entities (`&quot; -> "`) and backslash escapes (`\" -> "`).
 /// ```
 /// # use supramark_markdown::common::utils::unescape_all;

--- a/crates/supramark-markdown/src/common/utils.rs
+++ b/crates/supramark-markdown/src/common/utils.rs
@@ -13,8 +13,6 @@ static DIGITAL_ENTITY_TEST_RE: Lazy<Regex> =
     Lazy::new(|| Regex::new(r#"(?i)^&#(x[a-f0-9]{1,8}|[0-9]{1,8});$"#).unwrap());
 static UNESCAPE_ALL_RE: Lazy<Regex> =
     Lazy::new(|| Regex::new(&format!("{UNESCAPE_MD_RE}|{ENTITY_RE}")).unwrap());
-static ANCHORED_ENTITY_RE: Lazy<Regex> =
-    Lazy::new(|| Regex::new(&format!("^{ENTITY_RE}")).unwrap());
 
 #[allow(clippy::manual_range_contains)]
 /// Return true if a `code` you got from `&#xHHHH;` entity is a valid charcode.
@@ -101,14 +99,69 @@ fn replace_entity_pattern(str: &str) -> Option<String> {
     }
 }
 
-/// Decode a valid HTML entity / numeric character reference that starts at
-/// the beginning of `raw` (`&amp;`, `&#65;`, `&#x41;`), returning the decoded
-/// replacement and the raw byte length consumed. Returns `None` when `raw`
-/// does not start with a decodable entity.
+/// Anchored copies of the inline entity scanner's grammar
+/// (`plugins/cmark/inline/entity.rs` `DIGITAL_RE` / `NAMED_RE`). `RawValueMap`
+/// must recognize EXACTLY the spans the scanner consumed — a grammar that
+/// accepts more (e.g. 8-digit numeric refs, which the scanner leaves literal)
+/// mis-models a literal `&…;` as decoded and sinks the whole run to plain
+/// text; a grammar that accepts less misses a real decode the same way.
+static PARSER_DIGITAL_ENTITY_RE: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"(?i)^&#((?:x[a-f0-9]{1,6}|[0-9]{1,7}));").unwrap());
+static PARSER_NAMED_ENTITY_RE: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"(?i)^&([a-z][a-z0-9]{1,31});").unwrap());
+
+/// Decode the entity / numeric character reference that starts at the
+/// beginning of `raw`, mirroring what the inline entity scanner actually
+/// emitted into the value: `&amp;` -> `&`, `&#65;` -> `A`, and an invalid
+/// charcode (`&#0;`, `&#xD800;`, `&#x110000;`, ...) -> `U+FFFD` (the
+/// scanner's replacement, see `entity.rs::parse_digital_entity`). Returns
+/// the decoded replacement plus the raw byte length consumed, or `None`
+/// when `raw` does not start with an entity the scanner would consume
+/// (the `&` then stays literal and maps 1:1).
 pub(crate) fn decode_entity_at_start(raw: &str) -> Option<(String, usize)> {
-    let matched = ANCHORED_ENTITY_RE.find(raw)?;
-    let replacement = replace_entity_pattern(matched.as_str())?;
-    Some((replacement, matched.as_str().len()))
+    if let Some(captures) = PARSER_NAMED_ENTITY_RE.captures(raw) {
+        let matched = captures.get(0).unwrap();
+        let decoded = get_entity_from_str(matched.as_str())?;
+        return Some((decoded.to_owned(), matched.as_str().len()));
+    }
+    let captures = PARSER_DIGITAL_ENTITY_RE.captures(raw)?;
+    let matched = captures.get(0).unwrap();
+    let digits = captures.get(1).unwrap().as_str();
+    #[allow(clippy::from_str_radix_10)]
+    let code = if digits.starts_with('x') || digits.starts_with('X') {
+        u32::from_str_radix(&digits[1..], 16).unwrap()
+    } else {
+        u32::from_str_radix(digits, 10).unwrap()
+    };
+    let decoded = if is_valid_entity_code(code) {
+        char::from_u32(code).unwrap()
+    } else {
+        '\u{FFFD}'
+    };
+    Some((decoded.to_string(), matched.as_str().len()))
+}
+
+/// Decode every entity in `raw` that the inline entity scanner would have
+/// consumed (one level, matching the parser). Used for inline-math content
+/// carved from the raw source: backslash escapes must stay raw for TeX, but
+/// an entity the parser already decoded in surrounding text should reach the
+/// math engine decoded too (`$&lt;$` is the math `<`, not the four bytes
+/// `&lt;`).
+pub(crate) fn decode_entities(raw: &str) -> String {
+    let mut out = String::with_capacity(raw.len());
+    let mut rest = raw;
+    while let Some(amp) = rest.find('&') {
+        if let Some((decoded, len)) = decode_entity_at_start(&rest[amp..]) {
+            out.push_str(&rest[..amp]);
+            out.push_str(&decoded);
+            rest = &rest[amp + len..];
+        } else {
+            out.push_str(&rest[..=amp]);
+            rest = &rest[amp + 1..];
+        }
+    }
+    out.push_str(rest);
+    out
 }
 
 /// Unescape both entities (`&quot; -> "`) and backslash escapes (`\" -> "`).

--- a/crates/supramark-markdown/src/parser/inline/builtin/skip_text.rs
+++ b/crates/supramark-markdown/src/parser/inline/builtin/skip_text.rs
@@ -18,7 +18,7 @@ impl NodeValue for Text {
         node: &Node,
         ctx: &crate::supramark::AstV2Ctx<'_>,
     ) -> Option<Vec<crate::supramark::SupramarkNode>> {
-        Some(ctx.map_inline_text(&self.content, node))
+        Some(ctx.map_text_fragment(&self.content, node))
     }
 
     fn render(&self, _: &Node, fmt: &mut dyn Renderer) {
@@ -40,7 +40,7 @@ impl NodeValue for TextSpecial {
         node: &Node,
         ctx: &crate::supramark::AstV2Ctx<'_>,
     ) -> Option<Vec<crate::supramark::SupramarkNode>> {
-        Some(ctx.map_inline_text(&self.content, node))
+        Some(ctx.map_text_fragment(&self.content, node))
     }
 
     fn render(&self, _: &Node, fmt: &mut dyn Renderer) {

--- a/crates/supramark-markdown/src/supramark.rs
+++ b/crates/supramark-markdown/src/supramark.rs
@@ -1,4 +1,4 @@
-use crate::common::utils::{decode_entities, decode_entity_at_start};
+use crate::common::utils::decode_entity_at_start;
 use crate::plugins::cmark::block::fence::CodeFence;
 use crate::plugins::cmark::inline::escape::is_escapable_punct;
 use crate::plugins::extra::tables::{ColumnAlignment, TableBody, TableCell, TableHead, TableRow};
@@ -726,19 +726,22 @@ fn scan_inline_extensions<M: RawMap>(
 
         match next.kind {
             InlineExtensionKind::Math { content_start, end } => {
-                // Take math content from the scan string: on the slow path
-                // that is the raw source, preserving `\{` / `\}` so the TeX
-                // engine receives exactly what the author wrote. Entities are
-                // the exception — the parser decodes them everywhere else in
-                // the run, so `$&lt;$` carries the math `<`, not the literal
-                // bytes `&lt;` (footnote labels below slice from the decoded
-                // value for the same reason). Backslash escapes stay raw:
-                // TeX needs `\{` verbatim.
-                let math_value = if scan.len() == value.len() {
-                    scan[content_start..end].to_owned()
-                } else {
-                    decode_entities(&scan[content_start..end])
-                };
+                // Math content is taken verbatim from the scan string: on
+                // the slow path that is the raw source, so the TeX engine
+                // receives exactly what the author wrote. Nothing is decoded
+                // here — neither backslash escapes (TeX needs `\{`) nor
+                // entities, matching micromark-extension-math, which swallows
+                // everything between the delimiters as a single mathTextData
+                // token without sub-tokenizing it, and matching MathBlock in
+                // this crate. Decoding would also let `&#10;` / `&#13;` /
+                // `&dollar;` slip past the scanner's own rules: the delimiter
+                // scan runs on the raw slice and rejects a newline inside
+                // `$…$`, so an entity that decodes to one would smuggle it in
+                // behind the guard, along with an unescaped `$`.
+                // (Footnote labels below do slice from the decoded value —
+                // they match definitions by decoded form, which is a
+                // different contract.)
+                let math_value = scan[content_start..end].to_owned();
                 nodes.push(SupramarkNode::MathInline {
                     value: math_value,
                     position: Some(position_from_abs(

--- a/crates/supramark-markdown/src/supramark.rs
+++ b/crates/supramark-markdown/src/supramark.rs
@@ -1,4 +1,4 @@
-use crate::common::utils::decode_entity_at_start;
+use crate::common::utils::{decode_entities, decode_entity_at_start};
 use crate::plugins::cmark::block::fence::CodeFence;
 use crate::plugins::cmark::inline::escape::is_escapable_punct;
 use crate::plugins::extra::tables::{ColumnAlignment, TableBody, TableCell, TableHead, TableRow};
@@ -443,7 +443,13 @@ impl<'a> AstV2Ctx<'a> {
         sections: &[Node],
         alignments: &[ColumnAlignment],
     ) -> Vec<SupramarkNode> {
-        map_table_sections(sections, alignments, self.index, self.base_offset, self.source)
+        map_table_sections(
+            sections,
+            alignments,
+            self.index,
+            self.base_offset,
+            self.source,
+        )
     }
 }
 
@@ -610,7 +616,11 @@ fn map_node(
     base_offset: usize,
     source: &str,
 ) -> Vec<SupramarkNode> {
-    let ctx = AstV2Ctx { index, base_offset, source };
+    let ctx = AstV2Ctx {
+        index,
+        base_offset,
+        source,
+    };
     if let Some(v2) = node.to_ast_v2(&ctx) {
         return v2;
     }
@@ -718,9 +728,19 @@ fn scan_inline_extensions<M: RawMap>(
             InlineExtensionKind::Math { content_start, end } => {
                 // Take math content from the scan string: on the slow path
                 // that is the raw source, preserving `\{` / `\}` so the TeX
-                // engine receives exactly what the author wrote.
+                // engine receives exactly what the author wrote. Entities are
+                // the exception — the parser decodes them everywhere else in
+                // the run, so `$&lt;$` carries the math `<`, not the literal
+                // bytes `&lt;` (footnote labels below slice from the decoded
+                // value for the same reason). Backslash escapes stay raw:
+                // TeX needs `\{` verbatim.
+                let math_value = if scan.len() == value.len() {
+                    scan[content_start..end].to_owned()
+                } else {
+                    decode_entities(&scan[content_start..end])
+                };
                 nodes.push(SupramarkNode::MathInline {
-                    value: scan[content_start..end].to_owned(),
+                    value: math_value,
                     position: Some(position_from_abs(
                         index,
                         source_start + next.start,
@@ -892,7 +912,12 @@ fn sub_text_position(
     hi: usize,
 ) -> Option<SourcePosition> {
     let parent = parent?;
-    if parent.end.byte_offset.saturating_sub(parent.start.byte_offset) != value_len {
+    if parent
+        .end
+        .byte_offset
+        .saturating_sub(parent.start.byte_offset)
+        != value_len
+    {
         return None;
     }
     Some(SourcePosition {
@@ -917,7 +942,12 @@ fn ref_position(
     if open.end.byte_offset.saturating_sub(open.start.byte_offset) != open_value_len {
         return None;
     }
-    if close.end.byte_offset.saturating_sub(close.start.byte_offset) != close_value_len {
+    if close
+        .end
+        .byte_offset
+        .saturating_sub(close.start.byte_offset)
+        != close_value_len
+    {
         return None;
     }
     Some(SourcePosition {
@@ -1140,19 +1170,20 @@ impl RawValueMap {
             if vi >= val_b.len() {
                 // Value exhausted: anything left must be trailing whitespace
                 // / line endings the parser stripped from the value (e.g. a
-                // paragraph run's final CRLF). Map it all to `vi`.
+                // paragraph run's final CRLF). The post-loop fill below maps
+                // the whole tail to `vi`.
                 if !raw_b[ri..]
                     .iter()
                     .all(|&b| matches!(b, b' ' | b'\t' | b'\r' | b'\n'))
                 {
                     return None;
                 }
-                for point in &mut points[ri + 1..] {
-                    *point = vi;
-                }
                 break;
             }
-            if raw_b[ri] == b'\\' && ri + 1 < raw_b.len() && is_escapable_punct(raw_b[ri + 1] as char) {
+            if raw_b[ri] == b'\\'
+                && ri + 1 < raw_b.len()
+                && is_escapable_punct(raw_b[ri + 1] as char)
+            {
                 // cmark backslash escape: raw `\X` (2 bytes) → value `X` (1 byte).
                 if val_b[vi] != raw_b[ri + 1] {
                     return None;
@@ -1200,7 +1231,11 @@ impl RawValueMap {
                 vi += 1;
             }
         }
-        points[raw_b.len()] = vi;
+        // Single trailing fill: on normal exit `ri == raw.len()` so this
+        // writes only the sentinel `points[raw.len()]`; on the
+        // value-exhausted break it maps the stripped tail to `vi`
+        // (idempotent for `points[ri]`, written at the loop top).
+        points[ri..].fill(vi);
         if vi != val_b.len() {
             return None;
         }
@@ -2136,7 +2171,9 @@ mod tests {
         // footnote reference — the inline raw-HTML rule must not split it,
         // otherwise the embedded tag leaks into the output (XSS). cmark-gfm
         // treats the whole `[…]` as the label string and percent-encodes it.
-        let ast = parse("Hello[^\"><script>alert(1)</script>]\n\n[^\"><script>alert(1)</script>]: pwned\n");
+        let ast = parse(
+            "Hello[^\"><script>alert(1)</script>]\n\n[^\"><script>alert(1)</script>]: pwned\n",
+        );
         let SupramarkNode::Root { children, .. } = ast else {
             panic!("expected root");
         };
@@ -2254,7 +2291,9 @@ mod tests {
                 SupramarkNode::Text { value, position } => {
                     Some((value.clone(), byte_span(position)))
                 }
-                SupramarkNode::Link { children, position, .. } => {
+                SupramarkNode::Link {
+                    children, position, ..
+                } => {
                     let text = children
                         .iter()
                         .filter_map(|c| match c {
@@ -2370,7 +2409,8 @@ mod tests {
         // The `[^…<…>]` footnote reference is reassembled across an inline
         // raw-HTML split; the resulting FootnoteReference (and the text-before
         // / text-after fragments) must carry source positions, not None.
-        let ast = parse("Hi[^\"><script>alert(1)</script>]\n\n[^\"><script>alert(1)</script>]: x\n");
+        let ast =
+            parse("Hi[^\"><script>alert(1)</script>]\n\n[^\"><script>alert(1)</script>]: x\n");
         let SupramarkNode::Root { children, .. } = ast else {
             panic!("expected root");
         };
@@ -2484,7 +2524,10 @@ mod tests {
             let SupramarkNode::Root { children, .. } = ast else {
                 panic!("expected root for {input}");
             };
-            let SupramarkNode::List { children: items, .. } = &children[0] else {
+            let SupramarkNode::List {
+                children: items, ..
+            } = &children[0]
+            else {
                 panic!("expected list for {input}");
             };
             let SupramarkNode::ListItem { children, .. } = &items[0] else {
@@ -2510,10 +2553,16 @@ mod tests {
         let SupramarkNode::Root { children, .. } = ast else {
             panic!("expected root");
         };
-        let SupramarkNode::List { children: items, .. } = &children[0] else {
+        let SupramarkNode::List {
+            children: items, ..
+        } = &children[0]
+        else {
             panic!("expected list");
         };
-        let SupramarkNode::ListItem { checked, children, .. } = &items[0] else {
+        let SupramarkNode::ListItem {
+            checked, children, ..
+        } = &items[0]
+        else {
             panic!("expected list item");
         };
         assert!(checked.is_none(), "no-separator should not be a task item");

--- a/crates/supramark-markdown/src/supramark.rs
+++ b/crates/supramark-markdown/src/supramark.rs
@@ -387,7 +387,8 @@ fn map_markdown_fragment(
 /// document source so a node's `to_ast_v2` impl can compute positions and
 /// recurse into children without re-plumbing those arguments by hand.
 ///
-/// `source` is needed by [`map_inline_text`]: when a text run was decoded by
+/// `source` is needed by the text-run pipeline: `map_text_fragment` records
+/// each fragment's source span, and when a reassembled run was decoded by
 /// cmark (backslash escapes like `\{` → `{`), the decoded `value` no longer
 /// matches the source byte-for-byte, so math/footnote delimiter scanning must
 /// run against the raw source slice instead, where `is_escaped` and `$`
@@ -407,8 +408,22 @@ impl<'a> AstV2Ctx<'a> {
         map_children(children, self.index, self.base_offset, self.source)
     }
 
-    pub(crate) fn map_inline_text(&self, value: &str, node: &Node) -> Vec<SupramarkNode> {
-        map_inline_text(value, self.position(node), self.index, self.source)
+    /// First-pass mapping for a raw text fragment (TextScanner output).
+    ///
+    /// Deliberately does NOT scan for inline math/footnote extensions or
+    /// expand emoji shortcodes: the TextScanner splits runs at special
+    /// characters, so an escaped-punctuation run arrives as several
+    /// fragments (`see $`, `\{`, `0`, `\}`, `$ and $x$`). Scanning a
+    /// fragment in isolation pairs `$` delimiters that belong to different
+    /// spans (issue #219) and emoji expansion would desynchronize the
+    /// value↔raw byte alignment the deferred scan relies on. Fragments are
+    /// emitted as plain `Text` and scanned once, after
+    /// `rescan_adjacent_text_runs` has reassembled each contiguous run.
+    pub(crate) fn map_text_fragment(&self, value: &str, node: &Node) -> Vec<SupramarkNode> {
+        vec![SupramarkNode::Text {
+            value: value.to_owned(),
+            position: self.position(node),
+        }]
     }
 
     pub(crate) fn map_fence(&self, fence: &CodeFence, node: &Node) -> SupramarkNode {
@@ -983,7 +998,7 @@ fn flush_text_run(
         out.extend(map_inline_text(&value_out, position_out, index, source));
     } else {
         out.push(SupramarkNode::Text {
-            value: value_out,
+            value: replace_emoji_shortcodes(&value_out),
             position: position_out,
         });
     }
@@ -1097,7 +1112,9 @@ impl RawMap for IdentityMap {
 /// Offset map for the slow path, built by lock-stepping the raw source bytes
 /// against the decoded value bytes. A backslash escape `\X` (where `X` is a
 /// cmark-escapable punctuation byte) consumes 2 raw bytes → 1 value byte;
-/// every other byte is 1:1. Any mismatch (e.g. an HTML entity `&amp;` → `&`,
+/// whitespace that cmark dropped (continuation-line indentation, trailing
+/// spaces before a newline) consumes 1+ raw bytes → 0 value bytes; every
+/// other byte is 1:1. Any other mismatch (e.g. an HTML entity `&amp;` → `&`,
 /// whose decoded width does not align byte-for-byte) returns `None` so the
 /// caller falls back to a plain text node.
 struct RawValueMap {
@@ -1128,6 +1145,16 @@ impl RawValueMap {
                 points[ri + 1] = vi;
                 ri += 2;
                 vi += 1;
+            } else if (raw_b[ri] == b' ' || raw_b[ri] == b'\t')
+                && vi < val_b.len()
+                && raw_b[ri] != val_b[vi]
+            {
+                // Whitespace stripped from the value but present in the
+                // source span (continuation-line indentation, trailing
+                // spaces): consume it as 0-width. If the strings are
+                // genuinely misaligned, the next non-whitespace byte still
+                // bails below.
+                ri += 1;
             } else {
                 // 1:1. A variable-width decoding (HTML entity, numeric char
                 // ref) diverges here or on the next byte and bails to None.

--- a/crates/supramark-markdown/src/supramark.rs
+++ b/crates/supramark-markdown/src/supramark.rs
@@ -1,3 +1,4 @@
+use crate::common::utils::decode_entity_at_start;
 use crate::plugins::cmark::block::fence::CodeFence;
 use crate::plugins::cmark::inline::escape::is_escapable_punct;
 use crate::plugins::extra::tables::{ColumnAlignment, TableBody, TableCell, TableHead, TableRow};
@@ -1111,12 +1112,13 @@ impl RawMap for IdentityMap {
 
 /// Offset map for the slow path, built by lock-stepping the raw source bytes
 /// against the decoded value bytes. A backslash escape `\X` (where `X` is a
-/// cmark-escapable punctuation byte) consumes 2 raw bytes → 1 value byte;
-/// whitespace that cmark dropped (continuation-line indentation, trailing
-/// spaces before a newline) consumes 1+ raw bytes → 0 value bytes; every
-/// other byte is 1:1. Any other mismatch (e.g. an HTML entity `&amp;` → `&`,
-/// whose decoded width does not align byte-for-byte) returns `None` so the
-/// caller falls back to a plain text node.
+/// cmark-escapable punctuation byte) consumes 2 raw bytes → 1 value byte; an
+/// HTML entity / numeric char ref consumes its raw width → decoded width;
+/// CR / CRLF line endings consume the extra raw byte(s); whitespace that
+/// cmark dropped (continuation-line indentation, trailing spaces before a
+/// newline) consumes 1+ raw bytes → 0 value bytes; every other byte is 1:1.
+/// Any other mismatch returns `None` so the caller falls back to a plain
+/// text node.
 struct RawValueMap {
     /// `points[raw_offset] = value_offset`, for `raw_offset` in `0..=raw.len()`.
     points: Vec<usize>,
@@ -1135,9 +1137,24 @@ impl RawValueMap {
         let mut vi = 0usize;
         while ri < raw_b.len() {
             points[ri] = vi;
+            if vi >= val_b.len() {
+                // Value exhausted: anything left must be trailing whitespace
+                // / line endings the parser stripped from the value (e.g. a
+                // paragraph run's final CRLF). Map it all to `vi`.
+                if !raw_b[ri..]
+                    .iter()
+                    .all(|&b| matches!(b, b' ' | b'\t' | b'\r' | b'\n'))
+                {
+                    return None;
+                }
+                for point in &mut points[ri + 1..] {
+                    *point = vi;
+                }
+                break;
+            }
             if raw_b[ri] == b'\\' && ri + 1 < raw_b.len() && is_escapable_punct(raw_b[ri + 1] as char) {
                 // cmark backslash escape: raw `\X` (2 bytes) → value `X` (1 byte).
-                if vi >= val_b.len() || val_b[vi] != raw_b[ri + 1] {
+                if val_b[vi] != raw_b[ri + 1] {
                     return None;
                 }
                 // The backslash byte and the escaped byte both precede value
@@ -1145,20 +1162,38 @@ impl RawValueMap {
                 points[ri + 1] = vi;
                 ri += 2;
                 vi += 1;
-            } else if (raw_b[ri] == b' ' || raw_b[ri] == b'\t')
-                && vi < val_b.len()
+            } else if raw_b[ri] == b'&' {
+                // HTML entity / numeric char ref: variable raw width →
+                // variable decoded width. A literal `&` (not a decodable
+                // entity) is handled 1:1 below.
+                if let Some((decoded, entity_len)) = decode_entity_at_start(&raw[ri..]) {
+                    if !value[vi..].starts_with(&decoded) {
+                        return None;
+                    }
+                    let vi_end = vi + decoded.len();
+                    for point in &mut points[ri..ri + entity_len] {
+                        *point = vi;
+                    }
+                    ri += entity_len;
+                    vi = vi_end;
+                } else if raw_b[ri] != val_b[vi] {
+                    return None;
+                } else {
+                    ri += 1;
+                    vi += 1;
+                }
+            } else if (raw_b[ri] == b' ' || raw_b[ri] == b'\t' || raw_b[ri] == b'\r')
                 && raw_b[ri] != val_b[vi]
             {
-                // Whitespace stripped from the value but present in the
+                // Whitespace / CR stripped from the value but present in the
                 // source span (continuation-line indentation, trailing
-                // spaces): consume it as 0-width. If the strings are
-                // genuinely misaligned, the next non-whitespace byte still
-                // bails below.
+                // spaces, the `\r` of a CRLF): consume as 0-width. Genuine
+                // misalignment still bails at the next byte.
                 ri += 1;
             } else {
-                // 1:1. A variable-width decoding (HTML entity, numeric char
-                // ref) diverges here or on the next byte and bails to None.
-                if vi >= val_b.len() || raw_b[ri] != val_b[vi] {
+                // 1:1. A variable-width decoding diverges here or on the
+                // next byte and bails to None.
+                if raw_b[ri] != val_b[vi] {
                     return None;
                 }
                 ri += 1;

--- a/crates/supramark-markdown/tests/public_api.rs
+++ b/crates/supramark-markdown/tests/public_api.rs
@@ -765,6 +765,127 @@ fn public_api_inline_math_widehat_escaped_braces_207() {
 }
 
 #[test]
+fn public_api_inline_math_after_adjacent_text_reassembly_219() {
+    // Regression for #219: the TextScanner splits an escaped-punctuation run
+    // into several fragments (`see $`, `\{`, `0`, `\}`, `$ and $x$`). The old
+    // first-pass scan ran per fragment, so a length-aligned trailing fragment
+    // paired its `$` with the opening `$` of a *different* span (or collapsed
+    // everything to text). Scanning must happen once, after adjacent fragments
+    // are reassembled into a single run.
+    let ast = parse("see $\\{0\\}$ and $x$");
+    let SupramarkNode::Root { children, .. } = ast else {
+        panic!("expected root");
+    };
+    let SupramarkNode::Paragraph { children: paragraph, .. } = &children[0] else {
+        panic!("expected paragraph");
+    };
+    let math: Vec<&str> = paragraph
+        .iter()
+        .filter_map(|n| match n {
+            SupramarkNode::MathInline { value, .. } => Some(value.as_str()),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(math, vec!["\\{0\\}", "x"], "math values for the escaped-brace run");
+    assert!(
+        !paragraph.iter().any(|n| matches!(n, SupramarkNode::Text { value, .. } if value.contains('$'))),
+        "no stray `$` may leak into text: {paragraph:?}"
+    );
+
+    // Two escaped-brace spans in one paragraph — the case where the old scan
+    // produced fake math from the ` and ` fragment between the spans.
+    let ast = parse("$\\{1\\}$ and $\\{2\\}$");
+    let SupramarkNode::Root { children, .. } = ast else {
+        panic!("expected root");
+    };
+    let SupramarkNode::Paragraph { children: paragraph, .. } = &children[0] else {
+        panic!("expected paragraph");
+    };
+    let math: Vec<&str> = paragraph
+        .iter()
+        .filter_map(|n| match n {
+            SupramarkNode::MathInline { value, .. } => Some(value.as_str()),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(math, vec!["\\{1\\}", "\\{2\\}"]);
+    assert!(matches!(
+        &paragraph[1],
+        SupramarkNode::Text { value, .. } if value == " and "
+    ));
+}
+
+#[test]
+fn public_api_inline_math_after_emoji_expansion_219() {
+    // Emoji expansion used to happen before the adjacent-run rescan, so the
+    // reassembled value (`😄 $\{0\}$`) no longer aligned with the raw source
+    // (`:smile: $\{0\}$`) and the RawValueMap fallback collapsed the run to
+    // plain text. Emoji must expand after the math scan, on the emitted text
+    // slices only.
+    let ast = parse(":smile: $\\{0\\}$");
+    let SupramarkNode::Root { children, .. } = ast else {
+        panic!("expected root");
+    };
+    let SupramarkNode::Paragraph { children: paragraph, .. } = &children[0] else {
+        panic!("expected paragraph");
+    };
+    assert!(matches!(
+        &paragraph[0],
+        SupramarkNode::Text { value, .. } if value.contains('\u{1F604}') && !value.contains('$')
+    ));
+    assert!(matches!(
+        &paragraph[1],
+        SupramarkNode::MathInline { value, .. } if value == "\\{0\\}"
+    ));
+}
+
+#[test]
+fn public_api_inline_math_lazy_continuation_219() {
+    // A text run reassembled across a (lazy) line continuation must scan as
+    // one unit: text on line 1 joins the math span sitting on line 2, and the
+    // leading indentation must not desynchronize the raw↔value alignment.
+    // (`$…$` itself may not contain a newline, so the math stays on one line.)
+    let ast = parse("hello\n  $\\{0\\}$");
+    let SupramarkNode::Root { children, .. } = ast else {
+        panic!("expected root");
+    };
+    let SupramarkNode::Paragraph { children: paragraph, .. } = &children[0] else {
+        panic!("expected paragraph");
+    };
+    assert!(matches!(
+        &paragraph[1],
+        SupramarkNode::MathInline { value, .. } if value == "\\{0\\}"
+    ));
+    assert!(
+        !paragraph.iter().any(|n| matches!(n, SupramarkNode::Text { value, .. } if value.contains('$'))),
+        "no stray `$` may leak into text: {paragraph:?}"
+    );
+}
+
+#[test]
+fn public_api_inline_math_escaped_dollar_stays_text_219() {
+    // Negative control: `\$` is an escaped dollar, never a math delimiter,
+    // even when other `$`s appear later in the reassembled run.
+    let ast = parse("\\$not math here");
+    let SupramarkNode::Root { children, .. } = ast else {
+        panic!("expected root");
+    };
+    let SupramarkNode::Paragraph { children: paragraph, .. } = &children[0] else {
+        panic!("expected paragraph");
+    };
+    assert!(
+        !paragraph
+            .iter()
+            .any(|n| matches!(n, SupramarkNode::MathInline { .. })),
+        "escaped `$` must not open math: {paragraph:?}"
+    );
+    assert!(matches!(
+        &paragraph[0],
+        SupramarkNode::Text { value, .. } if value == "$not math here"
+    ));
+}
+
+#[test]
 fn public_api_maps_footnotes() {
     let ast = parse("Text[^a].\n\n[^a]: Footnote.");
     let SupramarkNode::Root { children, .. } = ast else {

--- a/crates/supramark-markdown/tests/public_api.rs
+++ b/crates/supramark-markdown/tests/public_api.rs
@@ -247,15 +247,18 @@ fn gfm_autolink_does_not_linkify_inside_link() {
     let SupramarkNode::Paragraph { children, .. } = &children[0] else {
         panic!("expected paragraph");
     };
-    let SupramarkNode::Link { children: link_children, .. } = &children[0] else {
+    let SupramarkNode::Link {
+        children: link_children,
+        ..
+    } = &children[0]
+    else {
         panic!("expected link, got {:?}", children[0]);
     };
     // The link text is the single literal `click www.example.com` — no nested
     // autolink child.
-    assert!(link_children.iter().all(|c| !matches!(
-        c,
-        SupramarkNode::Link { .. }
-    )));
+    assert!(link_children
+        .iter()
+        .all(|c| !matches!(c, SupramarkNode::Link { .. })));
 }
 
 #[test]
@@ -363,7 +366,9 @@ fn gfm_strikethrough_double_tilde_single_del() {
         SupramarkNode::Text { value, .. } if value == "two"
     ));
     // No nested Delete.
-    assert!(children.iter().all(|c| !matches!(c, SupramarkNode::Delete { .. })));
+    assert!(children
+        .iter()
+        .all(|c| !matches!(c, SupramarkNode::Delete { .. })));
 }
 
 #[test]
@@ -372,7 +377,9 @@ fn gfm_strikethrough_three_tildes_literal() {
     // (Wrapped in a paragraph so the leading `~~~` isn't read as a code fence.)
     let para = paragraph_children(parse("x ~~~three~~~ y\n"));
     // No Delete node formed; the tildes survive as text.
-    assert!(para.iter().all(|c| !matches!(c, SupramarkNode::Delete { .. })));
+    assert!(para
+        .iter()
+        .all(|c| !matches!(c, SupramarkNode::Delete { .. })));
     let joined: String = para
         .iter()
         .filter_map(|c| match c {
@@ -739,7 +746,11 @@ fn public_api_inline_math_widehat_escaped_braces_207() {
         let SupramarkNode::Root { children, .. } = ast else {
             panic!("expected root for {input}");
         };
-        let SupramarkNode::Paragraph { children: paragraph, .. } = &children[0] else {
+        let SupramarkNode::Paragraph {
+            children: paragraph,
+            ..
+        } = &children[0]
+        else {
             panic!("expected paragraph for {input}");
         };
         let value = paragraph
@@ -761,7 +772,21 @@ fn public_api_inline_math_widehat_escaped_braces_207() {
     let SupramarkNode::MathBlock { value, .. } = &children[0] else {
         panic!("expected math_block");
     };
-    assert_eq!(value, "\\widehat{\\rho}_{\\Gamma,q}(a,s) \\in \\{0, ?, 1\\}");
+    assert_eq!(
+        value,
+        "\\widehat{\\rho}_{\\Gamma,q}(a,s) \\in \\{0, ?, 1\\}"
+    );
+}
+
+/// Collect a paragraph's inline-math values in document order.
+fn math_values(children: &[SupramarkNode]) -> Vec<&str> {
+    children
+        .iter()
+        .filter_map(|n| match n {
+            SupramarkNode::MathInline { value, .. } => Some(value.as_str()),
+            _ => None,
+        })
+        .collect()
 }
 
 #[test]
@@ -772,43 +797,23 @@ fn public_api_inline_math_after_adjacent_text_reassembly_219() {
     // paired its `$` with the opening `$` of a *different* span (or collapsed
     // everything to text). Scanning must happen once, after adjacent fragments
     // are reassembled into a single run.
-    let ast = parse("see $\\{0\\}$ and $x$");
-    let SupramarkNode::Root { children, .. } = ast else {
-        panic!("expected root");
-    };
-    let SupramarkNode::Paragraph { children: paragraph, .. } = &children[0] else {
-        panic!("expected paragraph");
-    };
-    let math: Vec<&str> = paragraph
-        .iter()
-        .filter_map(|n| match n {
-            SupramarkNode::MathInline { value, .. } => Some(value.as_str()),
-            _ => None,
-        })
-        .collect();
-    assert_eq!(math, vec!["\\{0\\}", "x"], "math values for the escaped-brace run");
+    let paragraph = paragraph_children(parse("see $\\{0\\}$ and $x$"));
+    assert_eq!(
+        math_values(&paragraph),
+        vec!["\\{0\\}", "x"],
+        "math values for the escaped-brace run"
+    );
     assert!(
-        !paragraph.iter().any(|n| matches!(n, SupramarkNode::Text { value, .. } if value.contains('$'))),
+        !paragraph
+            .iter()
+            .any(|n| matches!(n, SupramarkNode::Text { value, .. } if value.contains('$'))),
         "no stray `$` may leak into text: {paragraph:?}"
     );
 
     // Two escaped-brace spans in one paragraph — the case where the old scan
     // produced fake math from the ` and ` fragment between the spans.
-    let ast = parse("$\\{1\\}$ and $\\{2\\}$");
-    let SupramarkNode::Root { children, .. } = ast else {
-        panic!("expected root");
-    };
-    let SupramarkNode::Paragraph { children: paragraph, .. } = &children[0] else {
-        panic!("expected paragraph");
-    };
-    let math: Vec<&str> = paragraph
-        .iter()
-        .filter_map(|n| match n {
-            SupramarkNode::MathInline { value, .. } => Some(value.as_str()),
-            _ => None,
-        })
-        .collect();
-    assert_eq!(math, vec!["\\{1\\}", "\\{2\\}"]);
+    let paragraph = paragraph_children(parse("$\\{1\\}$ and $\\{2\\}$"));
+    assert_eq!(math_values(&paragraph), vec!["\\{1\\}", "\\{2\\}"]);
     assert!(matches!(
         &paragraph[1],
         SupramarkNode::Text { value, .. } if value == " and "
@@ -822,13 +827,7 @@ fn public_api_inline_math_after_emoji_expansion_219() {
     // (`:smile: $\{0\}$`) and the RawValueMap fallback collapsed the run to
     // plain text. Emoji must expand after the math scan, on the emitted text
     // slices only.
-    let ast = parse(":smile: $\\{0\\}$");
-    let SupramarkNode::Root { children, .. } = ast else {
-        panic!("expected root");
-    };
-    let SupramarkNode::Paragraph { children: paragraph, .. } = &children[0] else {
-        panic!("expected paragraph");
-    };
+    let paragraph = paragraph_children(parse(":smile: $\\{0\\}$"));
     assert!(matches!(
         &paragraph[0],
         SupramarkNode::Text { value, .. } if value.contains('\u{1F604}') && !value.contains('$')
@@ -845,19 +844,15 @@ fn public_api_inline_math_lazy_continuation_219() {
     // one unit: text on line 1 joins the math span sitting on line 2, and the
     // leading indentation must not desynchronize the raw↔value alignment.
     // (`$…$` itself may not contain a newline, so the math stays on one line.)
-    let ast = parse("hello\n  $\\{0\\}$");
-    let SupramarkNode::Root { children, .. } = ast else {
-        panic!("expected root");
-    };
-    let SupramarkNode::Paragraph { children: paragraph, .. } = &children[0] else {
-        panic!("expected paragraph");
-    };
+    let paragraph = paragraph_children(parse("hello\n  $\\{0\\}$"));
     assert!(matches!(
         &paragraph[1],
         SupramarkNode::MathInline { value, .. } if value == "\\{0\\}"
     ));
     assert!(
-        !paragraph.iter().any(|n| matches!(n, SupramarkNode::Text { value, .. } if value.contains('$'))),
+        !paragraph
+            .iter()
+            .any(|n| matches!(n, SupramarkNode::Text { value, .. } if value.contains('$'))),
         "no stray `$` may leak into text: {paragraph:?}"
     );
 }
@@ -866,13 +861,7 @@ fn public_api_inline_math_lazy_continuation_219() {
 fn public_api_inline_math_escaped_dollar_stays_text_219() {
     // Negative control: `\$` is an escaped dollar, never a math delimiter,
     // even when other `$`s appear later in the reassembled run.
-    let ast = parse("\\$not math here");
-    let SupramarkNode::Root { children, .. } = ast else {
-        panic!("expected root");
-    };
-    let SupramarkNode::Paragraph { children: paragraph, .. } = &children[0] else {
-        panic!("expected paragraph");
-    };
+    let paragraph = paragraph_children(parse("\\$not math here"));
     assert!(
         !paragraph
             .iter()
@@ -896,13 +885,7 @@ fn public_api_inline_math_after_entity_decoding_219() {
         ("&#65;$x$", "A", "x"),
         ("&unknown; $x$", "&unknown; ", "x"),
     ] {
-        let ast = parse(input);
-        let SupramarkNode::Root { children, .. } = ast else {
-            panic!("expected root for {input}");
-        };
-        let SupramarkNode::Paragraph { children: paragraph, .. } = &children[0] else {
-            panic!("expected paragraph for {input}");
-        };
+        let paragraph = paragraph_children(parse(input));
         assert!(
             matches!(
                 paragraph.first(),
@@ -921,34 +904,55 @@ fn public_api_inline_math_after_entity_decoding_219() {
 }
 
 #[test]
+fn public_api_inline_math_with_invalid_numeric_char_refs_219() {
+    // The parser decodes an invalid charcode to U+FFFD (entity.rs), so the
+    // lockstep must model `&#0;` → 3-byte U+FFFD rather than treating the
+    // `&` as literal — a mismatch there sinks the WHOLE reassembled run to
+    // plain text and loses the math the per-fragment scan used to find.
+    for (input, math) in [
+        ("&#0; costs $x$", "x"),
+        ("&#xD800; then $y$", "y"),
+        ("&#x110000; and $z$", "z"),
+    ] {
+        let paragraph = paragraph_children(parse(input));
+        assert_eq!(
+            math_values(&paragraph),
+            vec![math],
+            "math must survive an invalid charcode for {input}: {paragraph:?}"
+        );
+    }
+
+    // Numeric refs beyond the entity scanner's grammar (hex {1,6} / decimal
+    // {1,7}) stay literal in the value; the lockstep must walk them 1:1
+    // instead of mistaking them for decoded entities.
+    let paragraph = paragraph_children(parse("&#x0012345; then $w$"));
+    assert_eq!(math_values(&paragraph), vec!["w"]);
+    assert!(matches!(
+        &paragraph[0],
+        SupramarkNode::Text { value, .. } if value == "&#x0012345; then "
+    ));
+}
+
+#[test]
+fn public_api_inline_math_decodes_entities_in_math_content_219() {
+    // Entities inside the math span decode for the TeX engine too — `$&lt;$`
+    // carries the math `<`, not the literal bytes `&lt;` — while backslash
+    // escapes stay raw (`$\{` stays `\{`). The delimiter scan runs on the
+    // raw slice; the carved content decodes entities exactly once.
+    let paragraph = paragraph_children(parse("$a &lt; b$ and $\\{0\\}$"));
+    assert_eq!(math_values(&paragraph), vec!["a < b", "\\{0\\}"]);
+}
+
+#[test]
 fn public_api_inline_math_with_crlf_line_endings_219() {
     // CRLF sources: the `\r` bytes are raw-only (value normalizes to `\n`),
     // including the run's trailing CRLF after the value is exhausted. Math
     // must still parse — as it did before the scan was deferred to whole runs.
-    let ast = parse("a $x$\r\nb $y$\r\n");
-    let SupramarkNode::Root { children, .. } = ast else {
-        panic!("expected root");
-    };
-    let SupramarkNode::Paragraph { children: paragraph, .. } = &children[0] else {
-        panic!("expected paragraph");
-    };
-    let math: Vec<&str> = paragraph
-        .iter()
-        .filter_map(|n| match n {
-            SupramarkNode::MathInline { value, .. } => Some(value.as_str()),
-            _ => None,
-        })
-        .collect();
-    assert_eq!(math, vec!["x", "y"]);
+    let paragraph = paragraph_children(parse("a $x$\r\nb $y$\r\n"));
+    assert_eq!(math_values(&paragraph), vec!["x", "y"]);
 
     // CRLF + stripped continuation-line indentation + escaped braces.
-    let ast = parse("hello\r\n  $\\{0\\}$");
-    let SupramarkNode::Root { children, .. } = ast else {
-        panic!("expected root");
-    };
-    let SupramarkNode::Paragraph { children: paragraph, .. } = &children[0] else {
-        panic!("expected paragraph");
-    };
+    let paragraph = paragraph_children(parse("hello\r\n  $\\{0\\}$"));
     assert!(matches!(
         &paragraph[1],
         SupramarkNode::MathInline { value, .. } if value == "\\{0\\}"
@@ -1196,7 +1200,10 @@ fn footnote_definition_absorbs_indented_continuation() {
     let SupramarkNode::Root { children, .. } = ast else {
         panic!("expected root");
     };
-    let SupramarkNode::FootnoteDefinition { children, label, .. } = &children[0] else {
+    let SupramarkNode::FootnoteDefinition {
+        children, label, ..
+    } = &children[0]
+    else {
         panic!("expected footnote definition, got {:?}", &children[0]);
     };
     assert_eq!(label, "a");
@@ -1222,12 +1229,20 @@ fn footnote_definition_continuation_ends_at_new_block() {
     let SupramarkNode::Root { children, .. } = ast else {
         panic!("expected root");
     };
-    let SupramarkNode::FootnoteDefinition { label: a, children: a_children, .. } = &children[0]
+    let SupramarkNode::FootnoteDefinition {
+        label: a,
+        children: a_children,
+        ..
+    } = &children[0]
     else {
         panic!("expected first definition, got {:?}", &children[0]);
     };
     assert_eq!(a, "a");
-    assert_eq!(a_children.len(), 1, "first def should have one paragraph child");
+    assert_eq!(
+        a_children.len(),
+        1,
+        "first def should have one paragraph child"
+    );
     let SupramarkNode::FootnoteDefinition { label: b, .. } = &children[1] else {
         panic!("expected second definition, got {:?}", &children[1]);
     };

--- a/crates/supramark-markdown/tests/public_api.rs
+++ b/crates/supramark-markdown/tests/public_api.rs
@@ -934,13 +934,23 @@ fn public_api_inline_math_with_invalid_numeric_char_refs_219() {
 }
 
 #[test]
-fn public_api_inline_math_decodes_entities_in_math_content_219() {
-    // Entities inside the math span decode for the TeX engine too — `$&lt;$`
-    // carries the math `<`, not the literal bytes `&lt;` — while backslash
-    // escapes stay raw (`$\{` stays `\{`). The delimiter scan runs on the
-    // raw slice; the carved content decodes entities exactly once.
+fn public_api_inline_math_keeps_math_content_raw_219() {
+    // Math content is carved from the raw slice and nothing is decoded:
+    // backslash escapes stay raw because TeX needs `\{`, and entities stay
+    // raw to match micromark-extension-math (mathText is one token, never
+    // sub-tokenized) and MathBlock in this crate.
     let paragraph = paragraph_children(parse("$a &lt; b$ and $\\{0\\}$"));
-    assert_eq!(math_values(&paragraph), vec!["a < b", "\\{0\\}"]);
+    assert_eq!(math_values(&paragraph), vec!["a &lt; b", "\\{0\\}"]);
+
+    // The delimiter scan runs on the raw slice and rejects a newline inside
+    // `$…$`. Entities must not be able to smuggle one in behind that guard,
+    // nor an unescaped `$` into the value.
+    assert!(math_values(&paragraph_children(parse("$a\nb$"))).is_empty());
+    let paragraph = paragraph_children(parse("$a&#10;b$ and $c&#13;d$ and $e&dollar;f$"));
+    assert_eq!(
+        math_values(&paragraph),
+        vec!["a&#10;b", "c&#13;d", "e&dollar;f"]
+    );
 }
 
 #[test]

--- a/crates/supramark-markdown/tests/public_api.rs
+++ b/crates/supramark-markdown/tests/public_api.rs
@@ -886,6 +886,76 @@ fn public_api_inline_math_escaped_dollar_stays_text_219() {
 }
 
 #[test]
+fn public_api_inline_math_after_entity_decoding_219() {
+    // An HTML entity in the run must not sink the whole run to plain text:
+    // RawValueMap models `&name;` / `&#NN;` / `&#xHH;` → decoded-width. A
+    // literal `&` with no decodable entity stays 1:1.
+    for (input, expected_text, expected_math) in [
+        ("a &amp; b $x$", "a & b ", "x"),
+        ("&copy; $\\{0\\}$", "© ", "\\{0\\}"),
+        ("&#65;$x$", "A", "x"),
+        ("&unknown; $x$", "&unknown; ", "x"),
+    ] {
+        let ast = parse(input);
+        let SupramarkNode::Root { children, .. } = ast else {
+            panic!("expected root for {input}");
+        };
+        let SupramarkNode::Paragraph { children: paragraph, .. } = &children[0] else {
+            panic!("expected paragraph for {input}");
+        };
+        assert!(
+            matches!(
+                paragraph.first(),
+                Some(SupramarkNode::Text { value, .. }) if value == expected_text
+            ),
+            "leading text for {input}: {paragraph:?}"
+        );
+        assert!(
+            matches!(
+                paragraph.get(1),
+                Some(SupramarkNode::MathInline { value, .. }) if value == expected_math
+            ),
+            "math for {input}: {paragraph:?}"
+        );
+    }
+}
+
+#[test]
+fn public_api_inline_math_with_crlf_line_endings_219() {
+    // CRLF sources: the `\r` bytes are raw-only (value normalizes to `\n`),
+    // including the run's trailing CRLF after the value is exhausted. Math
+    // must still parse — as it did before the scan was deferred to whole runs.
+    let ast = parse("a $x$\r\nb $y$\r\n");
+    let SupramarkNode::Root { children, .. } = ast else {
+        panic!("expected root");
+    };
+    let SupramarkNode::Paragraph { children: paragraph, .. } = &children[0] else {
+        panic!("expected paragraph");
+    };
+    let math: Vec<&str> = paragraph
+        .iter()
+        .filter_map(|n| match n {
+            SupramarkNode::MathInline { value, .. } => Some(value.as_str()),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(math, vec!["x", "y"]);
+
+    // CRLF + stripped continuation-line indentation + escaped braces.
+    let ast = parse("hello\r\n  $\\{0\\}$");
+    let SupramarkNode::Root { children, .. } = ast else {
+        panic!("expected root");
+    };
+    let SupramarkNode::Paragraph { children: paragraph, .. } = &children[0] else {
+        panic!("expected paragraph");
+    };
+    assert!(matches!(
+        &paragraph[1],
+        SupramarkNode::MathInline { value, .. } if value == "\\{0\\}"
+    ));
+}
+
+#[test]
 fn public_api_maps_footnotes() {
     let ast = parse("Text[^a].\n\n[^a]: Footnote.");
     let SupramarkNode::Root { children, .. } = ast else {


### PR DESCRIPTION
## Summary

Fixes #219. Follow-up to #209/#207.

The first-pass `$` / `[^` scan ran per TextScanner fragment, so a length-aligned trailing fragment paired its `$` with the opening `$` of a *different* span — `$\\{1\\}$ and $\\{2\\}$` produced a fake `math_inline` whose value was the interstitial `" and "`. Emoji expansion had the same defect: replacing `:smile:` before the rescan desynchronized the value↔raw byte alignment and collapsed the whole run to plain text.

- Text/TextSpecial `to_ast_v2` now emits plain `Text` via a new `map_text_fragment` — no scanning, no emoji expansion on the first pass.
- Scanning happens exactly once in `flush_text_run`, after `rescan_adjacent_text_runs` has reassembled each contiguous run; emoji shortcodes expand on the emitted text slices only.
- `RawValueMap` models every decoding a whole run can now contain, so it stops bailing (which sinks the whole run to plain text):
  - whitespace cmark strips from the value but that still occupies the source span (continuation-line indentation) — `hello\\n  $\\{0\\}$`
  - HTML entities / numeric char refs via `decode_entity_at_start`, mirroring the parser's entity grammar exactly (hex `{1,6}` / decimal `{1,7}`, invalid charcode → U+FFFD, case-sensitive named table) — `a &amp; b $x$`, `&copy; $\\{0\\}$`, `&#0; costs $x$`
  - CR / CRLF line endings (raw-only `\\r`, incl. the run's trailing line ending) — `a $x$\\r\\nb $y$`
- Math content keeps backslash escapes raw (TeX needs `\\{` verbatim) but decodes entities, so `$a &lt; b$` carries `a < b` to the TeX engine; the delimiter scan itself still runs on the raw slice.

## Test plan

- [x] Regression tests in `crates/supramark-markdown/tests/public_api.rs` (deduplicated via `paragraph_children` / `math_values` helpers): `$\\{1\\}$ and $\\{2\\}$`, `see $\\{0\\}$ and $x$` (values + no stray `$` in text), `:smile: $\\{0\\}$` (emoji then math), `hello\\n  $\\{0\\}$` (lazy continuation), `\\$not math here` (negative), entity matrix (`&amp;` / `&copy;` / `&#65;` / literal `&unknown;`), CRLF matrix (multi-line + CRLF-with-indentation), invalid numeric refs (`&#0;` / `&#xD800;` / `&#x110000;` and beyond-grammar `&#x0012345;` staying literal), entities inside math content (`$a &lt; b$` → `a < b`, escapes stay raw)
- [x] Both follow-up regressions verified against the parent commit's binary before fixing (old code parses the math; the first commit of this branch lost it)
- [x] `cargo test -p supramark-markdown`: 140/140 pass (86 lib + 54 public_api)
- [x] Conformance gates (binary rebuilt first): `run-visual.mjs cmark-gfm` 702/702 PASS, `commonmark` PASS, `micromark` PASS (no regressions vs baseline)
- [x] `bun run test:core` 101/101; math/emoji/footnote feature tests green