### PR TITLE
ci(conformance): add a stable Conformance gate check

### DIFF
--- a/.github/workflows/markdown-conformance.yml
+++ b/.github/workflows/markdown-conformance.yml
@@ -46,14 +46,12 @@ on:
   # The issue-filing step already carries a `github.event_name !=
   # 'pull_request'` guard (dead until now), so PR runs report through the
   # check and the run artifacts, and never open or update an issue.
+  # No `paths` filter here, unlike the push trigger. `Conformance gate` below
+  # is a required check on main, and a required check that never reports
+  # leaves the pull request waiting forever. A path filter would do exactly
+  # that for any pull request outside the six paths above, so the workflow
+  # runs on every pull request and the gate always reports.
   pull_request:
-    paths:
-      - ".github/workflows/markdown-conformance.yml"
-      - "tests/cases/**"
-      - "tests/markdown-conformance/**"
-      - "crates/supramark-markdown/**"
-      - "packages/core/**"
-      - "packages/renderers/web/**"
 
 permissions:
   contents: read
@@ -287,3 +285,32 @@ jobs:
         run: |
           echo "$SOURCE_NAME has failing semantic or visual conformance cases; the report and Issue content have been generated."
           exit 1
+
+  # Single stable check name for branch protection. The matrix job names are
+  # derived from the data sources, so they change whenever a source is added,
+  # removed or renamed — pinning those in a ruleset would break on the next
+  # source change. This job depends on the whole matrix instead: `needs`
+  # aggregates to `success` only when every leg succeeded.
+  conformance-gate:
+    name: Conformance gate
+    needs: [resolve-sources, markdown-conformance]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require every conformance source to pass
+        env:
+          RESOLVE_RESULT: ${{ needs.resolve-sources.result }}
+          MATRIX_RESULT: ${{ needs.markdown-conformance.result }}
+        shell: bash
+        run: |
+          echo "resolve-sources:       $RESOLVE_RESULT"
+          echo "markdown-conformance:  $MATRIX_RESULT"
+          if [ "$RESOLVE_RESULT" != "success" ]; then
+            echo "::error::Could not resolve the conformance data sources."
+            exit 1
+          fi
+          if [ "$MATRIX_RESULT" != "success" ]; then
+            echo "::error::At least one conformance source did not pass; see the per-source jobs."
+            exit 1
+          fi
+          echo "All conformance sources passed."


### PR DESCRIPTION
## Why

None of the conformance jobs is in the `main` ruleset's required checks, so the gate is advisory today — a red conformance run does not stop a merge. #229 is the concrete case: it landed a baseline declaring 13 semantic / 10 visual failures while the suite actually reports 7 / 6, pre-approving six passing cases (raw HTML blocks, emphasis delimiter runs, list-item thematic breaks, CDATA / mixed-case HTML blocks) as known failures. The regression gate only reacts to newly *added* failures, so those six would have been unguarded from the day they landed, and nothing in CI would have said so.

## Why not just require the four existing checks

Two ways that breaks:

1. The matrix job names come from the data sources (`${{ matrix.source }} semantic and visual conformance`). #229 has just added a fourth source; a fifth, or a rename, leaves a required name that never reports.
2. The `pull_request` trigger carried the same `paths` filter as `push`, so the workflow does not run for changes outside six paths. A required check that never reports leaves the PR stuck on "Expected — waiting for status" with no way to clear it. #205 and #216, both open right now, touch none of those paths.

## What this does

- Adds one `Conformance gate` job that `needs` the whole matrix. GitHub aggregates a matrix dependency to `success` only when every leg succeeded, so the gate is red if any source fails, and `if: always()` keeps it reporting when a leg fails or the matrix is skipped.
- Drops the `paths` filter from `pull_request` only, so the gate always reports on a PR. The `push` trigger keeps its filter.

After this merges, `Conformance gate` is the single name to add to the ruleset's required checks.

## Cost

Every PR now runs the four conformance sources instead of only path-matching ones. They run in parallel and the suite is the same one that already runs on the majority of PRs today.