### PR TITLE
feat(video): add :::video container with JSON config and host onVideoPress

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "supramark",
@@ -31,7 +30,11 @@
         "@supramark/engines": "workspace:*",
         "react": "*",
         "react-native": "*",
+        "react-native-windows": "*",
       },
+      "optionalPeers": [
+        "react-native-windows",
+      ],
     },
     "crates/d2-little/packages/web": {
       "name": "@actrium/d2-little-web",
@@ -83,7 +86,11 @@
         "@supramark/engines": "workspace:*",
         "react": "*",
         "react-native": "*",
+        "react-native-windows": "*",
       },
+      "optionalPeers": [
+        "react-native-windows",
+      ],
     },
     "crates/mermaid-little/packages/web": {
       "name": "@actrium/mermaid-little-web",
@@ -121,7 +128,11 @@
         "@supramark/core": "workspace:*",
         "react": "*",
         "react-native": "*",
+        "react-native-windows": "*",
       },
+      "optionalPeers": [
+        "react-native-windows",
+      ],
     },
     "crates/supramark-markdown/packages/web": {
       "name": "@supramark/markdown-web",
@@ -370,6 +381,17 @@
         "@types/jest": "^29.5.0",
         "jest": "^29.5.0",
         "ts-jest": "^29.1.0",
+        "typescript": "^5.5.0",
+      },
+      "peerDependencies": {
+        "@supramark/core": "*",
+      },
+    },
+    "packages/features/containers/video": {
+      "name": "@supramark/feature-video",
+      "version": "0.1.0",
+      "devDependencies": {
+        "@types/jest": "^29.5.0",
         "typescript": "^5.5.0",
       },
       "peerDependencies": {
@@ -1420,6 +1442,8 @@
     "@supramark/feature-mermaid": ["@supramark/feature-mermaid@workspace:packages/features/diagrams/mermaid"],
 
     "@supramark/feature-plantuml": ["@supramark/feature-plantuml@workspace:packages/features/diagrams/plantuml"],
+
+    "@supramark/feature-video": ["@supramark/feature-video@workspace:packages/features/containers/video"],
 
     "@supramark/feature-weather": ["@supramark/feature-weather@workspace:packages/features/containers/weather"],
 

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "supramark",
@@ -30,11 +31,7 @@
         "@supramark/engines": "workspace:*",
         "react": "*",
         "react-native": "*",
-        "react-native-windows": "*",
       },
-      "optionalPeers": [
-        "react-native-windows",
-      ],
     },
     "crates/d2-little/packages/web": {
       "name": "@actrium/d2-little-web",
@@ -86,11 +83,7 @@
         "@supramark/engines": "workspace:*",
         "react": "*",
         "react-native": "*",
-        "react-native-windows": "*",
       },
-      "optionalPeers": [
-        "react-native-windows",
-      ],
     },
     "crates/mermaid-little/packages/web": {
       "name": "@actrium/mermaid-little-web",
@@ -128,11 +121,7 @@
         "@supramark/core": "workspace:*",
         "react": "*",
         "react-native": "*",
-        "react-native-windows": "*",
       },
-      "optionalPeers": [
-        "react-native-windows",
-      ],
     },
     "crates/supramark-markdown/packages/web": {
       "name": "@supramark/markdown-web",
@@ -208,6 +197,7 @@
         "@supramark/feature-html-page": "workspace:*",
         "@supramark/feature-map": "workspace:*",
         "@supramark/feature-math": "workspace:*",
+        "@supramark/feature-video": "workspace:*",
         "@supramark/markdown-native-rn": "workspace:*",
         "@supramark/rn": "workspace:*",
         "@supramark/rn-selection": "workspace:*",
@@ -251,6 +241,7 @@
         "@supramark/feature-math": "workspace:*",
         "@supramark/feature-mermaid": "workspace:*",
         "@supramark/feature-plantuml": "workspace:*",
+        "@supramark/feature-video": "workspace:*",
         "@supramark/feature-weather": "workspace:*",
         "@supramark/web": "workspace:*",
         "echarts": "^5.5.0",
@@ -391,12 +382,22 @@
       "name": "@supramark/feature-video",
       "version": "0.1.0",
       "devDependencies": {
+        "@supramark/rn": "workspace:*",
         "@types/jest": "^29.5.0",
+        "react": "19.1.0",
+        "react-dom": "19.1.0",
         "typescript": "^5.5.0",
       },
       "peerDependencies": {
         "@supramark/core": "*",
+        "@supramark/rn": "*",
+        "react": ">=18.0.0",
+        "react-native": ">=0.72.0",
       },
+      "optionalPeers": [
+        "@supramark/rn",
+        "react-native",
+      ],
     },
     "packages/features/containers/weather": {
       "name": "@supramark/feature-weather",

--- a/crates/supramark-markdown/Cargo.toml
+++ b/crates/supramark-markdown/Cargo.toml
@@ -45,6 +45,7 @@ container-map = ["container"]
 container-html = ["container", "raw-html"]
 container-weather = ["container"]
 container-vison = ["container"]
+container-video = ["container"]
 linkify = ["dep:linkify"]
 
 [dependencies]

--- a/crates/supramark-markdown/src/supramark.rs
+++ b/crates/supramark-markdown/src/supramark.rs
@@ -1688,15 +1688,15 @@ fn parse_weather_data(params: Option<&str>, value: &str) -> serde_json::Value {
 
     match parsed {
         Ok(config) => {
-            copy_weather_field(&mut object, &config, "location", &["location"]);
-            copy_weather_field(&mut object, &config, "units", &["units"]);
-            copy_weather_field(
+            copy_config_field(&mut object, &config, "location", &["location"]);
+            copy_config_field(&mut object, &config, "units", &["units"]);
+            copy_config_field(
                 &mut object,
                 &config,
                 "showForecast",
                 &["showForecast", "show_forecast"],
             );
-            copy_weather_field(&mut object, &config, "days", &["days"]);
+            copy_config_field(&mut object, &config, "days", &["days"]);
         }
         Err(error) => {
             object.insert("parseError".to_owned(), serde_json::Value::String(error));
@@ -1788,7 +1788,7 @@ fn parse_weather_scalar_value(raw: &str) -> Option<serde_json::Value> {
     Some(serde_json::Value::String(unquoted.to_owned()))
 }
 
-fn copy_weather_field(
+fn copy_config_field(
     target: &mut serde_json::Map<String, serde_json::Value>,
     source: &serde_json::Map<String, serde_json::Value>,
     output_key: &str,
@@ -1799,6 +1799,43 @@ fn copy_weather_field(
             target.insert(output_key.to_owned(), value.clone());
         }
     }
+}
+
+/// Parses a `:::video` container body (a JSON object) into structured data.
+///
+/// Recognized fields: src / poster / title / autoplay / loop / muted /
+/// controls / width. Unknown fields are dropped. Invalid JSON or a non-object
+/// body yields `parseError` + `rawConfig` instead of failing the parse.
+fn parse_video_data(value: &str) -> serde_json::Value {
+    let mut object = serde_json::Map::new();
+
+    let parsed = match serde_json::from_str::<serde_json::Value>(value.trim()) {
+        Ok(serde_json::Value::Object(object)) => Ok(object),
+        Ok(_) => Err("video JSON config must be an object".to_owned()),
+        Err(error) => Err(error.to_string()),
+    };
+
+    match parsed {
+        Ok(config) => {
+            copy_config_field(&mut object, &config, "src", &["src"]);
+            copy_config_field(&mut object, &config, "poster", &["poster"]);
+            copy_config_field(&mut object, &config, "title", &["title"]);
+            copy_config_field(&mut object, &config, "autoplay", &["autoplay"]);
+            copy_config_field(&mut object, &config, "loop", &["loop"]);
+            copy_config_field(&mut object, &config, "muted", &["muted"]);
+            copy_config_field(&mut object, &config, "controls", &["controls"]);
+            copy_config_field(&mut object, &config, "width", &["width"]);
+        }
+        Err(error) => {
+            object.insert("parseError".to_owned(), serde_json::Value::String(error));
+            object.insert(
+                "rawConfig".to_owned(),
+                serde_json::Value::String(value.to_owned()),
+            );
+        }
+    }
+
+    serde_json::Value::Object(object)
 }
 
 fn parse_map_data(value: &str) -> Option<serde_json::Value> {
@@ -1980,6 +2017,7 @@ pub(crate) fn build_extension_node(
                 "vison" => Some(parse_vison_data(&value)),
                 "html" => Some(serde_json::json!({ "html": value.clone() })),
                 "weather" => Some(parse_weather_data(open.params.as_deref(), &value)),
+                "video" => Some(parse_video_data(&value)),
                 _ => None,
             };
             SupramarkNode::Container {

--- a/crates/supramark-markdown/src/supramark.rs
+++ b/crates/supramark-markdown/src/supramark.rs
@@ -1801,11 +1801,45 @@ fn copy_config_field(
     }
 }
 
+/// Copies a config field only when its JSON value has the expected type.
+///
+/// This keeps the AST contract clean before data reaches bundled or
+/// third-party renderers. Wrong-typed values are treated like unknown fields.
+fn copy_typed_config_field(
+    target: &mut serde_json::Map<String, serde_json::Value>,
+    source: &serde_json::Map<String, serde_json::Value>,
+    output_key: &str,
+    input_keys: &[&str],
+    predicate: fn(&serde_json::Value) -> bool,
+) {
+    // Resolve aliases in priority order, matching the existing copy helper.
+    if let Some(value) = input_keys.iter().find_map(|key| source.get(*key)) {
+        // Reject null and wrong-typed values before they enter the AST.
+        if !value.is_null() && predicate(value) {
+            target.insert(output_key.to_owned(), value.clone());
+        }
+    }
+}
+
+/// Caps invalid video config retained in the AST and rendered error card.
+fn truncate_video_raw_config(value: &str) -> String {
+    // Count Unicode scalar values so truncation never splits a UTF-8 sequence.
+    const MAX_RAW_CONFIG_CHARS: usize = 1024;
+    let mut chars = value.chars();
+    let truncated: String = chars.by_ref().take(MAX_RAW_CONFIG_CHARS).collect();
+    // Append a marker only when content was actually omitted.
+    if chars.next().is_some() {
+        format!("{truncated}…")
+    } else {
+        truncated
+    }
+}
+
 /// Parses a `:::video` container body (a JSON object) into structured data.
 ///
 /// Recognized fields: src / poster / title / autoplay / loop / muted /
-/// controls / width. Unknown fields are dropped. Invalid JSON or a non-object
-/// body yields `parseError` + `rawConfig` instead of failing the parse.
+/// controls / width. Unknown and wrong-typed fields are dropped. Invalid JSON
+/// or a non-object body yields `parseError` + `rawConfig` instead of failing.
 fn parse_video_data(value: &str) -> serde_json::Value {
     let mut object = serde_json::Map::new();
 
@@ -1817,20 +1851,68 @@ fn parse_video_data(value: &str) -> serde_json::Value {
 
     match parsed {
         Ok(config) => {
-            copy_config_field(&mut object, &config, "src", &["src"]);
-            copy_config_field(&mut object, &config, "poster", &["poster"]);
-            copy_config_field(&mut object, &config, "title", &["title"]);
-            copy_config_field(&mut object, &config, "autoplay", &["autoplay"]);
-            copy_config_field(&mut object, &config, "loop", &["loop"]);
-            copy_config_field(&mut object, &config, "muted", &["muted"]);
-            copy_config_field(&mut object, &config, "controls", &["controls"]);
-            copy_config_field(&mut object, &config, "width", &["width"]);
+            copy_typed_config_field(
+                &mut object,
+                &config,
+                "src",
+                &["src"],
+                serde_json::Value::is_string,
+            );
+            copy_typed_config_field(
+                &mut object,
+                &config,
+                "poster",
+                &["poster"],
+                serde_json::Value::is_string,
+            );
+            copy_typed_config_field(
+                &mut object,
+                &config,
+                "title",
+                &["title"],
+                serde_json::Value::is_string,
+            );
+            copy_typed_config_field(
+                &mut object,
+                &config,
+                "autoplay",
+                &["autoplay"],
+                serde_json::Value::is_boolean,
+            );
+            copy_typed_config_field(
+                &mut object,
+                &config,
+                "loop",
+                &["loop"],
+                serde_json::Value::is_boolean,
+            );
+            copy_typed_config_field(
+                &mut object,
+                &config,
+                "muted",
+                &["muted"],
+                serde_json::Value::is_boolean,
+            );
+            copy_typed_config_field(
+                &mut object,
+                &config,
+                "controls",
+                &["controls"],
+                serde_json::Value::is_boolean,
+            );
+            copy_typed_config_field(
+                &mut object,
+                &config,
+                "width",
+                &["width"],
+                serde_json::Value::is_number,
+            );
         }
         Err(error) => {
             object.insert("parseError".to_owned(), serde_json::Value::String(error));
             object.insert(
                 "rawConfig".to_owned(),
-                serde_json::Value::String(value.to_owned()),
+                serde_json::Value::String(truncate_video_raw_config(value)),
             );
         }
     }

--- a/crates/supramark-markdown/tests/public_api.rs
+++ b/crates/supramark-markdown/tests/public_api.rs
@@ -674,6 +674,25 @@ fn public_api_maps_video_container_non_object_error() {
 }
 
 #[test]
+fn public_api_maps_video_container_drops_unknown_fields() {
+    let ast = parse(
+        ":::video\n{\"src\": \"https://example.com/a.mp4\", \"unknown\": \"dropped\"}\n:::\n",
+    );
+    let SupramarkNode::Root { children, .. } = ast else {
+        panic!("expected root");
+    };
+    let SupramarkNode::Container { data, .. } = &children[0] else {
+        panic!("expected container");
+    };
+
+    assert_eq!(
+        data.as_ref().and_then(|data| data.pointer("/src")),
+        Some(&serde_json::json!("https://example.com/a.mp4"))
+    );
+    assert_eq!(data.as_ref().and_then(|data| data.pointer("/unknown")), None);
+}
+
+#[test]
 fn public_api_preserves_raw_html_blocks() {
     let ast = parse("<div>Hello</div>\n");
     let SupramarkNode::Root { children, .. } = ast else {

--- a/crates/supramark-markdown/tests/public_api.rs
+++ b/crates/supramark-markdown/tests/public_api.rs
@@ -585,6 +585,95 @@ fn public_api_maps_weather_container_data() {
 }
 
 #[test]
+fn public_api_maps_video_container_data() {
+    let ast = parse(
+        ":::video\n{\n  \"src\": \"https://example.com/demo.mp4\",\n  \"poster\": \"https://example.com/cover.jpg\",\n  \"title\": \"Product demo\",\n  \"autoplay\": true,\n  \"muted\": true,\n  \"loop\": false,\n  \"controls\": true,\n  \"width\": 80\n}\n:::\n",
+    );
+    let SupramarkNode::Root { children, .. } = ast else {
+        panic!("expected root");
+    };
+    let SupramarkNode::Container {
+        name, params, data, ..
+    } = &children[0]
+    else {
+        panic!("expected container");
+    };
+
+    assert_eq!(name, "video");
+    assert_eq!(params, &None);
+    assert_eq!(
+        data.as_ref().and_then(|data| data.pointer("/src")),
+        Some(&serde_json::json!("https://example.com/demo.mp4"))
+    );
+    assert_eq!(
+        data.as_ref().and_then(|data| data.pointer("/poster")),
+        Some(&serde_json::json!("https://example.com/cover.jpg"))
+    );
+    assert_eq!(
+        data.as_ref().and_then(|data| data.pointer("/title")),
+        Some(&serde_json::json!("Product demo"))
+    );
+    assert_eq!(
+        data.as_ref().and_then(|data| data.pointer("/autoplay")),
+        Some(&serde_json::json!(true))
+    );
+    assert_eq!(
+        data.as_ref().and_then(|data| data.pointer("/muted")),
+        Some(&serde_json::json!(true))
+    );
+    assert_eq!(
+        data.as_ref().and_then(|data| data.pointer("/loop")),
+        Some(&serde_json::json!(false))
+    );
+    assert_eq!(
+        data.as_ref().and_then(|data| data.pointer("/controls")),
+        Some(&serde_json::json!(true))
+    );
+    assert_eq!(
+        data.as_ref().and_then(|data| data.pointer("/width")),
+        Some(&serde_json::json!(80))
+    );
+}
+
+#[test]
+fn public_api_maps_video_container_parse_error() {
+    let ast = parse(":::video\n{invalid json}\n:::\n");
+    let SupramarkNode::Root { children, .. } = ast else {
+        panic!("expected root");
+    };
+    let SupramarkNode::Container { name, data, .. } = &children[0] else {
+        panic!("expected container");
+    };
+
+    assert_eq!(name, "video");
+    let error = data
+        .as_ref()
+        .and_then(|data| data.pointer("/parseError"))
+        .and_then(|value| value.as_str());
+    assert!(error.is_some(), "expected parseError in video data");
+    assert_eq!(
+        data.as_ref().and_then(|data| data.pointer("/rawConfig")),
+        Some(&serde_json::json!("{invalid json}"))
+    );
+}
+
+#[test]
+fn public_api_maps_video_container_non_object_error() {
+    let ast = parse(":::video\n[\"not\", \"an\", \"object\"]\n:::\n");
+    let SupramarkNode::Root { children, .. } = ast else {
+        panic!("expected root");
+    };
+    let SupramarkNode::Container { data, .. } = &children[0] else {
+        panic!("expected container");
+    };
+
+    assert_eq!(
+        data.as_ref().and_then(|data| data.pointer("/parseError")),
+        Some(&serde_json::json!("video JSON config must be an object"))
+    );
+}
+
+#[test]
 fn public_api_preserves_raw_html_blocks() {
     let ast = parse("<div>Hello</div>\n");
     let SupramarkNode::Root { children, .. } = ast else {

--- a/crates/supramark-markdown/tests/public_api.rs
+++ b/crates/supramark-markdown/tests/public_api.rs
@@ -689,7 +689,85 @@ fn public_api_maps_video_container_drops_unknown_fields() {
         data.as_ref().and_then(|data| data.pointer("/src")),
         Some(&serde_json::json!("https://example.com/a.mp4"))
     );
-    assert_eq!(data.as_ref().and_then(|data| data.pointer("/unknown")), None);
+    assert_eq!(
+        data.as_ref().and_then(|data| data.pointer("/unknown")),
+        None
+    );
+}
+
+#[test]
+fn public_api_maps_video_container_drops_wrong_typed_fields() {
+    let ast = parse(
+        ":::video\n{\n  \"src\": 123,\n  \"poster\": false,\n  \"title\": {\"x\": 1},\n  \"autoplay\": \"false\",\n  \"loop\": 1,\n  \"muted\": 0,\n  \"controls\": \"true\",\n  \"width\": \"80\"\n}\n:::\n",
+    );
+    let SupramarkNode::Root { children, .. } = ast else {
+        panic!("expected root");
+    };
+    let SupramarkNode::Container { name, data, .. } = &children[0] else {
+        panic!("expected container");
+    };
+
+    assert_eq!(name, "video");
+    for key in [
+        "src", "poster", "title", "autoplay", "loop", "muted", "controls", "width",
+    ] {
+        assert_eq!(
+            data.as_ref()
+                .and_then(|data| data.pointer(&format!("/{key}"))),
+            None,
+            "wrong-typed field {key} must be dropped"
+        );
+    }
+}
+
+#[test]
+fn public_api_maps_video_container_preserves_valid_false_and_numeric_values() {
+    let ast = parse(
+        ":::video\n{\"src\": \"https://example.com/a.mp4\", \"controls\": false, \"autoplay\": false, \"width\": 60}\n:::\n",
+    );
+    let SupramarkNode::Root { children, .. } = ast else {
+        panic!("expected root");
+    };
+    let SupramarkNode::Container { data, .. } = &children[0] else {
+        panic!("expected container");
+    };
+
+    assert_eq!(
+        data.as_ref().and_then(|data| data.pointer("/src")),
+        Some(&serde_json::json!("https://example.com/a.mp4"))
+    );
+    assert_eq!(
+        data.as_ref().and_then(|data| data.pointer("/controls")),
+        Some(&serde_json::json!(false))
+    );
+    assert_eq!(
+        data.as_ref().and_then(|data| data.pointer("/autoplay")),
+        Some(&serde_json::json!(false))
+    );
+    assert_eq!(
+        data.as_ref().and_then(|data| data.pointer("/width")),
+        Some(&serde_json::json!(60))
+    );
+}
+
+#[test]
+fn public_api_maps_video_container_caps_invalid_raw_config() {
+    let long_body = format!("{{invalid json {}}}", "x".repeat(4096));
+    let ast = parse(&format!(":::video\n{long_body}\n:::\n"));
+    let SupramarkNode::Root { children, .. } = ast else {
+        panic!("expected root");
+    };
+    let SupramarkNode::Container { data, .. } = &children[0] else {
+        panic!("expected container");
+    };
+
+    let raw = data
+        .as_ref()
+        .and_then(|data| data.pointer("/rawConfig"))
+        .and_then(|value| value.as_str())
+        .expect("expected rawConfig in video data");
+    assert_eq!(raw.chars().count(), 1025);
+    assert!(raw.ends_with('…'));
 }
 
 #[test]

--- a/docs/examples/gallery.md
+++ b/docs/examples/gallery.md
@@ -1,6 +1,6 @@
 # Feature Example Gallery
 
-This page is automatically aggregated from each Feature package's `src/examples.ts`, currently covering **21 Features** and **33 examples**.
+This page is automatically aggregated from each Feature package's `src/examples.ts`, currently covering **22 Features** and **38 examples**.
 
 These examples show the raw Markdown input; for the full live preview, open the [homepage preview](/preview/?feature=mermaid) or run `bun run feature:preview:web`.
 
@@ -26,6 +26,7 @@ These examples show the raw Markdown input; for the full live preview, open the 
 - [Math](#math) (1)
 - [Mermaid](#mermaid) (1)
 - [Plantuml](#plantuml) (3)
+- [Video](#video) (5)
 - [Weather](#weather) (4)
 
 ## Admonition
@@ -692,6 +693,76 @@ stop
 @enduml
 ```
 ````
+
+## Video
+
+Package: `@supramark/feature-video`  
+Path: `packages/features/containers/video`
+
+### Video embed - basic
+
+Embed a video with the minimal JSON config
+
+```markdown
+:::video
+{
+  "src": "https://example.com/demo.mp4"
+}
+:::
+```
+
+### Video embed - poster and title
+
+Show a thumbnail before playback and a caption below the player
+
+```markdown
+:::video
+{
+  "src": "https://example.com/demo.mp4",
+  "poster": "https://example.com/cover.jpg",
+  "title": "Product demo"
+}
+:::
+```
+
+### Video embed - autoplay muted loop
+
+Configure autoplay with muted and loop for an ambient clip (browsers require muted for autoplay)
+
+```markdown
+:::video
+{
+  "src": "https://example.com/ambient.mp4",
+  "autoplay": true,
+  "muted": true,
+  "loop": true,
+  "controls": false
+}
+:::
+```
+
+### Video embed - narrow width
+
+Constrain the player to a percentage of the container width
+
+```markdown
+:::video
+{
+  "src": "https://example.com/demo.mp4",
+  "width": 60
+}
+:::
+```
+
+### Video embed - invalid JSON shows an error card
+
+An unparsable body renders an inline error instead of failing the document
+
+```markdown
+:::video
+{invalid json}
+:::
+```
 
 ## Weather
 

--- a/docs/examples/gallery.md
+++ b/docs/examples/gallery.md
@@ -696,7 +696,7 @@ stop
 
 ## Video
 
-Package: `@supramark/feature-video`  
+Package: `@supramark/feature-video`
 Path: `packages/features/containers/video`
 
 ### Video embed - basic
@@ -713,7 +713,7 @@ Embed a video with the minimal JSON config
 
 ### Video embed - poster and title
 
-Show a thumbnail before playback and a caption below the player
+Show a thumbnail before playback and expose the title to assistive technology
 
 ```markdown
 :::video

--- a/docs/examples/react-native.md
+++ b/docs/examples/react-native.md
@@ -29,6 +29,8 @@ bun run start
 - `@supramark/rn-selection` - workspace:*
 - `@supramark/markdown-native-rn` - workspace:*
 
+## Source Code
+
 ## Project Structure
 
 ```

--- a/docs/examples/react-native.md
+++ b/docs/examples/react-native.md
@@ -29,8 +29,6 @@ bun run start
 - `@supramark/rn-selection` - workspace:*
 - `@supramark/markdown-native-rn` - workspace:*
 
-## Source Code
-
 ## Project Structure
 
 ```

--- a/examples/demos.mjs
+++ b/examples/demos.mjs
@@ -12,6 +12,7 @@ import { footnoteExamples } from '@supramark/feature-footnote';
 import { coreMarkdownExamples } from '@supramark/feature-core-markdown';
 import { htmlPageExamples } from '@supramark/feature-html-page';
 import { mapExamples } from '@supramark/feature-map';
+import { videoExamples } from '@supramark/feature-video';
 
 // Aggregate all examples and attach an id field
 export const DEMOS = [
@@ -24,4 +25,5 @@ export const DEMOS = [
   ...footnoteExamples.map(ex => ({ ...ex, id: 'footnote' })),
   ...htmlPageExamples.map(ex => ({ ...ex, id: 'html-page' })),
   ...mapExamples.map(ex => ({ ...ex, id: 'map' })),
+  ...videoExamples.map(ex => ({ ...ex, id: 'video' })),
 ];

--- a/examples/demos.ts
+++ b/examples/demos.ts
@@ -12,6 +12,7 @@ import { footnoteExamples } from '@supramark/feature-footnote';
 import { coreMarkdownExamples } from '@supramark/feature-core-markdown';
 import { htmlPageExamples } from '@supramark/feature-html-page';
 import { mapExamples } from '@supramark/feature-map';
+import { videoExamples } from '@supramark/feature-video';
 
 // Aggregate all examples and attach a unique id field
 export const DEMOS = [
@@ -24,4 +25,5 @@ export const DEMOS = [
   ...footnoteExamples.map((ex, idx) => ({ ...ex, id: `footnote-${idx}` })),
   ...htmlPageExamples.map((ex, idx) => ({ ...ex, id: `html-page-${idx}` })),
   ...mapExamples.map((ex, idx) => ({ ...ex, id: `map-${idx}` })),
+  ...videoExamples.map((ex, idx) => ({ ...ex, id: `video-${idx}` })),
 ];

--- a/examples/react-native/App.tsx
+++ b/examples/react-native/App.tsx
@@ -39,6 +39,7 @@ import { admonitionFeature } from '@supramark/feature-admonition';
 import { definitionListFeature } from '@supramark/feature-definition-list';
 import { htmlPageFeature } from '@supramark/feature-html-page';
 import { mapFeature } from '@supramark/feature-map';
+import { videoFeature, renderVideoContainerRN } from '@supramark/feature-video';
 import { diagramVegaLiteFeature } from '@supramark/feature-diagram-vega-lite';
 import { diagramEchartsFeature } from '@supramark/feature-diagram-echarts';
 import { diagramDotFeature } from '@supramark/feature-diagram-dot';
@@ -61,6 +62,7 @@ import SelectionDemo from './SelectionDemo';
 // explicitly. html-page / map register theirs via side-effect import in their
 // own index.ts.
 admonitionFeature.registerParser();
+videoFeature.registerParser();
 
 const BASE_CONFIG: SupramarkConfig = {
   features: [
@@ -82,6 +84,7 @@ const BASE_CONFIG: SupramarkConfig = {
     },
     { id: htmlPageFeature.metadata.id, enabled: true },
     { id: mapFeature.metadata.id, enabled: true, options: { provider: 'custom' } },
+    { id: videoFeature.id, enabled: true },
     { id: diagramVegaLiteFeature.metadata.id, enabled: true },
     { id: diagramEchartsFeature.metadata.id, enabled: true },
     { id: diagramDotFeature.metadata.id, enabled: true },
@@ -280,6 +283,7 @@ export default function App() {
             markdown={activeDemo.markdown}
             theme={theme}
             config={BASE_CONFIG}
+            containerRenderers={{ video: renderVideoContainerRN }}
             onOpenHtmlPage={(node) => {
               Alert.alert(
                 node.params || 'HTML Page',

--- a/examples/react-native/App.tsx
+++ b/examples/react-native/App.tsx
@@ -279,11 +279,18 @@ export default function App() {
         </View>
         <Text style={demoSectionTitleStyle}>Rendered output:</Text>
         <View style={styles.renderBlock}>
+          {/* The callback demonstrates that video playback belongs to the host app. */}
           <Supramark
             markdown={activeDemo.markdown}
             theme={theme}
             config={BASE_CONFIG}
             containerRenderers={{ video: renderVideoContainerRN }}
+            onVideoPress={(event) => {
+              Alert.alert(
+                event.title || 'Video',
+                `The host received the video URL:\n${event.src}`,
+              );
+            }}
             onOpenHtmlPage={(node) => {
               Alert.alert(
                 node.params || 'HTML Page',

--- a/examples/react-native/package.json
+++ b/examples/react-native/package.json
@@ -28,6 +28,7 @@
     "@supramark/feature-math": "workspace:*",
     "@supramark/feature-html-page": "workspace:*",
     "@supramark/feature-map": "workspace:*",
+    "@supramark/feature-video": "workspace:*",
     "@supramark/rn": "workspace:*",
     "@supramark/rn-selection": "workspace:*",
     "expo": "~54",

--- a/examples/react-native/src/all-features.ts
+++ b/examples/react-native/src/all-features.ts
@@ -1,0 +1,58 @@
+/* AUTO-GENERATED. DO NOT EDIT. */
+/**
+ * Supramark All-in-One Bundle (rn)
+ *
+ * Includes all officially registered Features in the project.
+ */
+
+import { coreMarkdownFeature } from '@supramark/feature-core-markdown';
+import { cardVisonFeature } from '@supramark/feature-card-vison';
+import { plantumlFeature } from '@supramark/feature-plantuml';
+import { diagramDotFeature } from '@supramark/feature-diagram-dot';
+import { diagramVegaLiteFeature } from '@supramark/feature-diagram-vega-lite';
+import { d2Feature } from '@supramark/feature-d2';
+import { mermaidFeature } from '@supramark/feature-mermaid';
+import { diagramEchartsFeature } from '@supramark/feature-diagram-echarts';
+import { videoFeature } from '@supramark/feature-video';
+import { htmlPageFeature } from '@supramark/feature-html-page';
+import { mapFeature } from '@supramark/feature-map';
+import { admonitionFeature } from '@supramark/feature-admonition';
+import { weatherFeature } from '@supramark/feature-weather';
+import { codeHighlightFeature } from '@supramark/feature-code-highlight';
+import { codeHighlightPresetDevFeature } from '@supramark/feature-code-highlight-preset-dev';
+import { emojiFeature } from '@supramark/feature-emoji';
+import { mathFeature } from '@supramark/feature-math';
+import { codeHighlightPresetFullFeature } from '@supramark/feature-code-highlight-preset-full';
+import { codeHighlightPresetDocsFeature } from '@supramark/feature-code-highlight-preset-docs';
+import { definitionListFeature } from '@supramark/feature-definition-list';
+import { footnoteFeature } from '@supramark/feature-footnote';
+import { gfmFeature } from '@supramark/feature-gfm';
+
+export const allFeatures = [
+  coreMarkdownFeature,
+  cardVisonFeature,
+  plantumlFeature,
+  diagramDotFeature,
+  diagramVegaLiteFeature,
+  d2Feature,
+  mermaidFeature,
+  diagramEchartsFeature,
+  videoFeature,
+  htmlPageFeature,
+  mapFeature,
+  admonitionFeature,
+  weatherFeature,
+  codeHighlightFeature,
+  codeHighlightPresetDevFeature,
+  emojiFeature,
+  mathFeature,
+  codeHighlightPresetFullFeature,
+  codeHighlightPresetDocsFeature,
+  definitionListFeature,
+  footnoteFeature,
+  gfmFeature
+];
+
+export const defaultFullConfig = {
+  features: allFeatures
+};

--- a/examples/react-web-csr/package.json
+++ b/examples/react-web-csr/package.json
@@ -33,6 +33,7 @@
     "@supramark/feature-mermaid": "workspace:*",
     "@supramark/feature-plantuml": "workspace:*",
     "@supramark/feature-weather": "workspace:*",
+    "@supramark/feature-video": "workspace:*",
     "@supramark/web": "workspace:*",
     "echarts": "^5.5.0",
     "react": "19.1.0",

--- a/examples/react-web-csr/src/App.tsx
+++ b/examples/react-web-csr/src/App.tsx
@@ -1,8 +1,9 @@
 import { useState } from 'react';
 import { Supramark } from '@supramark/web/client';
 
-// Register weather container hook (must be imported before using)
+// Register container hooks (must be imported before using)
 import { renderWeatherContainerWeb } from '@supramark/feature-weather';
+import { renderVideoContainerWeb } from '@supramark/feature-video';
 
 import './App.css';
 
@@ -55,6 +56,15 @@ This is a [link example](https://github.com)
 location: Shanghai
 condition: Cloudy
 tempC: 22
+:::
+
+### Video embed
+
+:::video
+{
+  "src": "https://interactive-examples.mdn.mozilla.net/cc0-videos/flower.mp4",
+  "title": "CC0 flower video"
+}
 :::
 
 ### Mermaid diagram
@@ -111,7 +121,7 @@ function App() {
             <Supramark
               markdown={markdown}
               theme={theme === 'none' ? undefined : theme}
-              containerRenderers={{ weather: renderWeatherContainerWeb }}
+              containerRenderers={{ weather: renderWeatherContainerWeb, video: renderVideoContainerWeb }}
             />
           </div>
         </div>

--- a/examples/react-web-csr/src/__mocks__/react-native.ts
+++ b/examples/react-web-csr/src/__mocks__/react-native.ts
@@ -26,6 +26,7 @@ export const NativeModules = {};
 export const PermissionsAndroid = { request: () => Promise.resolve('granted') };
 export const BackHandler = { addEventListener: () => ({}), removeEventListener: () => {} };
 export const Linking = { openURL: () => Promise.resolve() };
+export const Appearance = { getColorScheme: () => 'light' };
 export default {
   StyleSheet,
   View,
@@ -45,4 +46,5 @@ export default {
   PermissionsAndroid,
   BackHandler,
   Linking,
+  Appearance,
 };

--- a/examples/react-web-csr/src/__mocks__/react-native.ts
+++ b/examples/react-web-csr/src/__mocks__/react-native.ts
@@ -6,6 +6,7 @@ export const FlatList = 'FlatList';
 export const Image = 'Image';
 export const TouchableOpacity = 'TouchableOpacity';
 export const TouchableHighlight = 'TouchableHighlight';
+export const Pressable = 'Pressable';
 export const TextInput = 'TextInput';
 export const Modal = 'Modal';
 export const KeyboardAvoidingView = 'KeyboardAvoidingView';
@@ -24,6 +25,7 @@ export const Animated = {
 export const NativeModules = {};
 export const PermissionsAndroid = { request: () => Promise.resolve('granted') };
 export const BackHandler = { addEventListener: () => ({}), removeEventListener: () => {} };
+export const Linking = { openURL: () => Promise.resolve() };
 export default {
   StyleSheet,
   View,
@@ -33,6 +35,7 @@ export default {
   Image,
   TouchableOpacity,
   TouchableHighlight,
+  Pressable,
   TextInput,
   Modal,
   KeyboardAvoidingView,
@@ -41,4 +44,5 @@ export default {
   NativeModules,
   PermissionsAndroid,
   BackHandler,
+  Linking,
 };

--- a/examples/react-web-csr/src/__mocks__/react-native.ts
+++ b/examples/react-web-csr/src/__mocks__/react-native.ts
@@ -1,4 +1,7 @@
-export const StyleSheet = { create: () => ({}) };
+export const StyleSheet = {
+  create: () => ({}),
+  absoluteFillObject: { position: 'absolute', top: 0, right: 0, bottom: 0, left: 0 },
+};
 export const View = 'View';
 export const Text = 'Text';
 export const ScrollView = 'ScrollView';
@@ -26,7 +29,6 @@ export const NativeModules = {};
 export const PermissionsAndroid = { request: () => Promise.resolve('granted') };
 export const BackHandler = { addEventListener: () => ({}), removeEventListener: () => {} };
 export const Linking = { openURL: () => Promise.resolve() };
-export const Appearance = { getColorScheme: () => 'light' };
 export default {
   StyleSheet,
   View,
@@ -46,5 +48,4 @@ export default {
   PermissionsAndroid,
   BackHandler,
   Linking,
-  Appearance,
 };

--- a/examples/react-web-csr/src/all-features.ts
+++ b/examples/react-web-csr/src/all-features.ts
@@ -1,0 +1,58 @@
+/* AUTO-GENERATED. DO NOT EDIT. */
+/**
+ * Supramark All-in-One Bundle (web)
+ *
+ * Includes all officially registered Features in the project.
+ */
+
+import { coreMarkdownFeature } from '@supramark/feature-core-markdown';
+import { cardVisonFeature } from '@supramark/feature-card-vison';
+import { plantumlFeature } from '@supramark/feature-plantuml';
+import { diagramDotFeature } from '@supramark/feature-diagram-dot';
+import { diagramVegaLiteFeature } from '@supramark/feature-diagram-vega-lite';
+import { d2Feature } from '@supramark/feature-d2';
+import { mermaidFeature } from '@supramark/feature-mermaid';
+import { diagramEchartsFeature } from '@supramark/feature-diagram-echarts';
+import { videoFeature } from '@supramark/feature-video';
+import { htmlPageFeature } from '@supramark/feature-html-page';
+import { mapFeature } from '@supramark/feature-map';
+import { admonitionFeature } from '@supramark/feature-admonition';
+import { weatherFeature } from '@supramark/feature-weather';
+import { codeHighlightFeature } from '@supramark/feature-code-highlight';
+import { codeHighlightPresetDevFeature } from '@supramark/feature-code-highlight-preset-dev';
+import { emojiFeature } from '@supramark/feature-emoji';
+import { mathFeature } from '@supramark/feature-math';
+import { codeHighlightPresetFullFeature } from '@supramark/feature-code-highlight-preset-full';
+import { codeHighlightPresetDocsFeature } from '@supramark/feature-code-highlight-preset-docs';
+import { definitionListFeature } from '@supramark/feature-definition-list';
+import { footnoteFeature } from '@supramark/feature-footnote';
+import { gfmFeature } from '@supramark/feature-gfm';
+
+export const allFeatures = [
+  coreMarkdownFeature,
+  cardVisonFeature,
+  plantumlFeature,
+  diagramDotFeature,
+  diagramVegaLiteFeature,
+  d2Feature,
+  mermaidFeature,
+  diagramEchartsFeature,
+  videoFeature,
+  htmlPageFeature,
+  mapFeature,
+  admonitionFeature,
+  weatherFeature,
+  codeHighlightFeature,
+  codeHighlightPresetDevFeature,
+  emojiFeature,
+  mathFeature,
+  codeHighlightPresetFullFeature,
+  codeHighlightPresetDocsFeature,
+  definitionListFeature,
+  footnoteFeature,
+  gfmFeature
+];
+
+export const defaultFullConfig = {
+  features: allFeatures
+};

--- a/examples/react-web-csr/src/feature-registry.tsx
+++ b/examples/react-web-csr/src/feature-registry.tsx
@@ -38,13 +38,16 @@ import { weatherFeature } from '@supramark/feature-weather';
 import { weatherExamples, renderWeatherContainerWeb } from '@supramark/feature-weather';
 import { htmlPageFeature, htmlPageExamples } from '@supramark/feature-html-page';
 import { mapFeature, mapExamples } from '@supramark/feature-map';
+import { videoFeature } from '@supramark/feature-video';
+import { videoExamples, renderVideoContainerWeb } from '@supramark/feature-video';
 
 // Register container feature parsers (must run before parsing).
 // html-page and map register their container hooks via module side effect
 // (`import './runtime.js'` in their index.ts), so simply importing above
-// already wired the parser. Weather/admonition still use the explicit API.
+// already wired the parser. Weather/admonition/video still use the explicit API.
 admonitionFeature.registerParser();
 weatherFeature.registerParser();
+videoFeature.registerParser();
 
 // Container renderers for Supramark component
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -52,6 +55,7 @@ export const containerRenderers: Record<string, any> = {
   weather: renderWeatherContainerWeb,
   html: renderHtmlContainerWeb,
   map: renderMapContainerWeb,
+  video: renderVideoContainerWeb,
 };
 
 // Minimal inline renderers — html-page/map packages don't export a
@@ -142,6 +146,7 @@ export const featureRegistry: FeatureEntry[] = [
   { shortName: shortName(gfmFeature.metadata.id), displayName: gfmFeature.metadata.name, version: gfmFeature.metadata.version, examples: gfmExamples },
   { shortName: shortName(mathFeature.metadata.id), displayName: mathFeature.metadata.name, version: mathFeature.metadata.version, examples: mathExamples },
   { shortName: shortName(weatherFeature.id), displayName: weatherFeature.name, version: weatherFeature.version, examples: weatherExamples },
+  { shortName: shortName(videoFeature.id), displayName: videoFeature.name, version: videoFeature.version, examples: videoExamples },
   { shortName: shortName(htmlPageFeature.metadata.id), displayName: htmlPageFeature.metadata.name, version: htmlPageFeature.metadata.version, examples: htmlPageExamples },
   { shortName: shortName(mapFeature.metadata.id), displayName: mapFeature.metadata.name, version: mapFeature.metadata.version, examples: mapExamples },
 ].sort((a, b) => a.displayName.localeCompare(b.displayName));

--- a/features.manifest.json
+++ b/features.manifest.json
@@ -115,6 +115,14 @@
       "tsPackages": ["@supramark/feature-card-vison"],
       "containerNames": ["vison"]
     },
+    "container.video": {
+      "kind": "supramark",
+      "description": "Host-rendered :::video container with a JSON config body.",
+      "dependsOn": ["container"],
+      "cargoFeatures": ["container-video"],
+      "tsPackages": ["@supramark/feature-video"],
+      "containerNames": ["video"]
+    },
     "code_highlight": {
       "kind": "supramark",
       "description": "Renderer-side code highlighting metadata and optional engines.",

--- a/packages/core/src/container-feature.ts
+++ b/packages/core/src/container-feature.ts
@@ -161,6 +161,21 @@ export interface ContainerWebRenderArgs {
 export type ContainerWebRenderer = (args: ContainerWebRenderArgs) => unknown;
 
 /**
+ * Video tap event delivered to a host-supplied onVideoPress handler.
+ *
+ * Mirrors {@link SupramarkImagePressEvent} in shape but without gallery
+ * merging — videos render as standalone cards.
+ */
+export interface SupramarkVideoPressEvent {
+  /** The video source URL. */
+  src: string;
+  /** Poster image URL, if configured. */
+  poster?: string;
+  /** Title, if configured. */
+  title?: string;
+}
+
+/**
  * Arguments for a Container RN render function.
  */
 export interface ContainerRNRenderArgs {
@@ -172,6 +187,11 @@ export interface ContainerRNRenderArgs {
   styles: Record<string, unknown>;
   /** Supramark configuration */
   config?: SupramarkConfig;
+  /**
+   * Host handler for video card taps, threaded from the root
+   * `<Supramark onVideoPress={...}>` prop through the renderNode chain.
+   */
+  onVideoPress?: (event: SupramarkVideoPressEvent) => void;
   /** Function for rendering child nodes */
   renderChildren: (children: SupramarkNode[]) => unknown;
 }

--- a/packages/core/src/container-feature.ts
+++ b/packages/core/src/container-feature.ts
@@ -163,8 +163,9 @@ export type ContainerWebRenderer = (args: ContainerWebRenderArgs) => unknown;
 /**
  * Video tap event delivered to a host-supplied onVideoPress handler.
  *
- * Mirrors {@link SupramarkImagePressEvent} in shape but without gallery
- * merging — videos render as standalone cards.
+ * Shaped like the image-press event in `@supramark/rn`, but without gallery
+ * merging because videos render as standalone cards. The handler itself stays
+ * in the RN renderer package so this core container contract is feature-neutral.
  */
 export interface SupramarkVideoPressEvent {
   /** The video source URL. */
@@ -187,11 +188,6 @@ export interface ContainerRNRenderArgs {
   styles: Record<string, unknown>;
   /** Supramark configuration */
   config?: SupramarkConfig;
-  /**
-   * Host handler for video card taps, threaded from the root
-   * `<Supramark onVideoPress={...}>` prop through the renderNode chain.
-   */
-  onVideoPress?: (event: SupramarkVideoPressEvent) => void;
   /** Function for rendering child nodes */
   renderChildren: (children: SupramarkNode[]) => unknown;
 }

--- a/packages/core/src/index.rn.ts
+++ b/packages/core/src/index.rn.ts
@@ -35,7 +35,22 @@ export {
   type ContainerHookContext,
   type ContainerHook,
   registerContainerHook,
+  extractContainerInnerText,
 } from './syntax/container.js';
+
+// ContainerFeature contract (ContainerRNRenderArgs.onVideoPress etc.) —
+// the RN entry re-exports the same container-feature surface as the web
+// entry so RN hosts resolve identical types under the metro mapping.
+export {
+  validateContainerFeature,
+  type ContainerFeature,
+  type ContainerWebRenderArgs,
+  type ContainerWebRenderer,
+  type ContainerRNRenderArgs,
+  type ContainerRNRenderer,
+  type SupramarkVideoPressEvent,
+  type ExampleDefinition,
+} from './container-feature.js';
 
 // Native parser adapter registry —— for RN native wrapper packages
 // (e.g. `@supramark/markdown-native-rn`) to register via a side effect.

--- a/packages/core/src/index.rn.ts
+++ b/packages/core/src/index.rn.ts
@@ -38,9 +38,8 @@ export {
   extractContainerInnerText,
 } from './syntax/container.js';
 
-// ContainerFeature contract (ContainerRNRenderArgs.onVideoPress etc.) —
-// the RN entry re-exports the same container-feature surface as the web
-// entry so RN hosts resolve identical types under the metro mapping.
+// ContainerFeature contract — the RN entry re-exports the same surface as the
+// web entry so RN hosts resolve identical types under the metro mapping.
 export {
   validateContainerFeature,
   type ContainerFeature,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -44,6 +44,7 @@ export {
   type ContainerWebRenderArgs,
   type ContainerWebRenderer,
   type ContainerRNRenderArgs,
+  type SupramarkVideoPressEvent,
   type ContainerRNRenderer,
   validateContainerFeature,
 } from './container-feature.js';

--- a/packages/features/containers/video/README.zh.md
+++ b/packages/features/containers/video/README.zh.md
@@ -1,0 +1,49 @@
+# @supramark/feature-video
+
+视频嵌入容器，通过 `:::video` + JSON 配置体在 Markdown 中嵌入可播放的视频。
+
+## 语法
+
+```markdown
+:::video
+{
+"src": "https://example.com/demo.mp4"
+}
+:::
+```
+
+## 配置字段
+
+| 字段       | 类型    | 说明                                   |
+| ---------- | ------- | -------------------------------------- |
+| `src`      | string  | 视频 URL（渲染必需）                   |
+| `poster`   | string  | 封面图 URL                             |
+| `title`    | string  | 标题 / 无障碍说明                      |
+| `autoplay` | boolean | 自动播放（浏览器通常要求同时 `muted`） |
+| `loop`     | boolean | 循环播放                               |
+| `muted`    | boolean | 静音                                   |
+| `controls` | boolean | 显示原生控件，默认 `true`              |
+| `width`    | number  | 播放器宽度占容器百分比（1-100）        |
+
+未知字段会被忽略；JSON 非法时渲染内联错误卡片，而不是让整篇文档失败。
+
+## 平台行为
+
+- **Web**：渲染原生 `<video controls poster>`。
+- **React Native**：RN 没有内置视频组件，默认渲染封面图（或占位块）+ 播放按钮，
+  点击后经 `Linking` 打开系统播放器。需要内联播放的宿主可用
+  `react-native-video` / `expo-av` 自行实现渲染函数，并通过
+  `<Supramark containerRenderers={{ video: myRenderer }} />` 注入。
+
+## 宿主接入
+
+```tsx
+import { videoFeature, renderVideoContainerWeb } from '@supramark/feature-video';
+
+videoFeature.registerParser();
+
+<Supramark
+  config={{ features: [videoFeature] }}
+  containerRenderers={{ video: renderVideoContainerWeb }}
+/>;
+```

--- a/packages/features/containers/video/README.zh.md
+++ b/packages/features/containers/video/README.zh.md
@@ -25,25 +25,28 @@
 | `controls` | boolean | 显示原生控件，默认 `true`              |
 | `width`    | number  | 播放器宽度占容器百分比（1-100）        |
 
-未知字段会被忽略；JSON 非法时渲染内联错误卡片，而不是让整篇文档失败。
+未知字段和类型不匹配的字段会被忽略；JSON 非法时渲染内联错误卡片，而不是让整篇文档失败。
 
 ## 平台行为
 
-- **Web**：渲染原生 `<video controls poster>`。
+- **Web**：渲染原生 `<video controls poster>`。未配置 `poster` 时会使用
+  `preload="metadata"` 显示首帧，因此页面加载后浏览器可能主动请求视频 URL；
+  这与 Markdown 图片的加载隐私边界相同。`poster` 拒绝脚本型 URL scheme。
 - **React Native**：RN 没有内置视频组件，默认渲染封面图（或占位块）+ 播放按钮，
-  点击后经 `Linking` 打开系统播放器。需要内联播放的宿主可用
+  宿主未提供回调时只允许通过 `Linking` 打开 HTTP(S) URL。需要内联播放的宿主可用
   `react-native-video` / `expo-av` 自行实现渲染函数，并通过
   `<Supramark containerRenderers={{ video: myRenderer }} />` 注入。
 
 ## 宿主接入
 
 ```tsx
-import { videoFeature, renderVideoContainerWeb } from '@supramark/feature-video';
+import { videoFeature, renderVideoContainerRN } from '@supramark/feature-video';
 
 videoFeature.registerParser();
 
 <Supramark
   config={{ features: [videoFeature] }}
-  containerRenderers={{ video: renderVideoContainerWeb }}
+  containerRenderers={{ video: renderVideoContainerRN }}
+  onVideoPress={({ src, title }) => openVideoPlayer({ src, title })}
 />;
 ```

--- a/packages/features/containers/video/__tests__/feature.test.ts
+++ b/packages/features/containers/video/__tests__/feature.test.ts
@@ -1,0 +1,123 @@
+import { videoFeature, VIDEO_CONTAINER_NAMES } from '../src/feature';
+import { videoExamples } from '../src/examples';
+import { validateContainerFeature, parse } from '@supramark/core';
+import type { SupramarkNode, SupramarkContainerNode, SupramarkRootNode } from '@supramark/core';
+
+// Test-local view of a node that may carry children, used to walk an arbitrary tree.
+type NodeWithChildren = SupramarkNode & { children?: SupramarkNode[] };
+
+function findContainers(
+  node: SupramarkNode,
+  out: SupramarkContainerNode[] = []
+): SupramarkContainerNode[] {
+  const n = node as NodeWithChildren;
+  if (n && typeof n === 'object') {
+    if (n.type === 'container') out.push(n as SupramarkContainerNode);
+    for (const child of n.children ?? []) findContainers(child, out);
+  }
+  return out;
+}
+
+describe('Video Feature', () => {
+  describe('ContainerFeature shape', () => {
+    it('should have valid container feature definition', () => {
+      const result = validateContainerFeature(videoFeature);
+      expect(result.valid).toBe(true);
+      expect(result.errors).toHaveLength(0);
+    });
+
+    it('should have correct id', () => {
+      expect(videoFeature.id).toBe('@supramark/feature-video');
+    });
+
+    it('should have semantic version', () => {
+      expect(videoFeature.version).toMatch(/^\d+\.\d+\.\d+$/);
+    });
+
+    it('should expose the video container name', () => {
+      expect(videoFeature.containerNames).toEqual([...VIDEO_CONTAINER_NAMES]);
+    });
+
+    it('should provide parser registration and renderer exports', () => {
+      expect(typeof videoFeature.registerParser).toBe('function');
+      expect(videoFeature.webRendererExport).toBe('renderVideoContainerWeb');
+      expect(videoFeature.rnRendererExport).toBe('renderVideoContainerRN');
+    });
+  });
+
+  describe('parse() integration', () => {
+    it('parses a JSON body into structured video data', async () => {
+      const root: SupramarkRootNode = await parse(
+        ':::video\n{\n  "src": "https://example.com/demo.mp4",\n  "poster": "https://example.com/cover.jpg",\n  "title": "Product demo",\n  "autoplay": true,\n  "muted": true,\n  "loop": false,\n  "controls": true,\n  "width": 80\n}\n:::\n'
+      );
+      const [video] = findContainers(root);
+
+      expect(video).toBeDefined();
+      expect(video.name).toBe('video');
+      expect(video.data?.src).toBe('https://example.com/demo.mp4');
+      expect(video.data?.poster).toBe('https://example.com/cover.jpg');
+      expect(video.data?.title).toBe('Product demo');
+      expect(video.data?.autoplay).toBe(true);
+      expect(video.data?.muted).toBe(true);
+      expect(video.data?.loop).toBe(false);
+      expect(video.data?.controls).toBe(true);
+      expect(video.data?.width).toBe(80);
+    });
+
+    it('keeps the raw body on value and does not parse markdown children', async () => {
+      const root: SupramarkRootNode = await parse(
+        ':::video\n{"src": "https://example.com/demo.mp4"}\n:::\n'
+      );
+      const [video] = findContainers(root);
+
+      expect(video.children).toHaveLength(0);
+      expect(typeof video.value).toBe('string');
+    });
+
+    it('drops unknown config fields', async () => {
+      const root: SupramarkRootNode = await parse(
+        ':::video\n{"src": "https://example.com/a.mp4", "unknown": "dropped"}\n:::\n'
+      );
+      const [video] = findContainers(root);
+
+      expect(video.data?.src).toBe('https://example.com/a.mp4');
+      expect(video.data).not.toHaveProperty('unknown');
+    });
+
+    it('does not require src at parse time', async () => {
+      const root: SupramarkRootNode = await parse(':::video\n{"title": "No src yet"}\n:::\n');
+      const [video] = findContainers(root);
+
+      expect(video.data?.src).toBeUndefined();
+      expect(video.data?.title).toBe('No src yet');
+    });
+
+    it('reports parseError with rawConfig for invalid JSON', async () => {
+      const root: SupramarkRootNode = await parse(':::video\n{invalid json}\n:::\n');
+      const [video] = findContainers(root);
+
+      expect(typeof video.data?.parseError).toBe('string');
+      expect(video.data?.rawConfig).toBe('{invalid json}');
+    });
+
+    it('reports parseError for a non-object body', async () => {
+      const root: SupramarkRootNode = await parse(':::video\n["not", "an", "object"]\n:::\n');
+      const [video] = findContainers(root);
+
+      expect(video.data?.parseError).toBe('video JSON config must be an object');
+    });
+  });
+
+  describe('examples', () => {
+    it('should have at least one example', () => {
+      expect(videoExamples.length).toBeGreaterThan(0);
+    });
+
+    it('every example markdown contains a :::video block', () => {
+      for (const example of videoExamples) {
+        expect(example.markdown).toContain(':::video');
+        expect(example.markdown).toContain(':::');
+      }
+    });
+  });
+});

--- a/packages/features/containers/video/__tests__/feature.test.ts
+++ b/packages/features/containers/video/__tests__/feature.test.ts
@@ -84,6 +84,15 @@ describe('Video Feature', () => {
       expect(video.data).not.toHaveProperty('unknown');
     });
 
+    it('drops config fields whose JSON types do not match the public contract', async () => {
+      const root: SupramarkRootNode = await parse(
+        ':::video\n{"src": 123, "poster": false, "title": {}, "autoplay": "false", "loop": 1, "muted": 0, "controls": "true", "width": "80"}\n:::\n'
+      );
+      const [video] = findContainers(root);
+
+      expect(video.data).toEqual({});
+    });
+
     it('does not require src at parse time', async () => {
       const root: SupramarkRootNode = await parse(':::video\n{"title": "No src yet"}\n:::\n');
       const [video] = findContainers(root);

--- a/packages/features/containers/video/__tests__/runtime.web.test.tsx
+++ b/packages/features/containers/video/__tests__/runtime.web.test.tsx
@@ -1,0 +1,84 @@
+import { describe, expect, test } from 'bun:test';
+import type React from 'react';
+import type { SupramarkNode, SupramarkContainerNode, SupramarkRootNode } from '@supramark/core';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { parse } from '@supramark/core';
+// Direct module import: the package index also re-exports the RN runtime,
+// whose react-native import the bun test runtime cannot load.
+import { renderVideoContainerWeb } from '../src/runtime.web.js';
+
+function findContainers(
+  node: SupramarkNode,
+  out: SupramarkContainerNode[] = []
+): SupramarkContainerNode[] {
+  const n = node as SupramarkNode & { children?: SupramarkNode[] };
+  if (n && typeof n === 'object') {
+    if (n.type === 'container') out.push(n as SupramarkContainerNode);
+    for (const child of n.children ?? []) findContainers(child, out);
+  }
+  return out;
+}
+
+async function renderMarkdown(markdown: string): Promise<string> {
+  const root: SupramarkRootNode = await parse(markdown);
+  const [video] = findContainers(root);
+  const element = renderVideoContainerWeb({
+    node: video,
+    key: 0,
+    classNames: {},
+    renderChildren: () => null,
+  }) as React.ReactElement;
+  return renderToStaticMarkup(element);
+}
+
+describe('renderVideoContainerWeb', () => {
+  test('renders a native <video> with poster, controls and aria-label', async () => {
+    const html = await renderMarkdown(
+      ':::video\n{"src": "https://example.com/a.mp4", "poster": "https://example.com/c.jpg", "title": "Demo"}\n:::\n'
+    );
+
+    expect(html).toContain('<video');
+    expect(html).toContain('src="https://example.com/a.mp4"');
+    expect(html).toContain('poster="https://example.com/c.jpg"');
+    expect(html).toContain('controls=""');
+    expect(html).toContain('aria-label="Demo"');
+    // No visible caption on web either — the title lives on aria-label only.
+    expect(html).not.toContain('>Demo<');
+  });
+
+  test('maps autoplay/loop/muted onto the element and defaults controls on', async () => {
+    const html = await renderMarkdown(
+      ':::video\n{"src": "https://example.com/a.mp4", "autoplay": true, "muted": true, "loop": true}\n:::\n'
+    );
+
+    expect(html).toContain('autoPlay=""');
+    expect(html).toContain('muted=""');
+    expect(html).toContain('loop=""');
+    expect(html).toContain('controls=""');
+  });
+
+  test('preloads metadata when no poster so the browser shows the first frame', async () => {
+    const html = await renderMarkdown(':::video\n{"src": "https://example.com/a.mp4"}\n:::\n');
+
+    expect(html).toContain('preload="metadata"');
+  });
+
+  test('clamps width to a percentage of the container', async () => {
+    const html = await renderMarkdown(':::video\n{"src": "https://example.com/a.mp4", "width": 60}\n:::\n');
+
+    expect(html).toContain('width:60%');
+  });
+
+  test('renders an error card for invalid JSON instead of failing the document', async () => {
+    const html = await renderMarkdown(':::video\n{bad json}\n:::\n');
+
+    expect(html).toContain('Video config error');
+    expect(html).toContain('{bad json}');
+  });
+
+  test('renders an error card when src is missing', async () => {
+    const html = await renderMarkdown(':::video\n{"title": "No src"}\n:::\n');
+
+    expect(html).toContain('Missing src config');
+  });
+});

--- a/packages/features/containers/video/__tests__/runtime.web.test.tsx
+++ b/packages/features/containers/video/__tests__/runtime.web.test.tsx
@@ -31,6 +31,25 @@ async function renderMarkdown(markdown: string): Promise<string> {
   return renderToStaticMarkup(element);
 }
 
+/** Renders a hand-built container to exercise renderer-boundary validation. */
+function renderContainerData(data: Record<string, unknown>): string {
+  const node = {
+    type: 'container',
+    name: 'video',
+    mode: 'opaque',
+    data,
+    value: '{}',
+    children: [],
+  } as unknown as SupramarkContainerNode;
+  const element = renderVideoContainerWeb({
+    node,
+    key: 0,
+    classNames: {},
+    renderChildren: () => null,
+  }) as React.ReactElement;
+  return renderToStaticMarkup(element);
+}
+
 describe('renderVideoContainerWeb', () => {
   test('renders a native <video> with poster, controls and aria-label', async () => {
     const html = await renderMarkdown(
@@ -64,7 +83,9 @@ describe('renderVideoContainerWeb', () => {
   });
 
   test('clamps width to a percentage of the container', async () => {
-    const html = await renderMarkdown(':::video\n{"src": "https://example.com/a.mp4", "width": 60}\n:::\n');
+    const html = await renderMarkdown(
+      ':::video\n{"src": "https://example.com/a.mp4", "width": 60}\n:::\n'
+    );
 
     expect(html).toContain('width:60%');
   });
@@ -80,5 +101,45 @@ describe('renderVideoContainerWeb', () => {
     const html = await renderMarkdown(':::video\n{"title": "No src"}\n:::\n');
 
     expect(html).toContain('Missing src config');
+  });
+
+  test('wrong-typed boolean flags never become truthy HTML attributes', async () => {
+    const html = await renderMarkdown(
+      ':::video\n{"src": "https://example.com/a.mp4", "autoplay": "false", "loop": 1, "muted": 0, "controls": "false"}\n:::\n'
+    );
+
+    expect(html).not.toContain('autoPlay');
+    expect(html).not.toContain('loop=""');
+    expect(html).not.toContain('muted=""');
+    expect(html).toContain('controls=""');
+  });
+
+  test('drops a poster URL with a script-capable scheme', async () => {
+    const html = await renderMarkdown(
+      ':::video\n{"src": "https://example.com/a.mp4", "poster": "javascript:alert(1)"}\n:::\n'
+    );
+
+    expect(html).not.toContain('javascript:');
+    expect(html).not.toContain('poster=');
+    expect(html).toContain('preload="metadata"');
+  });
+
+  test('keeps a relative poster URL', async () => {
+    const html = await renderMarkdown(
+      ':::video\n{"src": "video.mp4", "poster": "./cover.jpg"}\n:::\n'
+    );
+
+    expect(html).toContain('poster="./cover.jpg"');
+  });
+
+  test('ignores wrong-typed parser error fields in a hand-built AST', () => {
+    const html = renderContainerData({
+      src: 'https://example.com/a.mp4',
+      parseError: { message: 'hostile' },
+      rawConfig: ['hostile'],
+    });
+
+    expect(html).toContain('<video');
+    expect(html).not.toContain('hostile');
   });
 });

--- a/packages/features/containers/video/jest.config.cjs
+++ b/packages/features/containers/video/jest.config.cjs
@@ -1,0 +1,11 @@
+/** @type {import('jest').Config} */
+module.exports = {
+  // Use the shared Supramark Jest preset
+  // Keeps this in sync with @supramark/core's test config
+  ...require('../../../jest.preset.cjs'),
+
+  // Feature-package-specific overrides can go here
+  // e.g.:
+  // testEnvironment: 'jsdom', // if a DOM environment is needed
+  // collectCoverage: true,     // enable coverage collection
+};

--- a/packages/features/containers/video/package.json
+++ b/packages/features/containers/video/package.json
@@ -1,0 +1,46 @@
+{
+  "name": "@supramark/feature-video",
+  "version": "0.1.0",
+  "description": "Video embed container with a JSON config body",
+  "type": "module",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "import": "./src/index.ts",
+      "default": "./src/index.ts"
+    }
+  },
+  "files": [
+    "dist",
+    "src",
+    "README.zh.md"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json --emitDeclarationOnly",
+    "test": "bun test",
+    "test:watch": "jest --watch",
+    "test:coverage": "jest --coverage"
+  },
+  "keywords": [
+    "supramark",
+    "feature",
+    "video",
+    "markdown"
+  ],
+  "author": "Supramark Team",
+  "license": "Apache-2.0",
+  "peerDependencies": {
+    "@supramark/core": "*"
+  },
+  "devDependencies": {
+    "@types/jest": "^29.5.0",
+    "typescript": "^5.5.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Actrium/supramark.git",
+    "directory": "packages/features/containers/video"
+  }
+}

--- a/packages/features/containers/video/package.json
+++ b/packages/features/containers/video/package.json
@@ -32,10 +32,24 @@
   "author": "Supramark Team",
   "license": "Apache-2.0",
   "peerDependencies": {
-    "@supramark/core": "*"
+    "@supramark/core": "*",
+    "@supramark/rn": "*",
+    "react": ">=18.0.0",
+    "react-native": ">=0.72.0"
+  },
+  "peerDependenciesMeta": {
+    "@supramark/rn": {
+      "optional": true
+    },
+    "react-native": {
+      "optional": true
+    }
   },
   "devDependencies": {
+    "@supramark/rn": "workspace:*",
     "@types/jest": "^29.5.0",
+    "react": "19.1.0",
+    "react-dom": "19.1.0",
     "typescript": "^5.5.0"
   },
   "repository": {

--- a/packages/features/containers/video/src/examples.ts
+++ b/packages/features/containers/video/src/examples.ts
@@ -1,0 +1,71 @@
+/**
+ * Video Feature examples
+ *
+ * @packageDocumentation
+ */
+
+import type { ExampleDefinition } from '@supramark/core';
+
+export const videoExamples: ExampleDefinition[] = [
+  {
+    name: 'Video embed - basic',
+    description: 'Embed a video with the minimal JSON config',
+    markdown: `
+:::video
+{
+  "src": "https://example.com/demo.mp4"
+}
+:::
+`.trim(),
+  },
+  {
+    name: 'Video embed - poster and title',
+    description: 'Show a thumbnail before playback and a caption below the player',
+    markdown: `
+:::video
+{
+  "src": "https://example.com/demo.mp4",
+  "poster": "https://example.com/cover.jpg",
+  "title": "Product demo"
+}
+:::
+`.trim(),
+  },
+  {
+    name: 'Video embed - autoplay muted loop',
+    description:
+      'Configure autoplay with muted and loop for an ambient clip (browsers require muted for autoplay)',
+    markdown: `
+:::video
+{
+  "src": "https://example.com/ambient.mp4",
+  "autoplay": true,
+  "muted": true,
+  "loop": true,
+  "controls": false
+}
+:::
+`.trim(),
+  },
+  {
+    name: 'Video embed - narrow width',
+    description: 'Constrain the player to a percentage of the container width',
+    markdown: `
+:::video
+{
+  "src": "https://example.com/demo.mp4",
+  "width": 60
+}
+:::
+`.trim(),
+  },
+  {
+    name: 'Video embed - invalid JSON shows an error card',
+    description: 'An unparsable body renders an inline error instead of failing the document',
+    markdown: `
+:::video
+{invalid json}
+:::
+`.trim(),
+  },
+];

--- a/packages/features/containers/video/src/examples.ts
+++ b/packages/features/containers/video/src/examples.ts
@@ -20,7 +20,7 @@ export const videoExamples: ExampleDefinition[] = [
   },
   {
     name: 'Video embed - poster and title',
-    description: 'Show a thumbnail before playback and a caption below the player',
+    description: 'Show a thumbnail before playback and expose the title to assistive technology',
     markdown: `
 :::video
 {

--- a/packages/features/containers/video/src/feature.ts
+++ b/packages/features/containers/video/src/feature.ts
@@ -1,0 +1,178 @@
+/**
+ * Video Feature definition
+ *
+ * Implements the ContainerFeature interface, embedding a playable video via
+ * a :::video container with a JSON config body.
+ *
+ * The JSON body is parsed into structured `data` by the Rust parser
+ * (`parse_video_data` in crates/supramark-markdown). The TS hook below keeps
+ * the ContainerFeature contract complete and mirrors that mapping for the
+ * registry/hook path.
+ *
+ * @example
+ * ```markdown
+ * :::video
+ * {
+ *   "src": "https://example.com/demo.mp4",
+ *   "poster": "https://example.com/cover.jpg",
+ *   "title": "Product demo"
+ * }
+ * :::
+ * ```
+ *
+ * @packageDocumentation
+ */
+
+import {
+  registerContainerHook,
+  extractContainerInnerText,
+  type ContainerFeature,
+  type ContainerHook,
+  type ContainerHookContext,
+  type SupramarkContainerNode,
+} from '@supramark/core';
+
+// ============================================================================
+// Container name definition (single source of truth)
+// ============================================================================
+
+/**
+ * Container names supported by Video
+ */
+export const VIDEO_CONTAINER_NAMES = ['video'] as const;
+
+export type VideoContainerName = (typeof VIDEO_CONTAINER_NAMES)[number];
+
+/**
+ * Video node data structure
+ *
+ * Populated by the Rust parser; this interface must stay in sync with
+ * `parse_video_data` in crates/supramark-markdown/src/supramark.rs.
+ */
+export interface VideoData {
+  /** Video source URL (required for rendering) */
+  src?: string;
+  /** Poster / thumbnail image URL */
+  poster?: string;
+  /** Accessible title / caption */
+  title?: string;
+  /** Autoplay on mount (browsers usually require muted as well) */
+  autoplay?: boolean;
+  /** Loop playback */
+  loop?: boolean;
+  /** Start muted */
+  muted?: boolean;
+  /** Show native playback controls (defaults to true in renderers) */
+  controls?: boolean;
+  /** Player width as a percentage of the container (1-100) */
+  width?: number;
+  /** Parse error message (kept when the JSON body is invalid) */
+  parseError?: string;
+  /** Raw config text (kept when parsing fails) */
+  rawConfig?: string;
+}
+
+/** Fields copied from the JSON config body into VideoData. */
+const VIDEO_CONFIG_FIELDS = [
+  'src',
+  'poster',
+  'title',
+  'autoplay',
+  'loop',
+  'muted',
+  'controls',
+  'width',
+] as const;
+
+/**
+ * Parse a JSON config body into VideoData
+ *
+ * Mirrors the Rust `parse_video_data` mapping: unknown fields are dropped,
+ * and invalid JSON yields parseError + rawConfig instead of throwing.
+ */
+function parseVideoConfig(content: string): Partial<VideoData> {
+  try {
+    const parsed: unknown = JSON.parse(content.trim());
+    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+      return { parseError: 'video JSON config must be an object', rawConfig: content };
+    }
+    const source = parsed as Record<string, unknown>;
+    const result: Record<string, unknown> = {};
+    for (const field of VIDEO_CONFIG_FIELDS) {
+      const value = source[field];
+      if (value !== undefined && value !== null) {
+        result[field] = value;
+      }
+    }
+    return result as Partial<VideoData>;
+  } catch (e) {
+    return { parseError: `JSON parse error: ${(e as Error).message}`, rawConfig: content };
+  }
+}
+
+// ============================================================================
+// Parsing logic
+// ============================================================================
+
+function createVideoContainerHook(name: string): ContainerHook {
+  return {
+    name,
+    opaque: true,
+    onOpen(ctx: ContainerHookContext) {
+      const { token, stack, sourceLines } = ctx;
+
+      const innerText = extractContainerInnerText(token, sourceLines);
+      const data: VideoData = { ...parseVideoConfig(innerText) };
+
+      const node: SupramarkContainerNode = {
+        type: 'container' as const,
+        name: 'video',
+        params: token.info ? String(token.info) : undefined,
+        data: { ...data },
+        children: [],
+      };
+
+      const parent = stack[stack.length - 1];
+      parent.children.push(node);
+      stack.push(node);
+    },
+    onClose(ctx: ContainerHookContext) {
+      const top = ctx.stack[ctx.stack.length - 1] as SupramarkContainerNode;
+      if (top && top.type === 'container' && top.name === 'video') {
+        ctx.stack.pop();
+      }
+    },
+  };
+}
+
+/**
+ * Register the Video parser
+ */
+function registerVideoParser(): void {
+  for (const name of VIDEO_CONTAINER_NAMES) {
+    registerContainerHook(createVideoContainerHook(name));
+  }
+}
+
+// ============================================================================
+// Feature definition (implements the ContainerFeature interface)
+// ============================================================================
+
+/**
+ * Video Feature
+ *
+ * A video embed container with a JSON config body
+ */
+export const videoFeature: ContainerFeature = {
+  id: '@supramark/feature-video',
+  name: 'Video',
+  version: '0.1.0',
+  description: 'A video embed container configured by a JSON body',
+
+  containerNames: [...VIDEO_CONTAINER_NAMES],
+
+  registerParser: registerVideoParser,
+
+  webRendererExport: 'renderVideoContainerWeb',
+  rnRendererExport: 'renderVideoContainerRN',
+};

--- a/packages/features/containers/video/src/feature.ts
+++ b/packages/features/containers/video/src/feature.ts
@@ -84,29 +84,56 @@ const VIDEO_CONFIG_FIELDS = [
   'width',
 ] as const;
 
+/** Returns whether a supported config field has its declared public type. */
+function isValidVideoConfigValue(
+  field: (typeof VIDEO_CONFIG_FIELDS)[number],
+  value: unknown
+): boolean {
+  // URL and accessible-label fields accept strings only.
+  if (field === 'src' || field === 'poster' || field === 'title') {
+    return typeof value === 'string';
+  }
+  // Width must stay finite because JSON.parse accepts exponent overflow as Infinity.
+  if (field === 'width') {
+    return typeof value === 'number' && Number.isFinite(value);
+  }
+  return typeof value === 'boolean';
+}
+
+/** Caps invalid config retained by the legacy TypeScript hook. */
+function truncateRawConfig(content: string): string {
+  const characters = Array.from(content);
+  // Preserve short error input verbatim and mark only truncated values.
+  if (characters.length <= 1024) return content;
+  return `${characters.slice(0, 1024).join('')}…`;
+}
+
 /**
  * Parse a JSON config body into VideoData
  *
- * Mirrors the Rust `parse_video_data` mapping: unknown fields are dropped,
- * and invalid JSON yields parseError + rawConfig instead of throwing.
+ * Matches the Rust `parse_video_data` supported-field filtering and failure
+ * shape. Exact parser error messages remain implementation-specific.
  */
 function parseVideoConfig(content: string): Partial<VideoData> {
   try {
     const parsed: unknown = JSON.parse(content.trim());
     if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
-      return { parseError: 'video JSON config must be an object', rawConfig: content };
+      return {
+        parseError: 'video JSON config must be an object',
+        rawConfig: truncateRawConfig(content),
+      };
     }
     const source = parsed as Record<string, unknown>;
     const result: Record<string, unknown> = {};
     for (const field of VIDEO_CONFIG_FIELDS) {
       const value = source[field];
-      if (value !== undefined && value !== null) {
+      if (value !== undefined && value !== null && isValidVideoConfigValue(field, value)) {
         result[field] = value;
       }
     }
     return result as Partial<VideoData>;
   } catch (e) {
-    return { parseError: `JSON parse error: ${(e as Error).message}`, rawConfig: content };
+    return { parseError: (e as Error).message, rawConfig: truncateRawConfig(content) };
   }
 }
 
@@ -127,8 +154,10 @@ function createVideoContainerHook(name: string): ContainerHook {
       const node: SupramarkContainerNode = {
         type: 'container' as const,
         name: 'video',
+        mode: 'opaque',
         params: token.info ? String(token.info) : undefined,
         data: { ...data },
+        value: innerText,
         children: [],
       };
 

--- a/packages/features/containers/video/src/index.ts
+++ b/packages/features/containers/video/src/index.ts
@@ -1,0 +1,22 @@
+/**
+ * Video Feature
+ *
+ * A video embed container configured by a JSON body
+ *
+ * @packageDocumentation
+ */
+
+// Feature definition (main export)
+export {
+  videoFeature,
+  VIDEO_CONTAINER_NAMES,
+  type VideoContainerName,
+  type VideoData,
+} from './feature.js';
+
+// Examples
+export { videoExamples } from './examples.js';
+
+// Renderers (for the registry to use)
+export { renderVideoContainerWeb } from './runtime.web.js';
+export { renderVideoContainerRN } from './runtime.rn.js';

--- a/packages/features/containers/video/src/runtime.rn.tsx
+++ b/packages/features/containers/video/src/runtime.rn.tsx
@@ -14,6 +14,7 @@
 
 import React from 'react';
 import {
+  Appearance,
   View,
   Text,
   Image,
@@ -42,11 +43,10 @@ const localStyles = StyleSheet.create({
     aspectRatio: 16 / 9,
     alignItems: 'center',
     justifyContent: 'center',
-    backgroundColor: '#1c1c1e',
   },
-  playIcon: {
-    fontSize: 40,
-    color: '#ffffff',
+  placeholderMeta: {
+    marginTop: 6,
+    fontSize: 13,
   },
   caption: {
     paddingVertical: 6,
@@ -97,10 +97,31 @@ function openVideo(src: string): void {
   });
 }
 
+/** Last path segment of the source URL, shown on the no-poster placeholder. */
+function videoFileName(src: string): string {
+  const segment = src.split('?')[0].split('/').filter(Boolean).pop() ?? src;
+  return segment.length > 40 ? `${segment.slice(0, 37)}...` : segment;
+}
+
+/**
+ * Neutral (light/dark aware) placeholder palette. Commanded imperatively via
+ * Appearance because container renderers are plain render functions invoked
+ * inside renderNode — not React components, so hooks are unavailable.
+ */
+function placeholderPalette(): { background: string; icon: string; meta: string } {
+  return Appearance.getColorScheme() === 'dark'
+    ? { background: '#2c2c2e', icon: '#98989d', meta: '#8e8e93' }
+    : { background: '#f2f2f7', icon: '#8e8e93', meta: '#8e8e93' };
+}
+
 /**
  * RN renderer for :::video (poster + play fallback; see module docs)
  */
-export function renderVideoContainerRN({ node, key }: ContainerRNRenderArgs): React.ReactNode {
+export function renderVideoContainerRN({
+  node,
+  key,
+  onVideoPress,
+}: ContainerRNRenderArgs): React.ReactNode {
   const data = (node?.data ?? {}) as unknown as VideoData;
   const { parseError, rawConfig, src, poster, title, width } = data;
 
@@ -125,6 +146,7 @@ export function renderVideoContainerRN({ node, key }: ContainerRNRenderArgs): Re
     );
   }
 
+  const palette = placeholderPalette();
   const widthStyle = playerWidth(width);
 
   return (
@@ -135,13 +157,22 @@ export function renderVideoContainerRN({ node, key }: ContainerRNRenderArgs): Re
       <Pressable
         accessibilityRole="button"
         accessibilityLabel={title ?? `Play video: ${src}`}
-        onPress={() => openVideo(src)}
+        onPress={() => {
+          if (onVideoPress) {
+            onVideoPress({ src, poster, title });
+            return;
+          }
+          openVideo(src);
+        }}
       >
         {poster ? (
           <Image source={{ uri: poster }} style={localStyles.poster} resizeMode="cover" />
         ) : (
-          <View style={localStyles.placeholder}>
-            <Text style={localStyles.playIcon}>▶</Text>
+          <View style={{ ...localStyles.placeholder, backgroundColor: palette.background }}>
+            <Text style={{ fontSize: 40, color: palette.icon }}>▶</Text>
+            <Text style={{ ...localStyles.placeholderMeta, color: palette.meta }}>
+              {title ?? videoFileName(src)}
+            </Text>
           </View>
         )}
       </Pressable>

--- a/packages/features/containers/video/src/runtime.rn.tsx
+++ b/packages/features/containers/video/src/runtime.rn.tsx
@@ -118,8 +118,15 @@ export function renderVideoContainerRN({
   key,
   onVideoPress,
 }: ContainerRNRenderArgs): React.ReactNode {
+  // The JSON body is user input: Rust copies fields verbatim without type
+  // validation, so guard every field before use — a non-string src must
+  // degrade to an error card instead of crashing the whole document.
   const data = (node?.data ?? {}) as unknown as VideoData;
-  const { parseError, rawConfig, src, poster, title, width } = data;
+  const src = typeof data.src === 'string' ? data.src : undefined;
+  const poster = typeof data.poster === 'string' ? data.poster : undefined;
+  const title = typeof data.title === 'string' ? data.title : undefined;
+  const width = typeof data.width === 'number' ? data.width : undefined;
+  const { parseError, rawConfig } = data;
 
   // Show an error message when parsing failed
   if (parseError) {

--- a/packages/features/containers/video/src/runtime.rn.tsx
+++ b/packages/features/containers/video/src/runtime.rn.tsx
@@ -1,0 +1,151 @@
+/**
+ * Video React Native renderer
+ *
+ * Implements the ContainerRNRenderer interface
+ *
+ * React Native has no built-in video component, so the default renderer shows
+ * a poster (or a neutral placeholder) with a play affordance that opens the
+ * source in the system player via Linking. Hosts that want inline playback
+ * (react-native-video / expo-av) can pass their own renderer through the
+ * Supramark `containerRenderers` prop instead of this one.
+ *
+ * @packageDocumentation
+ */
+
+import React from 'react';
+import {
+  View,
+  Text,
+  Image,
+  Pressable,
+  Linking,
+  StyleSheet,
+  type DimensionValue,
+} from 'react-native';
+import type { ContainerRNRenderArgs } from '@supramark/core';
+import type { VideoData } from './feature.js';
+
+const localStyles = StyleSheet.create({
+  container: {
+    width: '100%',
+    marginVertical: 12,
+    borderRadius: 8,
+    overflow: 'hidden',
+    backgroundColor: '#000',
+  },
+  poster: {
+    width: '100%',
+    aspectRatio: 16 / 9,
+  },
+  placeholder: {
+    width: '100%',
+    aspectRatio: 16 / 9,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: '#1c1c1e',
+  },
+  playIcon: {
+    fontSize: 40,
+    color: '#ffffff',
+  },
+  caption: {
+    paddingVertical: 6,
+    paddingHorizontal: 12,
+    fontSize: 14,
+    color: '#555',
+    textAlign: 'center',
+    backgroundColor: '#ffffff',
+  },
+  error: {
+    borderWidth: 1,
+    borderColor: '#f5c6cb',
+    backgroundColor: '#f8d7da',
+    borderRadius: 8,
+    padding: 12,
+    marginVertical: 12,
+  },
+  errorTitle: {
+    fontWeight: 'bold',
+    color: '#721c24',
+    marginBottom: 4,
+  },
+  errorText: {
+    color: '#721c24',
+  },
+  errorCode: {
+    marginTop: 6,
+    fontFamily: 'monospace' as const,
+    fontSize: 12,
+    color: '#721c24',
+  },
+});
+
+/**
+ * Clamp the configured width (percent) to a safe RN style value.
+ */
+function playerWidth(width: number | undefined): DimensionValue | undefined {
+  if (typeof width !== 'number' || !Number.isFinite(width) || width <= 0) {
+    return undefined;
+  }
+  return `${Math.min(width, 100)}%`;
+}
+
+/** Opens the video source in the system player; failures surface via console. */
+function openVideo(src: string): void {
+  Linking.openURL(src).catch((error: unknown) => {
+    console.error('Failed to open video URL:', error);
+  });
+}
+
+/**
+ * RN renderer for :::video (poster + play fallback; see module docs)
+ */
+export function renderVideoContainerRN({ node, key }: ContainerRNRenderArgs): React.ReactNode {
+  const data = (node?.data ?? {}) as unknown as VideoData;
+  const { parseError, rawConfig, src, poster, title, width } = data;
+
+  // Show an error message when parsing failed
+  if (parseError) {
+    return (
+      <View key={key} style={localStyles.error}>
+        <Text style={localStyles.errorTitle}>⚠️ Video config error</Text>
+        <Text style={localStyles.errorText}>{parseError}</Text>
+        {rawConfig && <Text style={localStyles.errorCode}>{rawConfig}</Text>}
+      </View>
+    );
+  }
+
+  // Missing required config
+  if (!src) {
+    return (
+      <View key={key} style={localStyles.error}>
+        <Text style={localStyles.errorTitle}>⚠️ Missing src config</Text>
+        <Text style={localStyles.errorText}>Please specify the src field with the video URL</Text>
+      </View>
+    );
+  }
+
+  const widthStyle = playerWidth(width);
+
+  return (
+    <View
+      key={key}
+      style={widthStyle ? { ...localStyles.container, width: widthStyle } : localStyles.container}
+    >
+      <Pressable
+        accessibilityRole="button"
+        accessibilityLabel={title ?? `Play video: ${src}`}
+        onPress={() => openVideo(src)}
+      >
+        {poster ? (
+          <Image source={{ uri: poster }} style={localStyles.poster} resizeMode="cover" />
+        ) : (
+          <View style={localStyles.placeholder}>
+            <Text style={localStyles.playIcon}>▶</Text>
+          </View>
+        )}
+      </Pressable>
+      {title && <Text style={localStyles.caption}>{title}</Text>}
+    </View>
+  );
+}

--- a/packages/features/containers/video/src/runtime.rn.tsx
+++ b/packages/features/containers/video/src/runtime.rn.tsx
@@ -32,11 +32,15 @@ const localStyles = StyleSheet.create({
     marginVertical: 12,
     borderRadius: 8,
     overflow: 'hidden',
-    backgroundColor: '#000',
   },
   poster: {
     width: '100%',
     aspectRatio: 16 / 9,
+  },
+  playBadge: {
+    ...StyleSheet.absoluteFillObject,
+    alignItems: 'center',
+    justifyContent: 'center',
   },
   placeholder: {
     width: '100%',
@@ -47,14 +51,6 @@ const localStyles = StyleSheet.create({
   placeholderMeta: {
     marginTop: 6,
     fontSize: 13,
-  },
-  caption: {
-    paddingVertical: 6,
-    paddingHorizontal: 12,
-    fontSize: 14,
-    color: '#555',
-    textAlign: 'center',
-    backgroundColor: '#ffffff',
   },
   error: {
     borderWidth: 1,
@@ -166,17 +162,28 @@ export function renderVideoContainerRN({
         }}
       >
         {poster ? (
-          <Image source={{ uri: poster }} style={localStyles.poster} resizeMode="cover" />
+          <View>
+            <Image
+              source={{ uri: poster }}
+              // Neutral underlay so a loading/failed poster shows the placeholder
+              // tone instead of a black band.
+              style={{ ...localStyles.poster, backgroundColor: palette.background }}
+              resizeMode="cover"
+            />
+            {/* Centered play affordance on the poster, matching the placeholder card. */}
+            <View style={localStyles.playBadge} pointerEvents="none">
+              <Text style={{ fontSize: 40, color: '#ffffff' }}>▶</Text>
+            </View>
+          </View>
         ) : (
           <View style={{ ...localStyles.placeholder, backgroundColor: palette.background }}>
             <Text style={{ fontSize: 40, color: palette.icon }}>▶</Text>
             <Text style={{ ...localStyles.placeholderMeta, color: palette.meta }}>
-              {title ?? videoFileName(src)}
+              {videoFileName(src)}
             </Text>
           </View>
         )}
       </Pressable>
-      {title && <Text style={localStyles.caption}>{title}</Text>}
     </View>
   );
 }

--- a/packages/features/containers/video/src/runtime.rn.tsx
+++ b/packages/features/containers/video/src/runtime.rn.tsx
@@ -4,17 +4,15 @@
  * Implements the ContainerRNRenderer interface
  *
  * React Native has no built-in video component, so the default renderer shows
- * a poster (or a neutral placeholder) with a play affordance that opens the
- * source in the system player via Linking. Hosts that want inline playback
- * (react-native-video / expo-av) can pass their own renderer through the
- * Supramark `containerRenderers` prop instead of this one.
+ * a poster (or a neutral placeholder) with a play affordance. A host callback
+ * owns playback when present; otherwise only http(s) sources are opened through
+ * Linking. Hosts that want inline playback can inject their own renderer.
  *
  * @packageDocumentation
  */
 
 import React from 'react';
 import {
-  Appearance,
   View,
   Text,
   Image,
@@ -22,8 +20,11 @@ import {
   Linking,
   StyleSheet,
   type DimensionValue,
+  type TextStyle,
+  type ViewStyle,
 } from 'react-native';
-import type { ContainerRNRenderArgs } from '@supramark/core';
+import type { ContainerRNRenderArgs, SupramarkVideoPressEvent } from '@supramark/core';
+import { useVideoPressHandler } from '@supramark/rn/video-press';
 import type { VideoData } from './feature.js';
 
 const localStyles = StyleSheet.create({
@@ -41,6 +42,11 @@ const localStyles = StyleSheet.create({
     ...StyleSheet.absoluteFillObject,
     alignItems: 'center',
     justifyContent: 'center',
+    pointerEvents: 'none',
+  },
+  playBadgeIcon: {
+    fontSize: 40,
+    color: '#ffffff',
   },
   placeholder: {
     width: '100%',
@@ -54,25 +60,18 @@ const localStyles = StyleSheet.create({
   },
   error: {
     borderWidth: 1,
-    borderColor: '#f5c6cb',
-    backgroundColor: '#f8d7da',
     borderRadius: 8,
     padding: 12,
     marginVertical: 12,
   },
   errorTitle: {
     fontWeight: 'bold',
-    color: '#721c24',
     marginBottom: 4,
-  },
-  errorText: {
-    color: '#721c24',
   },
   errorCode: {
     marginTop: 6,
     fontFamily: 'monospace' as const,
     fontSize: 12,
-    color: '#721c24',
   },
 });
 
@@ -86,8 +85,32 @@ function playerWidth(width: number | undefined): DimensionValue | undefined {
   return `${Math.min(width, 100)}%`;
 }
 
-/** Opens the video source in the system player; failures surface via console. */
+/** Returns whether the default Linking fallback may open this source. */
+function isOpenableVideoUrl(url: string): boolean {
+  return /^https?:\/\//i.test(url.trim());
+}
+
+/** Accepts image-capable poster schemes and rejects other explicit schemes. */
+function safePosterUrl(poster: string | undefined): string | undefined {
+  // Missing posters use the neutral placeholder instead.
+  if (!poster) return undefined;
+  const trimmed = poster.trim();
+  // Whitespace-only values are equivalent to no poster.
+  if (!trimmed) return undefined;
+  // Retain the image-capable schemes supported by React Native hosts.
+  if (/^(?:https?:|file:|content:|asset:|ph:|data:image\/)/i.test(trimmed)) return trimmed;
+  // Scheme-less values are retained for host-specific asset resolution.
+  if (/^[a-z][a-z\d+.-]*:/i.test(trimmed)) return undefined;
+  return trimmed;
+}
+
+/** Opens an http(s) video in the system player; failures surface via console. */
 function openVideo(src: string): void {
+  // Prevent opaque cards from dispatching phone, message, or app deep links.
+  if (!isOpenableVideoUrl(src)) {
+    console.error('Refusing to open non-http(s) video URL:', src);
+    return;
+  }
   Linking.openURL(src).catch((error: unknown) => {
     console.error('Failed to open video URL:', error);
   });
@@ -99,15 +122,53 @@ function videoFileName(src: string): string {
   return segment.length > 40 ? `${segment.slice(0, 37)}...` : segment;
 }
 
-/**
- * Neutral (light/dark aware) placeholder palette. Commanded imperatively via
- * Appearance because container renderers are plain render functions invoked
- * inside renderNode — not React components, so hooks are unavailable.
- */
-function placeholderPalette(): { background: string; icon: string; meta: string } {
-  return Appearance.getColorScheme() === 'dark'
-    ? { background: '#2c2c2e', icon: '#98989d', meta: '#8e8e93' }
-    : { background: '#f2f2f7', icon: '#8e8e93', meta: '#8e8e93' };
+/** Relative-luminance check used to select a readable error palette. */
+function isDarkColor(color: string): boolean {
+  const match = /^#(?:[0-9a-f]{3}|[0-9a-f]{6})$/i.exec(color.trim());
+  // Unknown color syntaxes fall back to the light palette.
+  if (!match) return false;
+  let hex = color.trim().slice(1);
+  // Expand shorthand colors before computing luminance.
+  if (hex.length === 3) {
+    hex = hex
+      .split('')
+      .map(character => character + character)
+      .join('');
+  }
+  const value = Number.parseInt(hex, 16);
+  const red = (value >> 16) & 0xff;
+  const green = (value >> 8) & 0xff;
+  const blue = value & 0xff;
+  return 0.299 * red + 0.587 * green + 0.114 * blue < 128;
+}
+
+interface VideoPalette {
+  background: string;
+  icon: string;
+  meta: string;
+}
+
+/** Derives placeholder colors from styles already resolved from the theme prop. */
+function placeholderPalette(styles: Record<string, unknown>): VideoPalette {
+  const placeholder = styles.imagePlaceholder as ViewStyle | undefined;
+  const placeholderText = styles.imagePlaceholderText as TextStyle | undefined;
+  const background =
+    typeof placeholder?.backgroundColor === 'string' ? placeholder.backgroundColor : '#f2f2f7';
+  const meta = typeof placeholderText?.color === 'string' ? placeholderText.color : '#8e8e93';
+  return { background, icon: meta, meta };
+}
+
+interface ErrorPalette {
+  borderColor: string;
+  backgroundColor: string;
+  textColor: string;
+}
+
+/** Selects an error-card palette that remains readable in the document theme. */
+function errorPalette(darkDocument: boolean): ErrorPalette {
+  return darkDocument
+    ? { borderColor: '#5a2d32', backgroundColor: '#3a2225', textColor: '#e8a1a8' }
+    : { borderColor: '#f5c6cb', backgroundColor: '#f8d7da', textColor: '#721c24' };
 }
 
 /**
@@ -116,25 +177,33 @@ function placeholderPalette(): { background: string; icon: string; meta: string 
 export function renderVideoContainerRN({
   node,
   key,
-  onVideoPress,
+  styles,
 }: ContainerRNRenderArgs): React.ReactNode {
-  // The JSON body is user input: Rust copies fields verbatim without type
-  // validation, so guard every field before use — a non-string src must
-  // degrade to an error card instead of crashing the whole document.
+  // Defense in depth: the parser filters types, but hosts may supply a hand-built AST.
   const data = (node?.data ?? {}) as unknown as VideoData;
   const src = typeof data.src === 'string' ? data.src : undefined;
-  const poster = typeof data.poster === 'string' ? data.poster : undefined;
+  const poster = safePosterUrl(typeof data.poster === 'string' ? data.poster : undefined);
   const title = typeof data.title === 'string' ? data.title : undefined;
   const width = typeof data.width === 'number' ? data.width : undefined;
-  const { parseError, rawConfig } = data;
+  // Hand-built AST diagnostics must also stay valid React text children.
+  const parseError = typeof data.parseError === 'string' ? data.parseError : undefined;
+  const rawConfig = typeof data.rawConfig === 'string' ? data.rawConfig : undefined;
+
+  const palette = placeholderPalette(styles);
+  const errorColors = errorPalette(isDarkColor(palette.background));
+  const errorStyle = [
+    localStyles.error,
+    { borderColor: errorColors.borderColor, backgroundColor: errorColors.backgroundColor },
+  ];
+  const errorTextStyle = { color: errorColors.textColor };
 
   // Show an error message when parsing failed
   if (parseError) {
     return (
-      <View key={key} style={localStyles.error}>
-        <Text style={localStyles.errorTitle}>⚠️ Video config error</Text>
-        <Text style={localStyles.errorText}>{parseError}</Text>
-        {rawConfig && <Text style={localStyles.errorCode}>{rawConfig}</Text>}
+      <View key={key} style={errorStyle}>
+        <Text style={[localStyles.errorTitle, errorTextStyle]}>⚠️ Video config error</Text>
+        <Text style={errorTextStyle}>{parseError}</Text>
+        {rawConfig && <Text style={[localStyles.errorCode, errorTextStyle]}>{rawConfig}</Text>}
       </View>
     );
   }
@@ -142,31 +211,56 @@ export function renderVideoContainerRN({
   // Missing required config
   if (!src) {
     return (
-      <View key={key} style={localStyles.error}>
-        <Text style={localStyles.errorTitle}>⚠️ Missing src config</Text>
-        <Text style={localStyles.errorText}>Please specify the src field with the video URL</Text>
+      <View key={key} style={errorStyle}>
+        <Text style={[localStyles.errorTitle, errorTextStyle]}>⚠️ Missing src config</Text>
+        <Text style={errorTextStyle}>Please specify the src field with the video URL</Text>
       </View>
     );
   }
 
-  const palette = placeholderPalette();
+  return (
+    <VideoCard key={key} src={src} poster={poster} title={title} width={width} palette={palette} />
+  );
+}
+
+/** A real component that can consume the host callback through React context. */
+function VideoCard({
+  src,
+  poster,
+  title,
+  width,
+  palette,
+}: {
+  src: string;
+  poster?: string;
+  title?: string;
+  width?: number;
+  palette: VideoPalette;
+}): React.ReactElement {
+  const onVideoPress = useVideoPressHandler();
   const widthStyle = playerWidth(width);
 
+  /** Delegates playback to the host, or uses the restricted Linking fallback. */
+  const handlePress = (): void => {
+    // A host callback always wins over the default external-player behavior.
+    if (onVideoPress) {
+      const event: SupramarkVideoPressEvent = { src };
+      // Omit absent optionals rather than materializing undefined fields.
+      if (poster !== undefined) event.poster = poster;
+      // Preserve the same exact-optional contract for the accessible title.
+      if (title !== undefined) event.title = title;
+      onVideoPress(event);
+      return;
+    }
+    openVideo(src);
+  };
+
   return (
-    <View
-      key={key}
-      style={widthStyle ? { ...localStyles.container, width: widthStyle } : localStyles.container}
-    >
+    <View style={[localStyles.container, widthStyle ? { width: widthStyle } : undefined]}>
       <Pressable
         accessibilityRole="button"
-        accessibilityLabel={title ?? `Play video: ${src}`}
-        onPress={() => {
-          if (onVideoPress) {
-            onVideoPress({ src, poster, title });
-            return;
-          }
-          openVideo(src);
-        }}
+        accessibilityLabel={title ? `Play video: ${title}` : 'Play video'}
+        onPress={handlePress}
       >
         {poster ? (
           <View>
@@ -174,18 +268,18 @@ export function renderVideoContainerRN({
               source={{ uri: poster }}
               // Neutral underlay so a loading/failed poster shows the placeholder
               // tone instead of a black band.
-              style={{ ...localStyles.poster, backgroundColor: palette.background }}
+              style={[localStyles.poster, { backgroundColor: palette.background }]}
               resizeMode="cover"
             />
             {/* Centered play affordance on the poster, matching the placeholder card. */}
-            <View style={localStyles.playBadge} pointerEvents="none">
-              <Text style={{ fontSize: 40, color: '#ffffff' }}>▶</Text>
+            <View style={localStyles.playBadge}>
+              <Text style={localStyles.playBadgeIcon}>▶</Text>
             </View>
           </View>
         ) : (
-          <View style={{ ...localStyles.placeholder, backgroundColor: palette.background }}>
-            <Text style={{ fontSize: 40, color: palette.icon }}>▶</Text>
-            <Text style={{ ...localStyles.placeholderMeta, color: palette.meta }}>
+          <View style={[localStyles.placeholder, { backgroundColor: palette.background }]}>
+            <Text style={[localStyles.playBadgeIcon, { color: palette.icon }]}>▶</Text>
+            <Text style={[localStyles.placeholderMeta, { color: palette.meta }]}>
               {videoFileName(src)}
             </Text>
           </View>

--- a/packages/features/containers/video/src/runtime.web.tsx
+++ b/packages/features/containers/video/src/runtime.web.tsx
@@ -21,12 +21,6 @@ const styles: Record<string, React.CSSProperties> = {
     borderRadius: '8px',
     backgroundColor: '#000',
   },
-  caption: {
-    marginTop: '6px',
-    fontSize: '14px',
-    color: '#555',
-    textAlign: 'center',
-  },
   error: {
     border: '1px solid #f5c6cb',
     backgroundColor: '#f8d7da',
@@ -92,13 +86,15 @@ export function renderVideoContainerWeb({ node, key }: ContainerWebRenderArgs): 
         style={styles.video}
         src={src}
         poster={poster}
+        // Without a poster, preload metadata so the browser renders the first
+        // frame instead of an empty black rectangle.
+        preload={poster ? undefined : 'metadata'}
         controls={controls ?? true}
         autoPlay={autoplay ?? false}
         loop={loop ?? false}
         muted={muted ?? false}
         aria-label={title}
       />
-      {title && <div style={styles.caption}>{title}</div>}
     </div>
   );
 }

--- a/packages/features/containers/video/src/runtime.web.tsx
+++ b/packages/features/containers/video/src/runtime.web.tsx
@@ -55,9 +55,15 @@ function playerWidth(width: number | undefined): string {
  * Web renderer for :::video
  */
 export function renderVideoContainerWeb({ node, key }: ContainerWebRenderArgs): React.ReactNode {
+  // The JSON body is user input: Rust copies fields verbatim without type
+  // validation, so guard every field before use — a non-string src must
+  // degrade to an error card instead of crashing the whole document.
   const data = (node?.data ?? {}) as unknown as VideoData;
-  const { parseError, rawConfig, src, poster, title, autoplay, loop, muted, controls, width } =
-    data;
+  const src = typeof data.src === 'string' ? data.src : undefined;
+  const poster = typeof data.poster === 'string' ? data.poster : undefined;
+  const title = typeof data.title === 'string' ? data.title : undefined;
+  const width = typeof data.width === 'number' ? data.width : undefined;
+  const { parseError, rawConfig, autoplay, loop, muted, controls } = data;
 
   // Show an error message when parsing failed
   if (parseError) {

--- a/packages/features/containers/video/src/runtime.web.tsx
+++ b/packages/features/containers/video/src/runtime.web.tsx
@@ -1,0 +1,104 @@
+/**
+ * Video web renderer
+ *
+ * Implements the ContainerWebRenderer interface
+ *
+ * @packageDocumentation
+ */
+
+import React from 'react';
+import type { ContainerWebRenderArgs } from '@supramark/core';
+import type { VideoData } from './feature.js';
+
+const styles: Record<string, React.CSSProperties> = {
+  container: {
+    width: '100%',
+    margin: '12px 0',
+  },
+  video: {
+    display: 'block',
+    width: '100%',
+    borderRadius: '8px',
+    backgroundColor: '#000',
+  },
+  caption: {
+    marginTop: '6px',
+    fontSize: '14px',
+    color: '#555',
+    textAlign: 'center',
+  },
+  error: {
+    border: '1px solid #f5c6cb',
+    backgroundColor: '#f8d7da',
+    color: '#721c24',
+    borderRadius: '8px',
+    padding: '12px 16px',
+    margin: '12px 0',
+  },
+  errorTitle: {
+    fontWeight: 'bold',
+    marginBottom: '4px',
+  },
+  errorCode: {
+    marginTop: '6px',
+    fontFamily: 'monospace',
+    fontSize: '12px',
+    whiteSpace: 'pre-wrap' as const,
+  },
+};
+
+/**
+ * Clamp the configured width (percent) to a safe CSS value.
+ */
+function playerWidth(width: number | undefined): string {
+  if (typeof width !== 'number' || !Number.isFinite(width) || width <= 0) {
+    return '100%';
+  }
+  return `${Math.min(width, 100)}%`;
+}
+
+/**
+ * Web renderer for :::video
+ */
+export function renderVideoContainerWeb({ node, key }: ContainerWebRenderArgs): React.ReactNode {
+  const data = (node?.data ?? {}) as unknown as VideoData;
+  const { parseError, rawConfig, src, poster, title, autoplay, loop, muted, controls, width } =
+    data;
+
+  // Show an error message when parsing failed
+  if (parseError) {
+    return (
+      <div key={key} style={styles.error}>
+        <div style={styles.errorTitle}>⚠️ Video config error</div>
+        <div>{parseError}</div>
+        {rawConfig && <pre style={styles.errorCode}>{rawConfig}</pre>}
+      </div>
+    );
+  }
+
+  // Missing required config
+  if (!src) {
+    return (
+      <div key={key} style={styles.error}>
+        <div style={styles.errorTitle}>⚠️ Missing src config</div>
+        <div>Please specify the src field with the video URL</div>
+      </div>
+    );
+  }
+
+  return (
+    <div key={key} style={{ ...styles.container, width: playerWidth(width) }}>
+      <video
+        style={styles.video}
+        src={src}
+        poster={poster}
+        controls={controls ?? true}
+        autoPlay={autoplay ?? false}
+        loop={loop ?? false}
+        muted={muted ?? false}
+        aria-label={title}
+      />
+      {title && <div style={styles.caption}>{title}</div>}
+    </div>
+  );
+}

--- a/packages/features/containers/video/src/runtime.web.tsx
+++ b/packages/features/containers/video/src/runtime.web.tsx
@@ -51,19 +51,37 @@ function playerWidth(width: number | undefined): string {
   return `${Math.min(width, 100)}%`;
 }
 
+/** Accepts browser-safe poster sources while preserving relative media URLs. */
+function safePosterUrl(poster: string | undefined): string | undefined {
+  // Missing posters activate the metadata preload path.
+  if (!poster) return undefined;
+  const trimmed = poster.trim();
+  // Whitespace-only values are equivalent to no poster.
+  if (!trimmed) return undefined;
+  // These explicit schemes are valid image sources in supported browsers.
+  if (/^(?:https?:|blob:|data:image\/)/i.test(trimmed)) return trimmed;
+  // Any other explicit URI scheme is rejected; scheme-less values are relative URLs.
+  if (/^[a-z][a-z\d+.-]*:/i.test(trimmed)) return undefined;
+  return trimmed;
+}
+
 /**
  * Web renderer for :::video
  */
 export function renderVideoContainerWeb({ node, key }: ContainerWebRenderArgs): React.ReactNode {
-  // The JSON body is user input: Rust copies fields verbatim without type
-  // validation, so guard every field before use — a non-string src must
-  // degrade to an error card instead of crashing the whole document.
+  // Defense in depth: the parser filters types, but hosts may supply a hand-built AST.
   const data = (node?.data ?? {}) as unknown as VideoData;
   const src = typeof data.src === 'string' ? data.src : undefined;
-  const poster = typeof data.poster === 'string' ? data.poster : undefined;
+  const poster = safePosterUrl(typeof data.poster === 'string' ? data.poster : undefined);
   const title = typeof data.title === 'string' ? data.title : undefined;
   const width = typeof data.width === 'number' ? data.width : undefined;
-  const { parseError, rawConfig, autoplay, loop, muted, controls } = data;
+  const autoplay = typeof data.autoplay === 'boolean' ? data.autoplay : false;
+  const loop = typeof data.loop === 'boolean' ? data.loop : false;
+  const muted = typeof data.muted === 'boolean' ? data.muted : false;
+  const controls = typeof data.controls === 'boolean' ? data.controls : true;
+  // Hand-built AST diagnostics must also stay valid React text children.
+  const parseError = typeof data.parseError === 'string' ? data.parseError : undefined;
+  const rawConfig = typeof data.rawConfig === 'string' ? data.rawConfig : undefined;
 
   // Show an error message when parsing failed
   if (parseError) {
@@ -95,10 +113,10 @@ export function renderVideoContainerWeb({ node, key }: ContainerWebRenderArgs): 
         // Without a poster, preload metadata so the browser renders the first
         // frame instead of an empty black rectangle.
         preload={poster ? undefined : 'metadata'}
-        controls={controls ?? true}
-        autoPlay={autoplay ?? false}
-        loop={loop ?? false}
-        muted={muted ?? false}
+        controls={controls}
+        autoPlay={autoplay}
+        loop={loop}
+        muted={muted}
         aria-label={title}
       />
     </div>

--- a/packages/features/containers/video/tsconfig.json
+++ b/packages/features/containers/video/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*", "../../../core/src/**/*.d.ts"],
+  "exclude": ["node_modules", "dist", "__tests__"]
+}

--- a/packages/renderers/rn/__tests__/support/mock-react-native.ts
+++ b/packages/renderers/rn/__tests__/support/mock-react-native.ts
@@ -16,9 +16,11 @@ mock.module('react-native', () => ({
   Image: 'Image',
   ScrollView: 'ScrollView',
   TouchableOpacity: 'TouchableOpacity',
+  Pressable: 'Pressable',
   ActivityIndicator: 'ActivityIndicator',
   Dimensions: { get: () => ({ width: 375, height: 812 }) },
   Linking: { openURL: async () => undefined },
+  Appearance: { getColorScheme: () => 'light' },
   StyleSheet: { create: (s: unknown) => s },
 }));
 

--- a/packages/renderers/rn/__tests__/support/mock-react-native.ts
+++ b/packages/renderers/rn/__tests__/support/mock-react-native.ts
@@ -1,5 +1,8 @@
 import { mock } from 'bun:test';
 
+/** Shared spy for assertions about the renderer's Linking fallback. */
+export const openUrlMock = mock(async (_url: string) => undefined);
+
 // react-native's JS entry contains Flow syntax (import typeof) that bun cannot load,
 // so tests always run against a mock. bun's mock.module registry is process-wide:
 // when multiple test files each register their own mock, a later narrow surface
@@ -19,9 +22,12 @@ mock.module('react-native', () => ({
   Pressable: 'Pressable',
   ActivityIndicator: 'ActivityIndicator',
   Dimensions: { get: () => ({ width: 375, height: 812 }) },
-  Linking: { openURL: async () => undefined },
-  Appearance: { getColorScheme: () => 'light' },
-  StyleSheet: { create: (s: unknown) => s },
+  Linking: { openURL: openUrlMock },
+  StyleSheet: {
+    create: (s: unknown) => s,
+    // Match React Native's production overlay primitive so tests verify layout.
+    absoluteFillObject: { position: 'absolute', top: 0, right: 0, bottom: 0, left: 0 },
+  },
 }));
 
 // react-native-svg is a native module under bun's test runtime; register its

--- a/packages/renderers/rn/__tests__/video-container.test.tsx
+++ b/packages/renderers/rn/__tests__/video-container.test.tsx
@@ -142,3 +142,37 @@ describe(':::video container rendering (RN)', () => {
     expect(text).toBe('');
   });
 });
+
+describe(':::video hostile config (RN)', () => {
+  test('non-string src degrades to the missing-src card instead of crashing', async () => {
+    const hostileAst = {
+      type: 'root',
+      children: [
+        {
+          type: 'container',
+          name: 'video',
+          mode: 'opaque',
+          // Rust copies JSON fields verbatim; a numeric src must not crash
+          // videoFileName's string handling and take the whole document down.
+          data: { src: 123, width: '120%' },
+          value: '{}',
+          children: [],
+        },
+      ],
+    } as unknown as SupramarkRootNode;
+    let renderer: ReactTestRenderer | null = null;
+    await act(async () => {
+      renderer = create(
+        React.createElement(Supramark, {
+          ast: hostileAst,
+          containerRenderers: { video: renderVideoContainerRN as never },
+        })
+      );
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    const text = flattenText(renderer!.toJSON());
+    expect(text).toContain('Missing src config');
+  });
+});

--- a/packages/renderers/rn/__tests__/video-container.test.tsx
+++ b/packages/renderers/rn/__tests__/video-container.test.tsx
@@ -1,0 +1,140 @@
+import { describe, expect, test } from 'bun:test';
+import React from 'react';
+import { act, create, type ReactTestRenderer } from 'react-test-renderer';
+import type { SupramarkRootNode } from '@supramark/core';
+
+import './support/mock-react-native';
+import './support/mock-renderer';
+
+// React's test renderer requires this flag before effects can be flushed through act().
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT =
+  true;
+
+// Import after the react-native mock is registered: the feature package's RN
+// runtime statically imports react-native, whose Flow-typed entry bun can't load.
+const { renderVideoContainerRN } = await import('@supramark/feature-video');
+const { Supramark } = await import('../src/Supramark');
+
+// Match the opaque node shape returned by the native parser for :::video with
+// a valid JSON body: structured data, empty children, raw body kept on value.
+const videoAst: SupramarkRootNode = {
+  type: 'root',
+  children: [
+    {
+      type: 'container',
+      name: 'video',
+      mode: 'opaque',
+      data: {
+        src: 'https://example.com/demo.mp4',
+        poster: 'https://example.com/cover.jpg',
+        title: 'Product demo',
+      },
+      value: '{"src":"https://example.com/demo.mp4"}',
+      children: [],
+    },
+  ],
+} as SupramarkRootNode;
+
+// Test-renderer JSON nodes keep children as a sibling of props, not inside it.
+interface TestRendererNode {
+  type: string;
+  props: Record<string, unknown>;
+  children?: TestRendererNode[] | null;
+}
+
+const asJsonNodes = (node: unknown): TestRendererNode[] =>
+  Array.isArray(node) ? (node as TestRendererNode[]) : node ? [node as TestRendererNode] : [];
+
+// Read string leaves from host Text nodes without depending on native text measurement.
+const flattenText = (node: unknown): string => {
+  if (node == null || typeof node === 'boolean') return '';
+  if (typeof node === 'string' || typeof node === 'number') return String(node);
+  if (Array.isArray(node)) return node.map(flattenText).join('');
+  if (typeof node === 'object' && 'type' in (node as Record<string, unknown>)) {
+    return flattenText((node as TestRendererNode).children);
+  }
+  return '';
+};
+
+// Collect host component types (e.g. 'Image', 'Text') from the rendered tree.
+const collectHostTypes = (node: unknown, out: Set<string> = new Set()): Set<string> => {
+  for (const item of asJsonNodes(node)) {
+    out.add(item.type);
+    collectHostTypes(item.children, out);
+  }
+  return out;
+};
+
+const renderVideo = async (): Promise<ReactTestRenderer> => {
+  let renderer: ReactTestRenderer | null = null;
+  await act(async () => {
+    renderer = create(
+      React.createElement(Supramark, {
+        ast: videoAst,
+        containerRenderers: { video: renderVideoContainerRN as never },
+      })
+    );
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+  return renderer as unknown as ReactTestRenderer;
+};
+
+describe(':::video container rendering (RN)', () => {
+  test('host-injected renderer turns the opaque video node into a poster card', async () => {
+    const renderer = await renderVideo();
+    const text = flattenText(renderer.toJSON());
+    const hostTypes = collectHostTypes(renderer.toJSON());
+
+    // The caption is rendered instead of the raw JSON body.
+    expect(text).toContain('Product demo');
+    expect(text).not.toContain('"src"');
+
+    // The poster image is rendered as a host Image.
+    expect(hostTypes.has('Image')).toBe(true);
+  });
+
+  test('onVideoPress prop reaches the container renderer and fires on tap', async () => {
+    const events: Array<{ src: string; poster?: string; title?: string }> = [];
+    let renderer: ReactTestRenderer | null = null;
+    await act(async () => {
+      renderer = create(
+        React.createElement(Supramark, {
+          ast: videoAst,
+          containerRenderers: { video: renderVideoContainerRN as never },
+          onVideoPress: event => events.push(event),
+        })
+      );
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    const pressable = renderer!.root.findByProps({ accessibilityRole: 'button' });
+    await act(async () => {
+      pressable.props.onPress();
+    });
+
+    expect(events).toEqual([
+      {
+        src: 'https://example.com/demo.mp4',
+        poster: 'https://example.com/cover.jpg',
+        title: 'Product demo',
+      },
+    ]);
+  });
+
+  test('missing renderer renders an empty generic container (documented fallback)', async () => {
+    let renderer: ReactTestRenderer | null = null;
+    await act(async () => {
+      renderer = create(React.createElement(Supramark, { ast: videoAst }));
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    const text = flattenText(renderer!.toJSON());
+
+    // No renderer → generic block with no params and empty children → blank.
+    expect(text).toBe('');
+  });
+});

--- a/packages/renderers/rn/__tests__/video-container.test.tsx
+++ b/packages/renderers/rn/__tests__/video-container.test.tsx
@@ -87,12 +87,16 @@ describe(':::video container rendering (RN)', () => {
     const text = flattenText(renderer.toJSON());
     const hostTypes = collectHostTypes(renderer.toJSON());
 
-    // The caption is rendered instead of the raw JSON body.
-    expect(text).toContain('Product demo');
+    // The raw JSON body is never rendered; the title survives only as the
+    // tappable region's accessibility label (no visible caption).
     expect(text).not.toContain('"src"');
+    expect(text).not.toContain('Product demo');
+    const pressable = renderer.root.findByProps({ accessibilityRole: 'button' });
+    expect(pressable.props.accessibilityLabel).toBe('Product demo');
 
-    // The poster image is rendered as a host Image.
+    // The poster image is rendered as a host Image with a centered play badge.
     expect(hostTypes.has('Image')).toBe(true);
+    expect(text).toContain('▶');
   });
 
   test('onVideoPress prop reaches the container renderer and fires on tap', async () => {

--- a/packages/renderers/rn/__tests__/video-container.test.tsx
+++ b/packages/renderers/rn/__tests__/video-container.test.tsx
@@ -1,9 +1,9 @@
-import { describe, expect, test } from 'bun:test';
+import { beforeEach, describe, expect, test } from 'bun:test';
 import React from 'react';
 import { act, create, type ReactTestRenderer } from 'react-test-renderer';
 import type { SupramarkRootNode } from '@supramark/core';
 
-import './support/mock-react-native';
+import { openUrlMock } from './support/mock-react-native';
 import './support/mock-renderer';
 
 // React's test renderer requires this flag before effects can be flushed through act().
@@ -65,6 +65,15 @@ const collectHostTypes = (node: unknown, out: Set<string> = new Set()): Set<stri
   return out;
 };
 
+/** Flattens the object/array style forms accepted by React Native. */
+const flattenStyle = (style: unknown): Record<string, unknown> => {
+  // Resolve nested RN style arrays in declaration order for assertions.
+  if (Array.isArray(style)) {
+    return Object.assign({}, ...style.filter(Boolean).map(flattenStyle));
+  }
+  return style && typeof style === 'object' ? (style as Record<string, unknown>) : {};
+};
+
 const renderVideo = async (): Promise<ReactTestRenderer> => {
   let renderer: ReactTestRenderer | null = null;
   await act(async () => {
@@ -82,6 +91,10 @@ const renderVideo = async (): Promise<ReactTestRenderer> => {
 };
 
 describe(':::video container rendering (RN)', () => {
+  beforeEach(() => {
+    openUrlMock.mockClear();
+  });
+
   test('host-injected renderer turns the opaque video node into a poster card', async () => {
     const renderer = await renderVideo();
     const text = flattenText(renderer.toJSON());
@@ -92,11 +105,25 @@ describe(':::video container rendering (RN)', () => {
     expect(text).not.toContain('"src"');
     expect(text).not.toContain('Product demo');
     const pressable = renderer.root.findByProps({ accessibilityRole: 'button' });
-    expect(pressable.props.accessibilityLabel).toBe('Product demo');
+    expect(pressable.props.accessibilityLabel).toBe('Play video: Product demo');
 
     // The poster image is rendered as a host Image with a centered play badge.
     expect(hostTypes.has('Image')).toBe(true);
     expect(text).toContain('▶');
+    const playIcon = renderer.root.find(
+      item => item.type === 'Text' && item.children.includes('▶')
+    );
+    const badgeStyle = flattenStyle(playIcon.parent?.props.style);
+    expect(badgeStyle).toMatchObject({
+      position: 'absolute',
+      top: 0,
+      right: 0,
+      bottom: 0,
+      left: 0,
+      alignItems: 'center',
+      justifyContent: 'center',
+      pointerEvents: 'none',
+    });
   });
 
   test('onVideoPress prop reaches the container renderer and fires on tap', async () => {
@@ -126,6 +153,127 @@ describe(':::video container rendering (RN)', () => {
         title: 'Product demo',
       },
     ]);
+    expect(openUrlMock).not.toHaveBeenCalled();
+  });
+
+  test('uses the resolved dark document styles for placeholder and error cards', async () => {
+    const noPosterAst = {
+      ...videoAst,
+      children: [
+        {
+          ...videoAst.children[0],
+          data: { src: 'https://example.com/demo.mp4' },
+        },
+      ],
+    } as SupramarkRootNode;
+    let placeholderRenderer: ReactTestRenderer | null = null;
+    await act(async () => {
+      placeholderRenderer = create(
+        React.createElement(Supramark, {
+          ast: noPosterAst,
+          theme: 'dark',
+          containerRenderers: { video: renderVideoContainerRN as never },
+        })
+      );
+      await Promise.resolve();
+    });
+    const placeholder = placeholderRenderer!.root.find(
+      item => item.type === 'View' && flattenStyle(item.props.style).aspectRatio === 16 / 9
+    );
+    expect(flattenStyle(placeholder.props.style).backgroundColor).toBe('#1a1a1a');
+
+    const missingSrcAst = {
+      ...videoAst,
+      children: [{ ...videoAst.children[0], data: {} }],
+    } as SupramarkRootNode;
+    let errorRenderer: ReactTestRenderer | null = null;
+    await act(async () => {
+      errorRenderer = create(
+        React.createElement(Supramark, {
+          ast: missingSrcAst,
+          theme: 'dark',
+          containerRenderers: { video: renderVideoContainerRN as never },
+        })
+      );
+      await Promise.resolve();
+    });
+    const errorTitle = errorRenderer!.root.find(
+      item => item.type === 'Text' && item.children.includes('⚠️ Missing src config')
+    );
+    expect(flattenStyle(errorTitle.parent?.props.style).backgroundColor).toBe('#3a2225');
+    expect(flattenStyle(errorTitle.props.style).color).toBe('#e8a1a8');
+  });
+
+  test('does not expose the full source URL as the fallback accessibility label', async () => {
+    const noTitleAst = {
+      ...videoAst,
+      children: [
+        {
+          ...videoAst.children[0],
+          data: { src: 'https://example.com/private/path/demo.mp4?token=secret' },
+        },
+      ],
+    } as SupramarkRootNode;
+    let renderer: ReactTestRenderer | null = null;
+    await act(async () => {
+      renderer = create(
+        React.createElement(Supramark, {
+          ast: noTitleAst,
+          containerRenderers: { video: renderVideoContainerRN as never },
+        })
+      );
+      await Promise.resolve();
+    });
+
+    const pressable = renderer!.root.findByProps({ accessibilityRole: 'button' });
+    expect(pressable.props.accessibilityLabel).toBe('Play video');
+  });
+
+  test('refuses non-http schemes in the Linking fallback', async () => {
+    const unsafeAst = {
+      ...videoAst,
+      children: [{ ...videoAst.children[0], data: { src: 'tel:+15551234567' } }],
+    } as SupramarkRootNode;
+    let renderer: ReactTestRenderer | null = null;
+    await act(async () => {
+      renderer = create(
+        React.createElement(Supramark, {
+          ast: unsafeAst,
+          containerRenderers: { video: renderVideoContainerRN as never },
+        })
+      );
+      await Promise.resolve();
+    });
+
+    const pressable = renderer!.root.findByProps({ accessibilityRole: 'button' });
+    await act(async () => {
+      pressable.props.onPress();
+    });
+    expect(openUrlMock).not.toHaveBeenCalled();
+  });
+
+  test('drops a poster URL with a script-capable scheme', async () => {
+    const unsafePosterAst = {
+      ...videoAst,
+      children: [
+        {
+          ...videoAst.children[0],
+          data: { src: 'https://example.com/demo.mp4', poster: 'javascript:alert(1)' },
+        },
+      ],
+    } as SupramarkRootNode;
+    let renderer: ReactTestRenderer | null = null;
+    await act(async () => {
+      renderer = create(
+        React.createElement(Supramark, {
+          ast: unsafePosterAst,
+          containerRenderers: { video: renderVideoContainerRN as never },
+        })
+      );
+      await Promise.resolve();
+    });
+
+    expect(collectHostTypes(renderer!.toJSON()).has('Image')).toBe(false);
   });
 
   test('missing renderer renders an empty generic container (documented fallback)', async () => {
@@ -152,8 +300,8 @@ describe(':::video hostile config (RN)', () => {
           type: 'container',
           name: 'video',
           mode: 'opaque',
-          // Rust copies JSON fields verbatim; a numeric src must not crash
-          // videoFileName's string handling and take the whole document down.
+          // Hand-built ASTs may bypass parser validation; a numeric src must
+          // not crash videoFileName and take the whole document down.
           data: { src: 123, width: '120%' },
           value: '{}',
           children: [],
@@ -174,5 +322,34 @@ describe(':::video hostile config (RN)', () => {
     });
     const text = flattenText(renderer!.toJSON());
     expect(text).toContain('Missing src config');
+  });
+
+  test('ignores wrong-typed parser error fields instead of rendering unsafe values', async () => {
+    const hostileAst = {
+      ...videoAst,
+      children: [
+        {
+          ...videoAst.children[0],
+          data: {
+            src: 'https://example.com/demo.mp4',
+            parseError: { message: 'hostile' },
+            rawConfig: ['hostile'],
+          },
+        },
+      ],
+    } as unknown as SupramarkRootNode;
+    let renderer: ReactTestRenderer | null = null;
+    await act(async () => {
+      renderer = create(
+        React.createElement(Supramark, {
+          ast: hostileAst,
+          containerRenderers: { video: renderVideoContainerRN as never },
+        })
+      );
+      await Promise.resolve();
+    });
+
+    expect(collectHostTypes(renderer!.toJSON()).has('Pressable')).toBe(true);
+    expect(flattenText(renderer!.toJSON())).not.toContain('hostile');
   });
 });

--- a/packages/renderers/rn/package.json
+++ b/packages/renderers/rn/package.json
@@ -4,6 +4,10 @@
   "description": "supramark 的 React Native 渲染层。",
   "main": "src/index.ts",
   "types": "src/index.ts",
+  "exports": {
+    ".": "./src/index.ts",
+    "./video-press": "./src/videoPressContext.ts"
+  },
   "license": "Apache-2.0",
   "scripts": {
     "build": "tsc -p tsconfig.json",

--- a/packages/renderers/rn/src/Supramark.tsx
+++ b/packages/renderers/rn/src/Supramark.tsx
@@ -17,6 +17,7 @@ import type {
   SupramarkCodeHighlightResult,
   SupramarkCodeHighlighter,
   SupramarkSourceState,
+  SupramarkVideoPressEvent,
 } from '@supramark/core';
 import {
   parse,
@@ -216,6 +217,7 @@ export interface ContainerRendererRN {
     styles: ReturnType<typeof mergeStyles>;
     config?: SupramarkConfig;
     onOpenHtmlPage?: (node: SupramarkContainerNode) => void;
+    onVideoPress?: SupramarkVideoPressHandler;
     renderNode: (node: SupramarkNode, key: number) => RenderedNode;
     renderChildren: (children: SupramarkNode[]) => RenderedNode;
   }): RenderedNode;
@@ -252,6 +254,9 @@ export interface SupramarkImagePressEvent {
 
 /** Host handler invoked when the user taps a block image. */
 export type SupramarkImagePressHandler = (event: SupramarkImagePressEvent) => void;
+
+/** Host handler invoked when the user taps a :::video card. */
+export type SupramarkVideoPressHandler = (event: SupramarkVideoPressEvent) => void;
 
 /**
  * Context pipe for the image-press handler. Carries the host callback from the
@@ -322,6 +327,7 @@ export interface SupramarkProps {
    * - the host may open a new page / modal / external browser from the callback.
    */
   onOpenHtmlPage?: (node: SupramarkContainerNode) => void;
+  onVideoPress?: SupramarkVideoPressHandler;
 
   /**
    * Callback invoked when the user taps a block image.
@@ -345,6 +351,7 @@ export const Supramark: React.FC<SupramarkProps> = ({
   onError,
   errorFallback,
   onOpenHtmlPage,
+  onVideoPress,
   onImagePress,
   containerRenderers,
   codeHighlighter,
@@ -544,6 +551,7 @@ export const Supramark: React.FC<SupramarkProps> = ({
               parsedDocument.highlighted,
               config,
               onOpenHtmlPage,
+              onVideoPress,
               mergedContainerRenderers
             )}
           </View>
@@ -722,6 +730,7 @@ function renderRootNodes(
   highlighted: ReadonlyMap<string, SupramarkCodeHighlightResult>,
   config?: SupramarkConfig,
   onOpenHtmlPage?: (node: SupramarkContainerNode) => void,
+  onVideoPress?: SupramarkVideoPressHandler,
   containerRenderers?: Record<string, ContainerRendererRN>
 ): RenderedNode[] {
   const rendered: RenderedNode[] = [];
@@ -737,6 +746,7 @@ function renderRootNodes(
           highlighted,
           config,
           onOpenHtmlPage,
+          onVideoPress,
           containerRenderers
         )
       );
@@ -874,6 +884,7 @@ function renderNode(
   highlighted: ReadonlyMap<string, SupramarkCodeHighlightResult>,
   config?: SupramarkConfig,
   onOpenHtmlPage?: (node: SupramarkContainerNode) => void,
+  onVideoPress?: SupramarkVideoPressHandler,
   containerRenderers?: Record<string, ContainerRendererRN>,
   listMarker?: string
 ): RenderedNode {
@@ -924,6 +935,7 @@ function renderNode(
               highlighted,
               config,
               onOpenHtmlPage,
+              onVideoPress,
               containerRenderers,
               list.ordered ? `${startIndex + index}.` : '•'
             )
@@ -972,6 +984,7 @@ function renderNode(
             highlighted,
             config,
             onOpenHtmlPage,
+            onVideoPress,
             containerRenderers
           )}
         </View>
@@ -1010,8 +1023,18 @@ function renderNode(
           styles,
           config,
           onOpenHtmlPage,
+          onVideoPress,
           renderNode: (n, k) =>
-            renderNode(n, k, styles, highlighted, config, onOpenHtmlPage, containerRenderers),
+            renderNode(
+              n,
+              k,
+              styles,
+              highlighted,
+              config,
+              onOpenHtmlPage,
+              onVideoPress,
+              containerRenderers
+            ),
           renderChildren: children =>
             children.map((child, index) =>
               renderNode(
@@ -1021,6 +1044,7 @@ function renderNode(
                 highlighted,
                 config,
                 onOpenHtmlPage,
+                onVideoPress,
                 containerRenderers
               )
             ),
@@ -1080,6 +1104,7 @@ function renderNode(
               highlighted,
               config,
               onOpenHtmlPage,
+              onVideoPress,
               containerRenderers
             )
           );
@@ -1108,9 +1133,7 @@ function renderNode(
 
         return (
           <View key={key} style={admonitionContainerStyle}>
-            {title ? (
-              <Text style={[styles.paragraph, { fontWeight: '600' }]}>{title}</Text>
-            ) : null}
+            {title ? <Text style={[styles.paragraph, { fontWeight: '600' }]}>{title}</Text> : null}
             {renderAdmonitionContent()}
           </View>
         );
@@ -1132,6 +1155,7 @@ function renderNode(
               highlighted,
               config,
               onOpenHtmlPage,
+              onVideoPress,
               containerRenderers
             )
           )}
@@ -1177,6 +1201,7 @@ function renderNode(
                           highlighted,
                           config,
                           onOpenHtmlPage,
+                          onVideoPress,
                           containerRenderers
                         )
                       )}
@@ -1211,6 +1236,7 @@ function renderNode(
                         highlighted,
                         config,
                         onOpenHtmlPage,
+                        onVideoPress,
                         containerRenderers
                       )
                     )}
@@ -1237,6 +1263,7 @@ function renderNode(
             highlighted,
             config,
             onOpenHtmlPage,
+            onVideoPress,
             containerRenderers
           )
         );
@@ -1264,7 +1291,16 @@ function renderNode(
       return (
         <View key={key} style={[styles.table, { width: screenWidth }]}>
           {table.children.map((row, index) =>
-            renderNode(row, index, styles, highlighted, config, onOpenHtmlPage, containerRenderers)
+            renderNode(
+              row,
+              index,
+              styles,
+              highlighted,
+              config,
+              onOpenHtmlPage,
+              onVideoPress,
+              containerRenderers
+            )
           )}
         </View>
       );
@@ -1274,7 +1310,16 @@ function renderNode(
       return (
         <View key={key} style={styles.tableRow}>
           {row.children.map((cell, index) =>
-            renderNode(cell, index, styles, highlighted, config, onOpenHtmlPage, containerRenderers)
+            renderNode(
+              cell,
+              index,
+              styles,
+              highlighted,
+              config,
+              onOpenHtmlPage,
+              onVideoPress,
+              containerRenderers
+            )
           )}
         </View>
       );
@@ -1302,7 +1347,16 @@ function renderNode(
       return (
         <View key={key} style={styles.blockquote}>
           {quote.children.map((child, i) =>
-            renderNode(child, i, styles, highlighted, config, onOpenHtmlPage, containerRenderers)
+            renderNode(
+              child,
+              i,
+              styles,
+              highlighted,
+              config,
+              onOpenHtmlPage,
+              onVideoPress,
+              containerRenderers
+            )
           )}
         </View>
       );
@@ -1426,6 +1480,7 @@ function renderListItemBody(
   highlighted: ReadonlyMap<string, SupramarkCodeHighlightResult>,
   config: SupramarkConfig | undefined,
   onOpenHtmlPage: ((node: SupramarkContainerNode) => void) | undefined,
+  onVideoPress: SupramarkVideoPressHandler | undefined,
   containerRenderers: Record<string, ContainerRendererRN> | undefined
 ): RenderedNode[] {
   const out: RenderedNode[] = [];
@@ -1482,7 +1537,16 @@ function renderListItemBody(
     flushInline();
     out.push(
       <View key={`li-${seq}`} style={styles.listItemIndent}>
-        {renderNode(child, 0, styles, highlighted, config, onOpenHtmlPage, containerRenderers)}
+        {renderNode(
+          child,
+          0,
+          styles,
+          highlighted,
+          config,
+          onOpenHtmlPage,
+          onVideoPress,
+          containerRenderers
+        )}
       </View>
     );
     seq += 1;
@@ -1526,13 +1590,7 @@ function renderInlineNode(
       // the same config from yielding structurally different output per
       // platform.
       if (parentType === 'strong' && config?.options?.flattenNestedStrong === true) {
-        return renderInlineNodes(
-          strongNode.children,
-          styles,
-          highlighted,
-          config,
-          'strong'
-        );
+        return renderInlineNodes(strongNode.children, styles, highlighted, config, 'strong');
       }
       return (
         <Text key={key} style={styles.strong}>

--- a/packages/renderers/rn/src/Supramark.tsx
+++ b/packages/renderers/rn/src/Supramark.tsx
@@ -17,7 +17,6 @@ import type {
   SupramarkCodeHighlightResult,
   SupramarkCodeHighlighter,
   SupramarkSourceState,
-  SupramarkVideoPressEvent,
 } from '@supramark/core';
 import {
   parse,
@@ -33,6 +32,7 @@ import { MathInline } from './MathInline';
 import { type SupramarkStyles, mergeStyles, darkThemeStyles } from './styles';
 import { ErrorBoundary, type ErrorInfo, ErrorDisplay } from './ErrorBoundary';
 import { SourceStateContext } from './SourceStateContext';
+import { VideoPressContext, type SupramarkVideoPressHandler } from './videoPressContext';
 import { resolveDevelopmentMode } from './devMode';
 import {
   getRendererCache,
@@ -217,7 +217,6 @@ export interface ContainerRendererRN {
     styles: ReturnType<typeof mergeStyles>;
     config?: SupramarkConfig;
     onOpenHtmlPage?: (node: SupramarkContainerNode) => void;
-    onVideoPress?: SupramarkVideoPressHandler;
     renderNode: (node: SupramarkNode, key: number) => RenderedNode;
     renderChildren: (children: SupramarkNode[]) => RenderedNode;
   }): RenderedNode;
@@ -254,9 +253,6 @@ export interface SupramarkImagePressEvent {
 
 /** Host handler invoked when the user taps a block image. */
 export type SupramarkImagePressHandler = (event: SupramarkImagePressEvent) => void;
-
-/** Host handler invoked when the user taps a :::video card. */
-export type SupramarkVideoPressHandler = (event: SupramarkVideoPressEvent) => void;
 
 /**
  * Context pipe for the image-press handler. Carries the host callback from the
@@ -327,6 +323,13 @@ export interface SupramarkProps {
    * - the host may open a new page / modal / external browser from the callback.
    */
   onOpenHtmlPage?: (node: SupramarkContainerNode) => void;
+
+  /**
+   * Callback invoked when the user taps a :::video card.
+   *
+   * The host owns playback when supplied. Otherwise the default video
+   * renderer opens http(s) sources through React Native Linking.
+   */
   onVideoPress?: SupramarkVideoPressHandler;
 
   /**
@@ -544,17 +547,18 @@ export const Supramark: React.FC<SupramarkProps> = ({
     <ErrorBoundary onError={onError} fallback={errorFallback}>
       <SourceStateContext.Provider value={parsedDocument.sourceState}>
         <ImagePressContext.Provider value={onImagePress}>
-          <View style={mergedStyles.root}>
-            {renderRootNodes(
-              parsedDocument.root.children,
-              mergedStyles,
-              parsedDocument.highlighted,
-              config,
-              onOpenHtmlPage,
-              onVideoPress,
-              mergedContainerRenderers
-            )}
-          </View>
+          <VideoPressContext.Provider value={onVideoPress}>
+            <View style={mergedStyles.root}>
+              {renderRootNodes(
+                parsedDocument.root.children,
+                mergedStyles,
+                parsedDocument.highlighted,
+                config,
+                onOpenHtmlPage,
+                mergedContainerRenderers
+              )}
+            </View>
+          </VideoPressContext.Provider>
         </ImagePressContext.Provider>
       </SourceStateContext.Provider>
     </ErrorBoundary>
@@ -730,7 +734,6 @@ function renderRootNodes(
   highlighted: ReadonlyMap<string, SupramarkCodeHighlightResult>,
   config?: SupramarkConfig,
   onOpenHtmlPage?: (node: SupramarkContainerNode) => void,
-  onVideoPress?: SupramarkVideoPressHandler,
   containerRenderers?: Record<string, ContainerRendererRN>
 ): RenderedNode[] {
   const rendered: RenderedNode[] = [];
@@ -746,7 +749,6 @@ function renderRootNodes(
           highlighted,
           config,
           onOpenHtmlPage,
-          onVideoPress,
           containerRenderers
         )
       );
@@ -884,7 +886,6 @@ function renderNode(
   highlighted: ReadonlyMap<string, SupramarkCodeHighlightResult>,
   config?: SupramarkConfig,
   onOpenHtmlPage?: (node: SupramarkContainerNode) => void,
-  onVideoPress?: SupramarkVideoPressHandler,
   containerRenderers?: Record<string, ContainerRendererRN>,
   listMarker?: string
 ): RenderedNode {
@@ -935,7 +936,6 @@ function renderNode(
               highlighted,
               config,
               onOpenHtmlPage,
-              onVideoPress,
               containerRenderers,
               list.ordered ? `${startIndex + index}.` : '•'
             )
@@ -984,7 +984,6 @@ function renderNode(
             highlighted,
             config,
             onOpenHtmlPage,
-            onVideoPress,
             containerRenderers
           )}
         </View>
@@ -1023,7 +1022,6 @@ function renderNode(
           styles,
           config,
           onOpenHtmlPage,
-          onVideoPress,
           renderNode: (n, k) =>
             renderNode(
               n,
@@ -1032,7 +1030,6 @@ function renderNode(
               highlighted,
               config,
               onOpenHtmlPage,
-              onVideoPress,
               containerRenderers
             ),
           renderChildren: children =>
@@ -1044,7 +1041,6 @@ function renderNode(
                 highlighted,
                 config,
                 onOpenHtmlPage,
-                onVideoPress,
                 containerRenderers
               )
             ),
@@ -1104,7 +1100,6 @@ function renderNode(
               highlighted,
               config,
               onOpenHtmlPage,
-              onVideoPress,
               containerRenderers
             )
           );
@@ -1155,7 +1150,6 @@ function renderNode(
               highlighted,
               config,
               onOpenHtmlPage,
-              onVideoPress,
               containerRenderers
             )
           )}
@@ -1201,7 +1195,6 @@ function renderNode(
                           highlighted,
                           config,
                           onOpenHtmlPage,
-                          onVideoPress,
                           containerRenderers
                         )
                       )}
@@ -1236,7 +1229,6 @@ function renderNode(
                         highlighted,
                         config,
                         onOpenHtmlPage,
-                        onVideoPress,
                         containerRenderers
                       )
                     )}
@@ -1263,7 +1255,6 @@ function renderNode(
             highlighted,
             config,
             onOpenHtmlPage,
-            onVideoPress,
             containerRenderers
           )
         );
@@ -1298,7 +1289,6 @@ function renderNode(
               highlighted,
               config,
               onOpenHtmlPage,
-              onVideoPress,
               containerRenderers
             )
           )}
@@ -1317,7 +1307,6 @@ function renderNode(
               highlighted,
               config,
               onOpenHtmlPage,
-              onVideoPress,
               containerRenderers
             )
           )}
@@ -1354,7 +1343,6 @@ function renderNode(
               highlighted,
               config,
               onOpenHtmlPage,
-              onVideoPress,
               containerRenderers
             )
           )}
@@ -1480,7 +1468,6 @@ function renderListItemBody(
   highlighted: ReadonlyMap<string, SupramarkCodeHighlightResult>,
   config: SupramarkConfig | undefined,
   onOpenHtmlPage: ((node: SupramarkContainerNode) => void) | undefined,
-  onVideoPress: SupramarkVideoPressHandler | undefined,
   containerRenderers: Record<string, ContainerRendererRN> | undefined
 ): RenderedNode[] {
   const out: RenderedNode[] = [];
@@ -1544,7 +1531,6 @@ function renderListItemBody(
           highlighted,
           config,
           onOpenHtmlPage,
-          onVideoPress,
           containerRenderers
         )}
       </View>

--- a/packages/renderers/rn/src/index.ts
+++ b/packages/renderers/rn/src/index.ts
@@ -2,4 +2,6 @@ export * from './Supramark';
 export * from './DiagramNode';
 export * from './styles';
 export * from './ErrorBoundary';
+export { VideoPressContext, useVideoPressHandler } from './videoPressContext';
+export type { SupramarkVideoPressHandler } from './videoPressContext';
 export { clearSupramarkRenderCache } from './renderCache';

--- a/packages/renderers/rn/src/videoPressContext.ts
+++ b/packages/renderers/rn/src/videoPressContext.ts
@@ -1,0 +1,20 @@
+/**
+ * Context pipe for the host's video-press handler.
+ *
+ * Keeping this callback in the RN renderer package avoids adding a
+ * video-specific field to core's feature-neutral ContainerRNRenderArgs.
+ */
+
+import { createContext, useContext } from 'react';
+import type { SupramarkVideoPressEvent } from '@supramark/core';
+
+/** Host handler invoked when the user taps a video card. */
+export type SupramarkVideoPressHandler = (event: SupramarkVideoPressEvent) => void;
+
+/** Carries the optional handler from the Supramark root to video cards. */
+export const VideoPressContext = createContext<SupramarkVideoPressHandler | undefined>(undefined);
+
+/** Reads the host-supplied handler from a React component. */
+export function useVideoPressHandler(): SupramarkVideoPressHandler | undefined {
+  return useContext(VideoPressContext);
+}

--- a/profiles/full.json
+++ b/profiles/full.json
@@ -16,6 +16,7 @@
     "container.html",
     "container.weather",
     "container.vison",
+    "container.video",
     "input",
     "code_highlight"
   ],

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -42,6 +42,7 @@
       "@supramark/web": ["packages/renderers/web/src/index.ts"],
       "@supramark/web/createSupramark": ["packages/renderers/web/src/createSupramark.tsx"],
       "@supramark/rn": ["packages/renderers/rn/src/index.ts"],
+      "@supramark/rn/video-press": ["packages/renderers/rn/src/videoPressContext.ts"],
       "@supramark/rn-selection": ["packages/renderers/rn-selection/src/index.ts"],
       "@boomsi/react-native-selectable-text": [
         "packages/renderers/rn-selection/src/shims/selectable-rich-text.d.ts"
@@ -67,6 +68,7 @@
       "@supramark/feature-weather": ["packages/features/containers/weather/src/index.ts"],
       "@supramark/feature-html-page": ["packages/features/containers/html-page/src/index.ts"],
       "@supramark/feature-map": ["packages/features/containers/map/src/index.ts"],
+      "@supramark/feature-video": ["packages/features/containers/video/src/index.ts"],
       "@supramark/feature-mermaid": ["packages/features/diagrams/mermaid/src/index.ts"],
       "@supramark/feature-diagram-dot": ["packages/features/diagrams/dot/src/index.ts"],
       "@supramark/feature-diagram-echarts": ["packages/features/diagrams/echarts/src/index.ts"],


### PR DESCRIPTION
Implements the video rendering capability requested in #199 with the established `ContainerFeature` pattern.

## Syntax

```markdown
:::video
{
  "src": "https://example.com/demo.mp4",
  "poster": "https://example.com/cover.jpg",
  "title": "Product demo"
}
:::
```

Recognized fields: `src` / `poster` / `title` / `autoplay` / `loop` / `muted` / `controls` / `width`. Unknown fields and values with the wrong JSON type are dropped by the canonical Rust parser. Invalid JSON yields `parseError` plus a bounded `rawConfig` instead of failing the document.

## Implementation

- **Canonical parser:** maps `:::video` JSON into a typed opaque container node, preserves valid `false` and numeric values, drops wrong-typed fields, and caps invalid raw input at 1,024 characters plus an ellipsis.
- **Feature package:** adds `@supramark/feature-video`, its legacy registry hook, examples, documentation, Web/RN renderers, package dependencies, and generated example wiring.
- **Web:** renders a native `<video>`, validates boolean attributes defensively, clamps width, preloads metadata only when there is no poster, and rejects poster URLs with unsafe explicit schemes.
- **React Native:** renders a themed poster/placeholder card, delegates playback through `onVideoPress` via RN-owned React context, and restricts the default `Linking` fallback to HTTP(S). Poster schemes and accessibility labels are also hardened.
- **Build registration:** adds `container.video` to the feature manifest, Cargo feature list, TypeScript paths, and the full build profile.

The video callback is no longer added to the feature-neutral `ContainerRNRenderArgs`; only the event payload contract remains in core.

## Test plan

- [x] `cargo test -p supramark-markdown` — 147 passed (86 unit + 61 public API)
- [x] `bun run test:core` — 101 passed
- [x] `bun run test:features` — all feature packages passed; video 24/24
- [x] `bun --filter @supramark/web test` — 67/67 passed
- [x] `bun --filter @supramark/rn test` — 167/167 passed
- [x] Targeted coverage — Web video runtime 100% functions/lines; RN video runtime 84.62% functions and 91.01% lines; video press context 100%
- [x] `bun run lint` — ESLint, feature lint 22/22, and CJK check passed
- [x] `bun run lint:types` — 0 type errors
- [x] `bun run quality` — passed
- [x] `bun run build` — full workspace and examples passed with supported Node.js 24
- [x] `bun scripts/build-profile.ts full` and changed-file Rust formatting checks passed
- [x] Verify playback behavior in a real downstream host/device before release
